### PR TITLE
Trim identity-hashcode to 25bit

### DIFF
--- a/src/hotspot/share/oops/markWord.hpp
+++ b/src/hotspot/share/oops/markWord.hpp
@@ -41,8 +41,8 @@
 //
 //  64 bits:
 //  --------
-//  unused:25 hash:31 -->| unused_gap:1   age:4    biased_lock:1 lock:2 (normal object)
-//  JavaThread*:54 epoch:2 unused_gap:1   age:4    biased_lock:1 lock:2 (biased object)
+//  unused:32 hash:25 -->|  age:4    biased_lock:1 lock:2 (normal object)
+//  JavaThread*:54 epoch:2  age:4    biased_lock:1 lock:2 (biased object)
 //
 //  - hash contains the identity hash value: largest value is
 //    31 bits, see os::random().  Also, 64-bit vm's require
@@ -130,8 +130,7 @@ class markWord {
   static const int lock_bits                      = 2;
   static const int biased_lock_bits               = 1;
   static const int max_hash_bits                  = BitsPerWord - age_bits - lock_bits - biased_lock_bits;
-  static const int hash_bits                      = max_hash_bits > 31 ? 31 : max_hash_bits;
-  static const int unused_gap_bits                = LP64_ONLY(1) NOT_LP64(0);
+  static const int hash_bits                      = max_hash_bits > 25 ? 25 : max_hash_bits;
   static const int epoch_bits                     = 2;
 
   // The biased locking code currently requires that the age bits be
@@ -139,8 +138,7 @@ class markWord {
   static const int lock_shift                     = 0;
   static const int biased_lock_shift              = lock_bits;
   static const int age_shift                      = lock_bits + biased_lock_bits;
-  static const int unused_gap_shift               = age_shift + age_bits;
-  static const int hash_shift                     = unused_gap_shift + unused_gap_bits;
+  static const int hash_shift                     = age_shift + age_bits;
   static const int epoch_shift                    = hash_shift;
 
   static const uintptr_t lock_mask                = right_n_bits(lock_bits);

--- a/src/hotspot/share/oops/markWord.hpp
+++ b/src/hotspot/share/oops/markWord.hpp
@@ -42,7 +42,7 @@
 //  64 bits:
 //  --------
 //  unused:32 hash:25 -->|  age:4    biased_lock:1 lock:2 (normal object)
-//  JavaThread*:54 epoch:2  age:4    biased_lock:1 lock:2 (biased object)
+//  JavaThread*:55 epoch:2  age:4    biased_lock:1 lock:2 (biased object)
 //
 //  - hash contains the identity hash value: largest value is
 //    31 bits, see os::random().  Also, 64-bit vm's require

--- a/src/hotspot/share/services/heapObjectStatistics.cpp
+++ b/src/hotspot/share/services/heapObjectStatistics.cpp
@@ -137,15 +137,21 @@ void HeapObjectStatistics::begin_sample() {
 
 void HeapObjectStatistics::visit_object(oop obj) {
   increase_counter(_num_objects);
-  if (!obj->mark().has_no_hash()) {
+  markWord mark = obj->mark();
+  if (!mark.has_no_hash()) {
     increase_counter(_num_ihashed);
-    if (obj->mark().age() > 0) {
+    if (mark.age() > 0) {
       increase_counter(_num_ihashed_moved);
     }
   }
-  if (obj->mark().is_locked()) {
+  if (mark.is_locked()) {
     increase_counter(_num_locked);
   }
+#ifdef ASSERT
+  if (!mark.has_displaced_mark_helper()) {
+    assert((mark.value() & 0xffffffff00000000) == 0, "upper 32 mark bits must be free");
+  }
+#endif
   increase_counter(_lds, obj->size());
 }
 

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbLongConstant.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbLongConstant.java
@@ -100,7 +100,7 @@ public class ClhsdbLongConstant {
 
         checkLongValue("markWord::hash_mask_in_place",
                        longConstantOutput,
-                       Platform.is64bit() ? 549755813632L: 4294967168L);
+                       4294967168L);
 
         String arch = System.getProperty("os.arch");
         if (arch.equals("amd64") || arch.equals("i386") || arch.equals("x86")) {


### PR DESCRIPTION
I'd like to trim the identity hashcode to 25 bits to make room in the upper 32bits for the compressed class-pointer.

This could in theory regress performance on workloads that make heavy use of i-hashes, but I could not show this in practice (by specjvm workloads like compiler which uses lots of ihashes).

Next step would be to move the Klass* into the upper 32bit part. (If you look closely, this would be the exact header layout of 32bit JVMs.) And then get rid of the dedicated Klass* field. :-D Eventually I'd make ihash-bits and klass* bits configurable to trade one for the other.

Testing:
 - [x] some manual benchmarks
 - [x] tier1
 - [ ] tier2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - Committer) ⚠️ Review applies to c3790d0cd45a65491a522a4645f5e09814dbc779


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/lilliput pull/3/head:pull/3` \
`$ git checkout pull/3`

Update a local copy of the PR: \
`$ git checkout pull/3` \
`$ git pull https://git.openjdk.java.net/lilliput pull/3/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3`

View PR using the GUI difftool: \
`$ git pr show -t 3`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/lilliput/pull/3.diff">https://git.openjdk.java.net/lilliput/pull/3.diff</a>

</details>
