### PR TITLE
Disable biased locking altogether

### DIFF
--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -4099,6 +4099,13 @@ jint Arguments::apply_ergo() {
       LogConfiguration::configure_stdout(LogLevel::Info, true, LOG_TAGS(valuebasedclasses));
     }
   }
+
+  if (!FLAG_IS_DEFAULT(UseBiasedLocking) && UseBiasedLocking) {
+    warning("Biased Locking is not supported with Lilliput build"
+            "; ignoring UseBiasedLocking flag." );
+  }
+  UseBiasedLocking = false;
+
   return JNI_OK;
 }
 

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -4101,8 +4101,7 @@ jint Arguments::apply_ergo() {
   }
 
   if (!FLAG_IS_DEFAULT(UseBiasedLocking) && UseBiasedLocking) {
-    warning("Biased Locking is not supported with Lilliput build"
-            "; ignoring UseBiasedLocking flag." );
+    warning("Biased Locking is not supported with Lilliput build; ignoring UseBiasedLocking flag." );
   }
   UseBiasedLocking = false;
 

--- a/test/hotspot/jtreg/runtime/logging/BiasedLockingTest.java
+++ b/test/hotspot/jtreg/runtime/logging/BiasedLockingTest.java
@@ -37,7 +37,7 @@ import jdk.test.lib.process.ProcessTools;
 public class BiasedLockingTest {
     static void analyzeOutputOn(ProcessBuilder pb) throws Exception {
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
-        output.shouldContain("Biased locking enabled");
+        output.shouldContain("Biased Locking is not supported");
         output.shouldHaveExitValue(0);
     }
 


### PR DESCRIPTION
In anticipation of eventual removal of biased locking (see JDK-8256425), I'd like to always disable BL in Lilliput. This makes room in the header to put the compressed Klass* in the upper 32 bit. With BL, it would clash with the Thread* there.

Testing:
 - [x] tier1
 - [x] tier2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - Committer) ⚠️ Review applies to c4a00134ab0ab50e80840b0280645019ad7d3cb1


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/lilliput pull/4/head:pull/4` \
`$ git checkout pull/4`

Update a local copy of the PR: \
`$ git checkout pull/4` \
`$ git pull https://git.openjdk.java.net/lilliput pull/4/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4`

View PR using the GUI difftool: \
`$ git pr show -t 4`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/lilliput/pull/4.diff">https://git.openjdk.java.net/lilliput/pull/4.diff</a>

</details>
