### PR TITLE
Unconditionally preserve all marks during GC

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -3061,7 +3061,7 @@ void G1CollectedHeap::do_collection_pause_at_safepoint_helper(double target_paus
 
 void G1CollectedHeap::preserve_mark_during_evac_failure(uint worker_id, oop obj, markWord m) {
   _evacuation_failed_info_array[worker_id].register_copy_failure(obj->size());
-  _preserved_marks_set.get(worker_id)->push_if_necessary(obj, m);
+  _preserved_marks_set.get(worker_id)->push(obj, m);
 }
 
 bool G1ParEvacuateFollowersClosure::offer_termination() {

--- a/src/hotspot/share/gc/g1/g1FullGCCompactionPoint.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCCompactionPoint.cpp
@@ -113,13 +113,6 @@ void G1FullGCCompactionPoint::forward(oop object, size_t size) {
       // even if the mark-word is used. This is no problem since
       // forwardee() will return NULL in the compaction phase as well.
       object->init_mark();
-    } else {
-      // Make sure object has the correct mark-word set or that it will be
-      // fixed when restoring the preserved marks.
-      assert(object->mark() == markWord::prototype_for_klass(object->klass()) || // Correct mark
-             (UseBiasedLocking && object->has_bias_pattern()), // Will be restored by BiasedLocking
-             "should have correct prototype obj: " PTR_FORMAT " mark: " PTR_FORMAT " prototype: " PTR_FORMAT,
-             p2i(object), object->mark().value(), markWord::prototype_for_klass(object->klass()).value());
     }
     assert(object->forwardee() == NULL, "should be forwarded to NULL");
   }

--- a/src/hotspot/share/gc/g1/g1FullGCCompactionPoint.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCCompactionPoint.cpp
@@ -117,7 +117,6 @@ void G1FullGCCompactionPoint::forward(oop object, size_t size) {
       // Make sure object has the correct mark-word set or that it will be
       // fixed when restoring the preserved marks.
       assert(object->mark() == markWord::prototype_for_klass(object->klass()) || // Correct mark
-             object->mark_must_be_preserved() || // Will be restored by PreservedMarksSet
              (UseBiasedLocking && object->has_bias_pattern()), // Will be restored by BiasedLocking
              "should have correct prototype obj: " PTR_FORMAT " mark: " PTR_FORMAT " prototype: " PTR_FORMAT,
              p2i(object), object->mark().value(), markWord::prototype_for_klass(object->klass()).value());

--- a/src/hotspot/share/gc/g1/g1FullGCMarker.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCMarker.inline.hpp
@@ -54,10 +54,9 @@ inline bool G1FullGCMarker::mark_object(oop obj) {
 
   // Marked by us, preserve if needed.
   markWord mark = obj->mark();
-  if (obj->mark_must_be_preserved(mark) &&
-      // It is not necessary to preserve marks for objects in regions we do not
-      // compact because we do not change their headers (i.e. forward them).
-      _collector->is_compacting(obj)) {
+  // It is not necessary to preserve marks for objects in regions we do not
+  // compact because we do not change their headers (i.e. forward them).
+  if (_collector->is_compacting(obj)) {
     preserved_stack()->push(obj, mark);
   }
 

--- a/src/hotspot/share/gc/g1/g1FullGCOopClosures.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCOopClosures.inline.hpp
@@ -79,10 +79,6 @@ template <class T> inline void G1AdjustClosure::adjust_pointer(T* p) {
   oop forwardee = obj->forwardee();
   if (forwardee == NULL) {
     // Not forwarded, return current reference.
-    assert(obj->mark() == markWord::prototype_for_klass(obj->klass()) || // Correct mark
-           (UseBiasedLocking && obj->has_bias_pattern()), // Will be restored by BiasedLocking
-           "Must have correct prototype or be preserved, obj: " PTR_FORMAT ", mark: " PTR_FORMAT ", prototype: " PTR_FORMAT,
-           p2i(obj), obj->mark().value(), markWord::prototype_for_klass(obj->klass()).value());
     return;
   }
 

--- a/src/hotspot/share/gc/g1/g1FullGCOopClosures.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCOopClosures.inline.hpp
@@ -80,7 +80,6 @@ template <class T> inline void G1AdjustClosure::adjust_pointer(T* p) {
   if (forwardee == NULL) {
     // Not forwarded, return current reference.
     assert(obj->mark() == markWord::prototype_for_klass(obj->klass()) || // Correct mark
-           obj->mark_must_be_preserved() || // Will be restored by PreservedMarksSet
            (UseBiasedLocking && obj->has_bias_pattern()), // Will be restored by BiasedLocking
            "Must have correct prototype or be preserved, obj: " PTR_FORMAT ", mark: " PTR_FORMAT ", prototype: " PTR_FORMAT,
            p2i(obj), obj->mark().value(), markWord::prototype_for_klass(obj->klass()).value());

--- a/src/hotspot/share/gc/parallel/psPromotionManager.cpp
+++ b/src/hotspot/share/gc/parallel/psPromotionManager.cpp
@@ -360,7 +360,7 @@ oop PSPromotionManager::oop_promotion_failed(oop obj, markWord obj_mark) {
 
     push_contents(obj);
 
-    _preserved_marks->push_if_necessary(obj, obj_mark);
+    _preserved_marks->push(obj, obj_mark);
   }  else {
     // We lost, someone else "owns" this object
     guarantee(obj->is_forwarded(), "Object must be forwarded if the cas failed.");

--- a/src/hotspot/share/gc/serial/defNewGeneration.cpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.cpp
@@ -680,7 +680,7 @@ void DefNewGeneration::handle_promotion_failure(oop old) {
 
   _promotion_failed = true;
   _promotion_failed_info.register_copy_failure(old->size());
-  _preserved_marks_set.get()->push_if_necessary(old, old->mark());
+  _preserved_marks_set.get()->push(old, old->mark());
   // forward to self
   old->forward_to(old);
 

--- a/src/hotspot/share/gc/serial/markSweep.inline.hpp
+++ b/src/hotspot/share/gc/serial/markSweep.inline.hpp
@@ -41,9 +41,7 @@ inline void MarkSweep::mark_object(oop obj) {
   markWord mark = obj->mark();
   obj->set_mark(markWord::prototype().set_marked());
 
-  if (obj->mark_must_be_preserved(mark)) {
-    preserve_mark(obj, mark);
-  }
+  preserve_mark(obj, mark);
 }
 
 template <class T> inline void MarkSweep::mark_and_push(T* p) {

--- a/src/hotspot/share/gc/shared/preservedMarks.hpp
+++ b/src/hotspot/share/gc/shared/preservedMarks.hpp
@@ -52,12 +52,9 @@ private:
 
   OopAndMarkWordStack _stack;
 
-  inline bool should_preserve_mark(oop obj, markWord m) const;
-
 public:
   size_t size() const { return _stack.size(); }
   inline void push(oop obj, markWord m);
-  inline void push_if_necessary(oop obj, markWord m);
   // Iterate over the stack, restore all preserved marks, and
   // reclaim the memory taken up by the stack segments.
   void restore();

--- a/src/hotspot/share/gc/shared/preservedMarks.inline.hpp
+++ b/src/hotspot/share/gc/shared/preservedMarks.inline.hpp
@@ -30,20 +30,9 @@
 #include "oops/oop.inline.hpp"
 #include "utilities/stack.inline.hpp"
 
-inline bool PreservedMarks::should_preserve_mark(oop obj, markWord m) const {
-  return obj->mark_must_be_preserved_for_promotion_failure(m);
-}
-
 inline void PreservedMarks::push(oop obj, markWord m) {
-  assert(should_preserve_mark(obj, m), "pre-condition");
   OopAndMarkWord elem(obj, m);
   _stack.push(elem);
-}
-
-inline void PreservedMarks::push_if_necessary(oop obj, markWord m) {
-  if (should_preserve_mark(obj, m)) {
-    push(obj, m);
-  }
 }
 
 inline void PreservedMarks::init_forwarded_mark(oop obj) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
@@ -360,7 +360,7 @@ public:
     // Object fits into current region, record new location:
     assert(_compact_point + obj_size <= _to_region->end(), "must fit");
     shenandoah_assert_not_forwarded(NULL, p);
-    _preserved_marks->push_if_necessary(p, p->mark());
+    _preserved_marks->push(p, p->mark());
     p->forward_to(cast_to_oop(_compact_point));
     _compact_point += obj_size;
   }
@@ -468,7 +468,7 @@ void ShenandoahFullGC::calculate_target_humongous_objects() {
 
       if (start >= to_begin && start != r->index()) {
         // Fits into current window, and the move is non-trivial. Record the move then, and continue scan.
-        _preserved_marks->get(0)->push_if_necessary(old_obj, old_obj->mark());
+        _preserved_marks->get(0)->push(old_obj, old_obj->mark());
         old_obj->forward_to(cast_to_oop(heap->get_region(start)->bottom()));
         to_end = start;
         continue;

--- a/src/hotspot/share/oops/markWord.hpp
+++ b/src/hotspot/share/oops/markWord.hpp
@@ -236,30 +236,6 @@ class markWord {
   // is transient and *should* be short-lived).
   static markWord INFLATING() { return zero(); }    // inflate-in-progress
 
-  // Should this header be preserved during GC?
-  template <typename KlassProxy>
-  inline bool must_be_preserved(KlassProxy klass) const;
-
-  // Should this header (including its age bits) be preserved in the
-  // case of a promotion failure during scavenge?
-  // Note that we special case this situation. We want to avoid
-  // calling BiasedLocking::preserve_marks()/restore_marks() (which
-  // decrease the number of mark words that need to be preserved
-  // during GC) during each scavenge. During scavenges in which there
-  // is no promotion failure, we actually don't need to call the above
-  // routines at all, since we don't mutate and re-initialize the
-  // marks of promoted objects using init_mark(). However, during
-  // scavenges which result in promotion failure, we do re-initialize
-  // the mark words of objects, meaning that we should have called
-  // these mark word preservation routines. Currently there's no good
-  // place in which to call them in any of the scavengers (although
-  // guarded by appropriate locks we could make one), but the
-  // observation is that promotion failures are quite rare and
-  // reducing the number of mark words preserved during them isn't a
-  // high priority.
-  template <typename KlassProxy>
-  inline bool must_be_preserved_for_promotion_failure(KlassProxy klass) const;
-
   // WARNING: The following routines are used EXCLUSIVELY by
   // synchronization functions. They are not really gc safe.
   // They must get updated if markWord layout get changed.

--- a/src/hotspot/share/oops/oop.hpp
+++ b/src/hotspot/share/oops/oop.hpp
@@ -294,11 +294,6 @@ class oopDesc {
   inline markWord displaced_mark() const;
   inline void     set_displaced_mark(markWord m);
 
-  // Checks if the mark word needs to be preserved
-  inline bool mark_must_be_preserved() const;
-  inline bool mark_must_be_preserved(markWord m) const;
-  inline bool mark_must_be_preserved_for_promotion_failure(markWord m) const;
-
   static bool has_klass_gap();
 
   // for code generation

--- a/src/hotspot/share/oops/oop.inline.hpp
+++ b/src/hotspot/share/oops/oop.inline.hpp
@@ -409,21 +409,4 @@ public:
   }
 };
 
-bool oopDesc::mark_must_be_preserved() const {
-  return mark_must_be_preserved(mark());
-}
-
-bool oopDesc::mark_must_be_preserved(markWord m) const {
-  // There's a circular dependency between oop.inline.hpp and
-  // markWord.inline.hpp because markWord::must_be_preserved wants to call
-  // oopDesc::klass(). This could be solved by calling klass() here. However,
-  // not all paths inside must_be_preserved calls klass(). Defer the call until
-  // the klass is actually needed.
-  return m.must_be_preserved(DeferredObjectToKlass(this));
-}
-
-bool oopDesc::mark_must_be_preserved_for_promotion_failure(markWord m) const {
-  return m.must_be_preserved_for_promotion_failure(DeferredObjectToKlass(this));
-}
-
 #endif // SHARE_OOPS_OOP_INLINE_HPP

--- a/src/hotspot/share/prims/jvmtiTagMap.cpp
+++ b/src/hotspot/share/prims/jvmtiTagMap.cpp
@@ -1441,10 +1441,8 @@ inline void ObjectMarker::mark(oop o) {
   // object's mark word
   markWord mark = o->mark();
 
-  if (o->mark_must_be_preserved(mark)) {
-    _saved_mark_stack->push(mark);
-    _saved_oop_stack->push(o);
-  }
+  _saved_mark_stack->push(mark);
+  _saved_oop_stack->push(o);
 
   // mark the object
   o->set_mark(markWord::prototype().set_marked());


### PR DESCRIPTION
When storing the Klass* in the object header, we need to preserve all marks during GC, because otherwise we'd be loosing the Klass*.

This means that the PreservedMarks structure is repurposed as a full (reverse) forwarding table. Reverse because instead of mapping object->forwardee, and leaving the mark alone, it maps object->mark and stores the forwardee in the header, which might be a better idea because it means we can have a most compact table.

Shenandoah doesn't have this problem, except during full-GC, and ZGC has its own forwarding table.

This change will likely affect performance, but I haven't checked by how much, yet. It's probably more useful to see this in the context of actually reduced header.
Testing:
 - [x] tier1
 - [x] tier2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/lilliput pull/6/head:pull/6` \
`$ git checkout pull/6`

Update a local copy of the PR: \
`$ git checkout pull/6` \
`$ git pull https://git.openjdk.java.net/lilliput pull/6/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6`

View PR using the GUI difftool: \
`$ git pr show -t 6`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/lilliput/pull/6.diff">https://git.openjdk.java.net/lilliput/pull/6.diff</a>

</details>
