### PR TITLE
Use sliding forwarding in SerialGC

### DIFF
--- a/src/hotspot/share/gc/serial/genMarkSweep.cpp
+++ b/src/hotspot/share/gc/serial/genMarkSweep.cpp
@@ -271,6 +271,8 @@ void GenMarkSweep::mark_sweep_phase3() {
   // Need new claim bits for the pointer adjustment tracing.
   ClassLoaderDataGraph::clear_claimed_marks();
 
+  AdjustPointerClosure adjust_pointer_closure(gch->forwarding());
+  CLDToOopClosure adjust_cld_closure(&adjust_pointer_closure, ClassLoaderData::_claim_strong);
   {
     StrongRootsScope srs(0);
 

--- a/src/hotspot/share/gc/serial/markSweep.cpp
+++ b/src/hotspot/share/gc/serial/markSweep.cpp
@@ -26,6 +26,7 @@
 #include "compiler/compileBroker.hpp"
 #include "gc/serial/markSweep.inline.hpp"
 #include "gc/shared/collectedHeap.inline.hpp"
+#include "gc/shared/genCollectedHeap.hpp"
 #include "gc/shared/gcTimer.hpp"
 #include "gc/shared/gcTrace.hpp"
 #include "gc/shared/gc_globals.hpp"
@@ -62,7 +63,6 @@ MarkSweep::FollowRootClosure  MarkSweep::follow_root_closure;
 
 MarkAndPushClosure MarkSweep::mark_and_push_closure;
 CLDToOopClosure    MarkSweep::follow_cld_closure(&mark_and_push_closure, ClassLoaderData::_claim_strong);
-CLDToOopClosure    MarkSweep::adjust_cld_closure(&adjust_pointer_closure, ClassLoaderData::_claim_strong);
 
 template <class T> inline void MarkSweep::KeepAliveClosure::do_oop_work(T* p) {
   mark_and_push(p);
@@ -144,8 +144,8 @@ template <class T> inline void MarkSweep::follow_root(T* p) {
 void MarkSweep::FollowRootClosure::do_oop(oop* p)       { follow_root(p); }
 void MarkSweep::FollowRootClosure::do_oop(narrowOop* p) { follow_root(p); }
 
-void PreservedMark::adjust_pointer() {
-  MarkSweep::adjust_pointer(&_obj);
+void PreservedMark::adjust_pointer(SlidingForwarding* forwarding) {
+  MarkSweep::adjust_pointer(forwarding, &_obj);
 }
 
 void PreservedMark::restore() {
@@ -173,22 +173,22 @@ void MarkSweep::set_ref_processor(ReferenceProcessor* rp) {
   mark_and_push_closure.set_ref_discoverer(_ref_processor);
 }
 
-AdjustPointerClosure MarkSweep::adjust_pointer_closure;
-
 void MarkSweep::adjust_marks() {
   assert( _preserved_oop_stack.size() == _preserved_mark_stack.size(),
          "inconsistent preserved oop stacks");
 
+  SlidingForwarding* forwarding = GenCollectedHeap::heap()->forwarding();
+
   // adjust the oops we saved earlier
   for (size_t i = 0; i < _preserved_count; i++) {
-    _preserved_marks[i].adjust_pointer();
+    _preserved_marks[i].adjust_pointer(forwarding);
   }
 
   // deal with the overflow stack
   StackIterator<oop, mtGC> iter(_preserved_oop_stack);
   while (!iter.is_empty()) {
     oop* p = iter.next_addr();
-    adjust_pointer(p);
+    adjust_pointer(forwarding, p);
   }
 }
 

--- a/src/hotspot/share/gc/serial/markSweep.hpp
+++ b/src/hotspot/share/gc/serial/markSweep.hpp
@@ -38,6 +38,7 @@
 class ReferenceProcessor;
 class DataLayout;
 class SerialOldTracer;
+class SlidingForwarding;
 class STWGCTimer;
 
 // MarkSweep takes care of global mark-compact garbage collection for a
@@ -124,8 +125,6 @@ class MarkSweep : AllStatic {
   static MarkAndPushClosure   mark_and_push_closure;
   static FollowStackClosure   follow_stack_closure;
   static CLDToOopClosure      follow_cld_closure;
-  static AdjustPointerClosure adjust_pointer_closure;
-  static CLDToOopClosure      adjust_cld_closure;
 
   // Accessors
   static uint total_invocations() { return _total_invocations; }
@@ -142,7 +141,7 @@ class MarkSweep : AllStatic {
   static void adjust_marks();   // Adjust the pointers in the preserved marks table
   static void restore_marks();  // Restore the marks that we saved in preserve_mark
 
-  static int adjust_pointers(oop obj);
+  static int adjust_pointers(SlidingForwarding* forwarding, oop obj);
 
   static void follow_stack();   // Empty marking stack.
 
@@ -150,7 +149,7 @@ class MarkSweep : AllStatic {
 
   static void follow_cld(ClassLoaderData* cld);
 
-  template <class T> static inline void adjust_pointer(T* p);
+  template <class T> static inline void adjust_pointer(SlidingForwarding* forwarding, T* p);
 
   // Check mark and maybe push on marking stack
   template <class T> static void mark_and_push(T* p);
@@ -186,7 +185,10 @@ public:
 };
 
 class AdjustPointerClosure: public BasicOopIterateClosure {
+private:
+  SlidingForwarding* const _forwarding;
  public:
+  AdjustPointerClosure(SlidingForwarding* forwarding) : _forwarding(forwarding) {}
   template <typename T> void do_oop_work(T* p);
   virtual void do_oop(oop* p);
   virtual void do_oop(narrowOop* p);
@@ -204,7 +206,7 @@ public:
     _mark = mark;
   }
 
-  void adjust_pointer();
+  void adjust_pointer(SlidingForwarding* forwarding);
   void restore();
 };
 

--- a/src/hotspot/share/gc/serial/markSweep.inline.hpp
+++ b/src/hotspot/share/gc/serial/markSweep.inline.hpp
@@ -27,6 +27,7 @@
 
 #include "classfile/classLoaderData.inline.hpp"
 #include "gc/serial/markSweep.hpp"
+#include "gc/shared/slidingForwarding.hpp"
 #include "memory/universe.hpp"
 #include "oops/markWord.inline.hpp"
 #include "oops/access.inline.hpp"
@@ -73,7 +74,7 @@ inline void MarkAndPushClosure::do_oop(narrowOop* p)         { do_oop_work(p); }
 inline void MarkAndPushClosure::do_klass(Klass* k)           { MarkSweep::follow_klass(k); }
 inline void MarkAndPushClosure::do_cld(ClassLoaderData* cld) { MarkSweep::follow_cld(cld); }
 
-template <class T> inline void MarkSweep::adjust_pointer(T* p) {
+template <class T> inline void MarkSweep::adjust_pointer(SlidingForwarding* forwarding, T* p) {
   T heap_oop = RawAccess<>::oop_load(p);
   if (!CompressedOops::is_null(heap_oop)) {
     oop obj = CompressedOops::decode_not_null(heap_oop);
@@ -81,7 +82,7 @@ template <class T> inline void MarkSweep::adjust_pointer(T* p) {
 
     markWord header = obj->mark();
     if (header.is_marked()) {
-      oop new_obj = cast_to_oop(header.decode_pointer());
+      oop new_obj = forwarding->forwardee(obj);
       assert(new_obj != NULL, "must be forwarded");
       assert(is_object_aligned(new_obj), "oop must be aligned");
       RawAccess<IS_NOT_NULL>::oop_store(p, new_obj);
@@ -90,13 +91,14 @@ template <class T> inline void MarkSweep::adjust_pointer(T* p) {
 }
 
 template <typename T>
-void AdjustPointerClosure::do_oop_work(T* p)           { MarkSweep::adjust_pointer(p); }
+void AdjustPointerClosure::do_oop_work(T* p)           { MarkSweep::adjust_pointer(_forwarding, p); }
 inline void AdjustPointerClosure::do_oop(oop* p)       { do_oop_work(p); }
 inline void AdjustPointerClosure::do_oop(narrowOop* p) { do_oop_work(p); }
 
 
-inline int MarkSweep::adjust_pointers(oop obj) {
-  return obj->oop_iterate_size(&MarkSweep::adjust_pointer_closure);
+inline int MarkSweep::adjust_pointers(SlidingForwarding* forwarding, oop obj) {
+  AdjustPointerClosure cl(forwarding);
+  return obj->oop_iterate_size(&cl);
 }
 
 #endif // SHARE_GC_SERIAL_MARKSWEEP_INLINE_HPP

--- a/src/hotspot/share/gc/shared/genCollectedHeap.cpp
+++ b/src/hotspot/share/gc/shared/genCollectedHeap.cpp
@@ -52,6 +52,7 @@
 #include "gc/shared/oopStorageSet.inline.hpp"
 #include "gc/shared/oopStorageParState.inline.hpp"
 #include "gc/shared/scavengableNMethods.hpp"
+#include "gc/shared/slidingForwarding.hpp"
 #include "gc/shared/space.hpp"
 #include "gc/shared/strongRootsScope.hpp"
 #include "gc/shared/weakProcessor.hpp"
@@ -122,6 +123,7 @@ jint GenCollectedHeap::initialize() {
   }
 
   initialize_reserved_region(heap_rs);
+  _forwarding = new SlidingForwarding(_reserved);
 
   _rem_set = create_rem_set(heap_rs.region());
   _rem_set->initialize();
@@ -1113,6 +1115,7 @@ GenCollectedHeap* GenCollectedHeap::heap() {
 void GenCollectedHeap::prepare_for_compaction() {
   // Start by compacting into same gen.
   CompactPoint cp(_old_gen);
+  _forwarding->clear();
   _old_gen->prepare_for_compaction(&cp);
   _young_gen->prepare_for_compaction(&cp);
 }

--- a/src/hotspot/share/gc/shared/genCollectedHeap.hpp
+++ b/src/hotspot/share/gc/shared/genCollectedHeap.hpp
@@ -35,6 +35,7 @@ class AdaptiveSizePolicy;
 class CardTableRS;
 class GCPolicyCounters;
 class GenerationSpec;
+class SlidingForwarding;
 class StrongRootsScope;
 class SubTasksDone;
 class WorkGang;
@@ -87,6 +88,8 @@ private:
 
   // In support of ExplicitGCInvokesConcurrent functionality
   unsigned int _full_collections_completed;
+
+  SlidingForwarding* _forwarding;
 
   // Collects the given generation.
   void collect_generation(Generation* gen, bool full, size_t size, bool is_tlab,
@@ -331,6 +334,10 @@ public:
   // asserted to be this type.
   static GenCollectedHeap* heap();
 
+  SlidingForwarding* forwarding() const {
+    return _forwarding;
+  }
+
   // The ScanningOption determines which of the roots
   // the closure is applied to:
   // "SO_None" does none;
@@ -433,6 +440,7 @@ private:
   // Return true if we need to perform full collection.
   bool should_do_full_collection(size_t size, bool full,
                                  bool is_tlab, GenerationType max_gen) const;
+
 };
 
 #endif // SHARE_GC_SHARED_GENCOLLECTEDHEAP_HPP

--- a/src/hotspot/share/gc/shared/preservedMarks.cpp
+++ b/src/hotspot/share/gc/shared/preservedMarks.cpp
@@ -24,6 +24,7 @@
 
 #include "precompiled.hpp"
 #include "gc/shared/preservedMarks.inline.hpp"
+#include "gc/shared/slidingForwarding.hpp"
 #include "gc/shared/workgroup.hpp"
 #include "memory/allocation.inline.hpp"
 #include "memory/resourceArea.hpp"
@@ -47,6 +48,18 @@ void PreservedMarks::adjust_during_full_gc() {
     oop obj = elem->get_oop();
     if (obj->is_forwarded()) {
       elem->set_oop(obj->forwardee());
+    }
+  }
+}
+
+void PreservedMarks::adjust_during_full_gc(SlidingForwarding* forwarding) {
+  StackIterator<OopAndMarkWord, mtGC> iter(_stack);
+  while (!iter.is_empty()) {
+    OopAndMarkWord* elem = iter.next_addr();
+
+    oop obj = elem->get_oop();
+    if (obj->is_forwarded()) {
+      elem->set_oop(forwarding->forwardee(obj));
     }
   }
 }

--- a/src/hotspot/share/gc/shared/preservedMarks.hpp
+++ b/src/hotspot/share/gc/shared/preservedMarks.hpp
@@ -32,6 +32,7 @@
 
 class AbstractGangTask;
 class PreservedMarksSet;
+class SlidingForwarding;
 class WorkGang;
 
 class PreservedMarks {
@@ -64,6 +65,7 @@ public:
   // Iterate over the stack, adjust all preserved marks according
   // to their forwarding location stored in the mark.
   void adjust_during_full_gc();
+  void adjust_during_full_gc(SlidingForwarding* forwarding);
 
   void restore_and_increment(volatile size_t* const _total_size_addr);
   inline static void init_forwarded_mark(oop obj);

--- a/src/hotspot/share/gc/shared/slidingForwarding.cpp
+++ b/src/hotspot/share/gc/shared/slidingForwarding.cpp
@@ -37,7 +37,7 @@ SlidingForwarding::SlidingForwarding(MemRegion heap, size_t region_size_words_sh
   _num_regions(((heap.end() - heap.start()) >> region_size_words_shift) + 1),
   _region_size_words_shift(region_size_words_shift),
   _target_base_table(NEW_C_HEAP_ARRAY(HeapWord*, _num_regions * 2, mtGC)) {
-  assert(region_size_words_shift <= NUM_BITS, "regions must not be larger than maximum addressing bits allow");
+  assert(region_size_words_shift <= NUM_COMPRESSED_BITS, "regions must not be larger than maximum addressing bits allow");
 #else
 {
 #endif

--- a/src/hotspot/share/gc/shared/slidingForwarding.cpp
+++ b/src/hotspot/share/gc/shared/slidingForwarding.cpp
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *2,q
+ */
+
+#include "precompiled.hpp"
+#include "gc/shared/slidingForwarding.hpp"
+#include "oops/markWord.hpp"
+#include "oops/oop.inline.hpp"
+
+HeapWord* const SlidingForwarding::UNUSED_BASE = reinterpret_cast<HeapWord*>(0x1);
+
+SlidingForwarding::SlidingForwarding(MemRegion heap, size_t region_size_words_shift) :
+  _heap_start(heap.start()),
+  _num_regions(((heap.end() - heap.start()) >> region_size_words_shift) + 1),
+  _region_size_words_shift(region_size_words_shift),
+  _target_base_table(NEW_C_HEAP_ARRAY(HeapWord*, _num_regions * 2, mtGC)) {
+  assert(region_size_words_shift <= NUM_BITS, "regions must not be larger than maximum addressing bits allow");
+}
+
+SlidingForwarding::~SlidingForwarding() {
+  FREE_C_HEAP_ARRAY(HeapWord*, _target_base_table);
+}
+
+void SlidingForwarding::clear() {
+  size_t max = _num_regions * 2;
+  for (size_t i = 0; i < max; i++) {
+    _target_base_table[i] = UNUSED_BASE;
+  }
+}
+
+size_t SlidingForwarding::region_index_containing(HeapWord* addr) {
+  assert(addr >= _heap_start, "sanity: addr: " PTR_FORMAT " heap base: " PTR_FORMAT, p2i(addr), p2i(_heap_start));
+  size_t index = ((size_t) (addr - _heap_start)) >> _region_size_words_shift;
+  assert(index < _num_regions, "Region index is in bounds: " PTR_FORMAT, p2i(addr));
+  return index;
+}
+
+bool SlidingForwarding::region_contains(HeapWord* region_base, HeapWord* addr) {
+  return (addr - region_base) < (1 << _region_size_words_shift);
+}
+
+uintptr_t SlidingForwarding::encode_forwarding(HeapWord* original, HeapWord* target) {
+  size_t orig_idx = region_index_containing(original);
+  size_t base_table_idx = orig_idx * 2;
+  size_t target_idx = region_index_containing(target);
+  HeapWord* encode_base = _target_base_table[base_table_idx];
+  uintptr_t flag = 0;
+  if (encode_base == UNUSED_BASE) {
+    encode_base = _heap_start + target_idx * (1 << _region_size_words_shift);
+    _target_base_table[base_table_idx] = encode_base;
+  } else if (!region_contains(encode_base, target)) {
+    base_table_idx++;
+    flag = 1;
+    encode_base = _target_base_table[base_table_idx];
+    if (encode_base == UNUSED_BASE) {
+      encode_base = _heap_start + target_idx * (1 << _region_size_words_shift);
+      _target_base_table[base_table_idx] = encode_base;
+    }
+  }
+  assert(region_contains(encode_base, target), "region must contain target");
+  uintptr_t encoded = (((uintptr_t)(target - encode_base)) << COMPRESSED_BITS_SHIFT) |
+                      (flag << REGION_INDICATOR_FLAG_SHIFT) | markWord::marked_value;
+  assert(target == decode_forwarding(original, encoded), "must be reversible");
+  return encoded;
+}
+
+HeapWord* SlidingForwarding::decode_forwarding(HeapWord* original, uintptr_t encoded) {
+  assert(encoded & markWord::marked_value == markWord::marked_value, "must be marked as forwarded");
+  size_t orig_idx = region_index_containing(original);
+  size_t flag = (encoded >> REGION_INDICATOR_FLAG_SHIFT) & 1;
+  size_t base_table_idx = orig_idx * 2 + flag;
+  HeapWord* decoded = _target_base_table[base_table_idx] + (encoded >> COMPRESSED_BITS_SHIFT);
+  return decoded;
+}
+
+void SlidingForwarding::forward_to(oop original, oop target) {
+  markWord header = original->mark();
+  uintptr_t encoded = encode_forwarding(cast_from_oop<HeapWord*>(original), cast_from_oop<HeapWord*>(target));
+  assert((encoded & markWord::klass_mask_in_place) == 0, "encoded forwardee must not overlap with Klass*");
+  header = markWord((header.value() & markWord::klass_mask_in_place) | encoded);
+  original->set_mark(header);
+}
+
+oop SlidingForwarding::forwardee(oop original) {
+  markWord header = original->mark();
+  uintptr_t encoded = header.value() & ~markWord::klass_mask_in_place;
+  HeapWord* forwardee = decode_forwarding(cast_from_oop<HeapWord*>(original), encoded);
+  return cast_to_oop(forwardee);
+}

--- a/src/hotspot/share/gc/shared/slidingForwarding.cpp
+++ b/src/hotspot/share/gc/shared/slidingForwarding.cpp
@@ -67,7 +67,7 @@ size_t SlidingForwarding::region_index_containing(HeapWord* addr) {
 }
 
 bool SlidingForwarding::region_contains(HeapWord* region_base, HeapWord* addr) {
-  return (addr - region_base) < (1 << _region_size_words_shift);
+  return (addr - region_base) < (1L << _region_size_words_shift);
 }
 
 uintptr_t SlidingForwarding::encode_forwarding(HeapWord* original, HeapWord* target) {
@@ -77,14 +77,14 @@ uintptr_t SlidingForwarding::encode_forwarding(HeapWord* original, HeapWord* tar
   HeapWord* encode_base = _target_base_table[base_table_idx];
   uintptr_t flag = 0;
   if (encode_base == UNUSED_BASE) {
-    encode_base = _heap_start + target_idx * (1 << _region_size_words_shift);
+    encode_base = _heap_start + target_idx * (1L << _region_size_words_shift);
     _target_base_table[base_table_idx] = encode_base;
   } else if (!region_contains(encode_base, target)) {
     base_table_idx++;
     flag = 1;
     encode_base = _target_base_table[base_table_idx];
     if (encode_base == UNUSED_BASE) {
-      encode_base = _heap_start + target_idx * (1 << _region_size_words_shift);
+      encode_base = _heap_start + target_idx * (1L << _region_size_words_shift);
       _target_base_table[base_table_idx] = encode_base;
     }
   }

--- a/src/hotspot/share/gc/shared/slidingForwarding.cpp
+++ b/src/hotspot/share/gc/shared/slidingForwarding.cpp
@@ -59,15 +59,15 @@ void SlidingForwarding::clear() {
 }
 
 #ifdef _LP64
-size_t SlidingForwarding::region_index_containing(HeapWord* addr) {
+size_t SlidingForwarding::region_index_containing(HeapWord* addr) const {
   assert(addr >= _heap_start, "sanity: addr: " PTR_FORMAT " heap base: " PTR_FORMAT, p2i(addr), p2i(_heap_start));
   size_t index = ((size_t) (addr - _heap_start)) >> _region_size_words_shift;
   assert(index < _num_regions, "Region index is in bounds: " PTR_FORMAT, p2i(addr));
   return index;
 }
 
-bool SlidingForwarding::region_contains(HeapWord* region_base, HeapWord* addr) {
-  return (addr - region_base) < (1L << _region_size_words_shift);
+bool SlidingForwarding::region_contains(HeapWord* region_base, HeapWord* addr) const {
+  return (addr - region_base) < (ptrdiff_t)(ONE << _region_size_words_shift);
 }
 
 uintptr_t SlidingForwarding::encode_forwarding(HeapWord* original, HeapWord* target) {
@@ -77,14 +77,14 @@ uintptr_t SlidingForwarding::encode_forwarding(HeapWord* original, HeapWord* tar
   HeapWord* encode_base = _target_base_table[base_table_idx];
   uintptr_t flag = 0;
   if (encode_base == UNUSED_BASE) {
-    encode_base = _heap_start + target_idx * (1L << _region_size_words_shift);
+    encode_base = _heap_start + target_idx * (ONE << _region_size_words_shift);
     _target_base_table[base_table_idx] = encode_base;
   } else if (!region_contains(encode_base, target)) {
     base_table_idx++;
     flag = 1;
     encode_base = _target_base_table[base_table_idx];
     if (encode_base == UNUSED_BASE) {
-      encode_base = _heap_start + target_idx * (1L << _region_size_words_shift);
+      encode_base = _heap_start + target_idx * (ONE << _region_size_words_shift);
       _target_base_table[base_table_idx] = encode_base;
     }
   }

--- a/src/hotspot/share/gc/shared/slidingForwarding.cpp
+++ b/src/hotspot/share/gc/shared/slidingForwarding.cpp
@@ -96,7 +96,7 @@ uintptr_t SlidingForwarding::encode_forwarding(HeapWord* original, HeapWord* tar
 }
 
 HeapWord* SlidingForwarding::decode_forwarding(HeapWord* original, uintptr_t encoded) {
-  assert(encoded & markWord::marked_value == markWord::marked_value, "must be marked as forwarded");
+  assert((encoded & markWord::marked_value) == markWord::marked_value, "must be marked as forwarded");
   size_t orig_idx = region_index_containing(original);
   size_t flag = (encoded >> REGION_INDICATOR_FLAG_SHIFT) & 1;
   size_t base_table_idx = orig_idx * 2 + flag;

--- a/src/hotspot/share/gc/shared/slidingForwarding.cpp
+++ b/src/hotspot/share/gc/shared/slidingForwarding.cpp
@@ -31,13 +31,25 @@
 HeapWord* const SlidingForwarding::UNUSED_BASE = reinterpret_cast<HeapWord*>(0x1);
 #endif
 
+SlidingForwarding::SlidingForwarding(MemRegion heap)
+#ifdef _LP64
+: _heap_start(heap.start()),
+  _num_regions(((heap.end() - heap.start()) >> NUM_COMPRESSED_BITS) + 1),
+  _region_size_words_shift(NUM_COMPRESSED_BITS),
+  _target_base_table(NEW_C_HEAP_ARRAY(HeapWord*, _num_regions * 2, mtGC)) {
+  assert(_region_size_words_shift <= NUM_COMPRESSED_BITS, "regions must not be larger than maximum addressing bits allow");
+#else
+{
+#endif
+}
+
 SlidingForwarding::SlidingForwarding(MemRegion heap, size_t region_size_words_shift)
 #ifdef _LP64
 : _heap_start(heap.start()),
   _num_regions(((heap.end() - heap.start()) >> region_size_words_shift) + 1),
   _region_size_words_shift(region_size_words_shift),
   _target_base_table(NEW_C_HEAP_ARRAY(HeapWord*, _num_regions * 2, mtGC)) {
-  assert(region_size_words_shift <= NUM_COMPRESSED_BITS, "regions must not be larger than maximum addressing bits allow");
+  assert(_region_size_words_shift <= NUM_COMPRESSED_BITS, "regions must not be larger than maximum addressing bits allow");
 #else
 {
 #endif

--- a/src/hotspot/share/gc/shared/slidingForwarding.cpp
+++ b/src/hotspot/share/gc/shared/slidingForwarding.cpp
@@ -27,27 +27,38 @@
 #include "oops/markWord.hpp"
 #include "oops/oop.inline.hpp"
 
+#ifdef _LP64
 HeapWord* const SlidingForwarding::UNUSED_BASE = reinterpret_cast<HeapWord*>(0x1);
+#endif
 
-SlidingForwarding::SlidingForwarding(MemRegion heap, size_t region_size_words_shift) :
-  _heap_start(heap.start()),
+SlidingForwarding::SlidingForwarding(MemRegion heap, size_t region_size_words_shift)
+#ifdef _LP64
+: _heap_start(heap.start()),
   _num_regions(((heap.end() - heap.start()) >> region_size_words_shift) + 1),
   _region_size_words_shift(region_size_words_shift),
   _target_base_table(NEW_C_HEAP_ARRAY(HeapWord*, _num_regions * 2, mtGC)) {
   assert(region_size_words_shift <= NUM_BITS, "regions must not be larger than maximum addressing bits allow");
+#else
+{
+#endif
 }
 
 SlidingForwarding::~SlidingForwarding() {
+#ifdef _LP64
   FREE_C_HEAP_ARRAY(HeapWord*, _target_base_table);
+#endif
 }
 
 void SlidingForwarding::clear() {
+#ifdef _LP64
   size_t max = _num_regions * 2;
   for (size_t i = 0; i < max; i++) {
     _target_base_table[i] = UNUSED_BASE;
   }
+#endif
 }
 
+#ifdef _LP64
 size_t SlidingForwarding::region_index_containing(HeapWord* addr) {
   assert(addr >= _heap_start, "sanity: addr: " PTR_FORMAT " heap base: " PTR_FORMAT, p2i(addr), p2i(_heap_start));
   size_t index = ((size_t) (addr - _heap_start)) >> _region_size_words_shift;
@@ -92,18 +103,27 @@ HeapWord* SlidingForwarding::decode_forwarding(HeapWord* original, uintptr_t enc
   HeapWord* decoded = _target_base_table[base_table_idx] + (encoded >> COMPRESSED_BITS_SHIFT);
   return decoded;
 }
+#endif
 
 void SlidingForwarding::forward_to(oop original, oop target) {
+#ifdef _LP64
   markWord header = original->mark();
   uintptr_t encoded = encode_forwarding(cast_from_oop<HeapWord*>(original), cast_from_oop<HeapWord*>(target));
   assert((encoded & markWord::klass_mask_in_place) == 0, "encoded forwardee must not overlap with Klass*");
   header = markWord((header.value() & markWord::klass_mask_in_place) | encoded);
   original->set_mark(header);
+#else
+  original->forward_to(target);
+#endif
 }
 
 oop SlidingForwarding::forwardee(oop original) {
+#ifdef _LP64
   markWord header = original->mark();
   uintptr_t encoded = header.value() & ~markWord::klass_mask_in_place;
   HeapWord* forwardee = decode_forwarding(cast_from_oop<HeapWord*>(original), encoded);
   return cast_to_oop(forwardee);
+#else
+  return original->forwardee();
+#endif
 }

--- a/src/hotspot/share/gc/shared/slidingForwarding.hpp
+++ b/src/hotspot/share/gc/shared/slidingForwarding.hpp
@@ -97,6 +97,7 @@ private:
 #endif
 
 public:
+  SlidingForwarding(MemRegion heap);
   SlidingForwarding(MemRegion heap, size_t num_regions);
   ~SlidingForwarding();
 

--- a/src/hotspot/share/gc/shared/slidingForwarding.hpp
+++ b/src/hotspot/share/gc/shared/slidingForwarding.hpp
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef SHARE_GC_SHARED_SLIDINGFORWARDING_HPP
+#define SHARE_GC_SHARED_SLIDINGFORWARDING_HPP
+
+#include "memory/allocation.hpp"
+#include "memory/memRegion.hpp"
+#include "oops/oopsHierarchy.hpp"
+
+/**
+ * SlidingForwarding is a method to store forwarding information in a compressed form into the object header,
+ * that has been specifically designed for sliding compaction GCs.
+ * It avoids overriding the compressed class pointer in the upper bits of the header, which would otherwise
+ * be lost. SlidingForwarding requires only small side tables and guarantees constant-time access and modification.
+ *
+ * The idea is to use a pointer compression scheme very similar to the one that is used for compressed oops.
+ * We divide the heap into number of logical regions. Each region spans maximum of 2^NUM_BITS words.
+ * We take advantage of the fact that sliding compaction can forward objects from ore region to a maximum of
+ * two regions (including itself, but that does not really matter). We need 1 bit to indicate which region is forwarded
+ * into. We also currently require the two lowest header bits to indicate that the object is forwarded.
+ *
+ * For addressing, we need a table with N*2 entries, for N logical regions. For each region, it gives the base
+ * address of the two target regions, or a special placeholder if not used.
+ *
+ * Adding a forwarding then works as follows:
+ * Given an original address 'orig', and a 'target' address:
+ * - Look-up first target base of region of orig. If not yet used,
+ *   establish it to be the base of region of target address. Use that base in step 3.
+ * - Else, if first target base is already used, check second target base. This must either be unused, or the
+ *   base of the region of our target address. If unused, establish it to be the base of the region of our target
+ *   address. Use that base for next step.
+ * - Now we found a base address. Encode the target address with that base into lowest NUM_BITS bits, and shift
+ *   that up by 3 bits. Set the 3rd bit if we used the secondary target base, otherwise leave it at 0. Set the
+ *   lowest two bits to indicate that the object has been forwarded. Store that in the lowest NUM_BITS+3 bits of the
+ *   original object's header.
+ *
+ * Similarily, looking up the target address, given an original object address works as follows:
+ * - Load lowest NUM_BITS + 3 from original object header. Extract target region bit and compressed address bits.
+ * - Depending on target region bit, load base address from the target base table by looking up the corresponding entry
+ *   for the region of the original object.
+ * - Decode the target address by using the target base address and the compressed address bits.
+ */
+
+class SlidingForwarding : public CHeapObj<mtGC> {
+private:
+  // How many bits we use for the compressed pointer (we are going to need one more bit to indicate target region, and
+  // two lowest bits to mark objects as forwarded)
+  static const int NUM_COMPRESSED_BITS = 29;
+
+  // The compressed address bits start here
+  static const int COMPRESSED_BITS_SHIFT = 3;
+
+  // The region indicator flag is here.
+  static const int REGION_INDICATOR_FLAG_SHIFT = 2;
+
+  // Indicates an usused base address in the target base table. We cannot use 0, because that may already be
+  // a valid base address in zero-based heaps. 0x1 is safe because heap base addresses must be aligned by 2^X.
+  static HeapWord* const UNUSED_BASE;
+
+  HeapWord*  const _heap_start;
+  size_t     const _num_regions;
+  size_t           _region_size_words_shift;
+  HeapWord** const _target_base_table;
+
+  size_t region_index_containing(HeapWord* addr);
+  bool region_contains(HeapWord* region_base, HeapWord* addr);
+
+public:
+  SlidingForwarding(MemRegion heap, size_t num_regions);
+  ~SlidingForwarding();
+
+  void clear();
+
+  uintptr_t encode_forwarding(HeapWord* original, HeapWord* target);
+  HeapWord* decode_forwarding(HeapWord* original, uintptr_t encoded);
+
+  void forward_to(oop original, oop target);
+  oop forwardee(oop original);
+};
+
+#endif // SHARE_GC_SHARE_SLIDINGFORWARDING_HPP

--- a/src/hotspot/share/gc/shared/slidingForwarding.hpp
+++ b/src/hotspot/share/gc/shared/slidingForwarding.hpp
@@ -66,6 +66,9 @@
 class SlidingForwarding : public CHeapObj<mtGC> {
 #ifdef _LP64
 private:
+
+  static const uintptr_t ONE = 1ULL;
+
   // How many bits we use for the compressed pointer (we are going to need one more bit to indicate target region, and
   // two lowest bits to mark objects as forwarded)
   static const int NUM_COMPRESSED_BITS = 29;
@@ -85,8 +88,8 @@ private:
   size_t           _region_size_words_shift;
   HeapWord** const _target_base_table;
 
-  size_t region_index_containing(HeapWord* addr);
-  bool region_contains(HeapWord* region_base, HeapWord* addr);
+  size_t region_index_containing(HeapWord* addr) const;
+  bool region_contains(HeapWord* region_base, HeapWord* addr) const;
 
   uintptr_t encode_forwarding(HeapWord* original, HeapWord* target);
   HeapWord* decode_forwarding(HeapWord* original, uintptr_t encoded);
@@ -102,4 +105,4 @@ public:
   oop forwardee(oop original);
 };
 
-#endif // SHARE_GC_SHARE_SLIDINGFORWARDING_HPP
+#endif // SHARE_GC_SHARED_SLIDINGFORWARDING_HPP

--- a/src/hotspot/share/gc/shared/slidingForwarding.hpp
+++ b/src/hotspot/share/gc/shared/slidingForwarding.hpp
@@ -64,6 +64,7 @@
  */
 
 class SlidingForwarding : public CHeapObj<mtGC> {
+#ifdef _LP64
 private:
   // How many bits we use for the compressed pointer (we are going to need one more bit to indicate target region, and
   // two lowest bits to mark objects as forwarded)
@@ -87,15 +88,16 @@ private:
   size_t region_index_containing(HeapWord* addr);
   bool region_contains(HeapWord* region_base, HeapWord* addr);
 
+  uintptr_t encode_forwarding(HeapWord* original, HeapWord* target);
+  HeapWord* decode_forwarding(HeapWord* original, uintptr_t encoded);
+
+#endif
+
 public:
   SlidingForwarding(MemRegion heap, size_t num_regions);
   ~SlidingForwarding();
 
   void clear();
-
-  uintptr_t encode_forwarding(HeapWord* original, HeapWord* target);
-  HeapWord* decode_forwarding(HeapWord* original, uintptr_t encoded);
-
   void forward_to(oop original, oop target);
   oop forwardee(oop original);
 };

--- a/src/hotspot/share/gc/shared/space.cpp
+++ b/src/hotspot/share/gc/shared/space.cpp
@@ -29,6 +29,7 @@
 #include "gc/shared/collectedHeap.inline.hpp"
 #include "gc/shared/genCollectedHeap.hpp"
 #include "gc/shared/genOopClosures.inline.hpp"
+#include "gc/shared/slidingForwarding.hpp"
 #include "gc/shared/space.hpp"
 #include "gc/shared/space.inline.hpp"
 #include "gc/shared/spaceDecorator.inline.hpp"
@@ -347,7 +348,7 @@ void CompactibleSpace::clear(bool mangle_space) {
 }
 
 HeapWord* CompactibleSpace::forward(oop q, size_t size,
-                                    CompactPoint* cp, HeapWord* compact_top) {
+                                    CompactPoint* cp, HeapWord* compact_top, SlidingForwarding* forwarding) {
   // q is alive
   // First check if we should switch compaction space
   assert(this == cp->space, "'this' should be current compaction space.");
@@ -370,7 +371,7 @@ HeapWord* CompactibleSpace::forward(oop q, size_t size,
 
   // store the forwarding pointer into the mark word
   if (cast_from_oop<HeapWord*>(q) != compact_top) {
-    q->forward_to(cast_to_oop(compact_top));
+    forwarding->forward_to(q, cast_to_oop(compact_top));
     assert(q->is_gc_marked(), "encoding the pointer should preserve the mark");
   } else {
     // if the object isn't moving we can just set the mark to the default

--- a/src/hotspot/share/gc/shared/space.hpp
+++ b/src/hotspot/share/gc/shared/space.hpp
@@ -50,6 +50,7 @@ class CompactibleSpace;
 class BlockOffsetTable;
 class CardTableRS;
 class DirtyCardToOopClosure;
+class SlidingForwarding;
 
 // A Space describes a heap area. Class Space is an abstract
 // base class.
@@ -432,7 +433,7 @@ public:
   // function of the then-current compaction space, and updates "cp->threshold
   // accordingly".
   virtual HeapWord* forward(oop q, size_t size, CompactPoint* cp,
-                    HeapWord* compact_top);
+                    HeapWord* compact_top, SlidingForwarding* forwarding);
 
   // Return a size with adjustments as required of the space.
   virtual size_t adjust_object_size_v(size_t size) const { return size; }

--- a/src/hotspot/share/gc/shared/space.inline.hpp
+++ b/src/hotspot/share/gc/shared/space.inline.hpp
@@ -28,6 +28,7 @@
 #include "gc/shared/blockOffsetTable.inline.hpp"
 #include "gc/shared/collectedHeap.hpp"
 #include "gc/shared/generation.hpp"
+#include "gc/shared/genCollectedHeap.hpp"
 #include "gc/shared/space.hpp"
 #include "gc/shared/spaceDecorator.hpp"
 #include "oops/oopsHierarchy.hpp"
@@ -162,12 +163,13 @@ inline void CompactibleSpace::scan_and_forward(SpaceType* space, CompactPoint* c
   HeapWord* cur_obj = space->bottom();
   HeapWord* scan_limit = space->scan_limit();
 
+  SlidingForwarding* forwarding = GenCollectedHeap::heap()->forwarding();
   while (cur_obj < scan_limit) {
     if (space->scanned_block_is_obj(cur_obj) && cast_to_oop(cur_obj)->is_gc_marked()) {
       // prefetch beyond cur_obj
       Prefetch::write(cur_obj, interval);
       size_t size = space->scanned_block_size(cur_obj);
-      compact_top = cp->space->forward(cast_to_oop(cur_obj), size, cp, compact_top);
+      compact_top = cp->space->forward(cast_to_oop(cur_obj), size, cp, compact_top, forwarding);
       cur_obj += size;
       end_of_live = cur_obj;
     } else {
@@ -183,7 +185,7 @@ inline void CompactibleSpace::scan_and_forward(SpaceType* space, CompactPoint* c
       // we don't have to compact quite as often.
       if (cur_obj == compact_top && dead_spacer.insert_deadspace(cur_obj, end)) {
         oop obj = cast_to_oop(cur_obj);
-        compact_top = cp->space->forward(obj, obj->size(), cp, compact_top);
+        compact_top = cp->space->forward(obj, obj->size(), cp, compact_top, forwarding);
         end_of_live = end;
       } else {
         // otherwise, it really is a free region.
@@ -222,6 +224,7 @@ inline void CompactibleSpace::scan_and_adjust_pointers(SpaceType* space) {
   HeapWord* cur_obj = space->bottom();
   HeapWord* const end_of_live = space->_end_of_live;  // Established by "scan_and_forward".
   HeapWord* const first_dead = space->_first_dead;    // Established by "scan_and_forward".
+  SlidingForwarding* forwarding = GenCollectedHeap::heap()->forwarding();
 
   assert(first_dead <= end_of_live, "Stands to reason, no?");
 
@@ -233,7 +236,7 @@ inline void CompactibleSpace::scan_and_adjust_pointers(SpaceType* space) {
     if (cur_obj < first_dead || cast_to_oop(cur_obj)->is_gc_marked()) {
       // cur_obj is alive
       // point all the oops to the new location
-      size_t size = MarkSweep::adjust_pointers(cast_to_oop(cur_obj));
+      size_t size = MarkSweep::adjust_pointers(forwarding, cast_to_oop(cur_obj));
       size = space->adjust_obj_size(size);
       debug_only(prev_obj = cur_obj);
       cur_obj += size;
@@ -315,6 +318,8 @@ inline void CompactibleSpace::scan_and_compact(SpaceType* space) {
     cur_obj = *(HeapWord**)(space->_first_dead);
   }
 
+  SlidingForwarding* forwarding = GenCollectedHeap::heap()->forwarding();
+
   debug_only(HeapWord* prev_obj = NULL);
   while (cur_obj < end_of_live) {
     if (!cast_to_oop(cur_obj)->is_gc_marked()) {
@@ -328,7 +333,7 @@ inline void CompactibleSpace::scan_and_compact(SpaceType* space) {
 
       // size and destination
       size_t size = space->obj_size(cur_obj);
-      HeapWord* compaction_top = cast_from_oop<HeapWord*>(cast_to_oop(cur_obj)->forwardee());
+      HeapWord* compaction_top = cast_from_oop<HeapWord*>(forwarding->forwardee(cast_to_oop(cur_obj)));
 
       // prefetch beyond compaction_top
       Prefetch::write(compaction_top, copy_interval);

--- a/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
@@ -27,6 +27,7 @@
 #include "compiler/oopMap.hpp"
 #include "gc/shared/gcTraceTime.inline.hpp"
 #include "gc/shared/preservedMarks.inline.hpp"
+#include "gc/shared/slidingForwarding.hpp"
 #include "gc/shared/tlab_globals.hpp"
 #include "gc/shenandoah/heuristics/shenandoahHeuristics.hpp"
 #include "gc/shenandoah/shenandoahConcurrentGC.hpp"
@@ -184,6 +185,7 @@ void ShenandoahFullGC::do_it(GCCause::Cause gc_cause) {
     // The rest of prologue:
     BiasedLocking::preserve_marks();
     _preserved_marks->init(heap->workers()->active_workers());
+    heap->forwarding()->clear();
 
     assert(heap->has_forwarded_objects() == has_forwarded_objects, "This should not change");
   }
@@ -296,6 +298,7 @@ void ShenandoahFullGC::phase1_mark_heap() {
 class ShenandoahPrepareForCompactionObjectClosure : public ObjectClosure {
 private:
   PreservedMarks*          const _preserved_marks;
+  SlidingForwarding*       const _forwarding;
   ShenandoahHeap*          const _heap;
   GrowableArray<ShenandoahHeapRegion*>& _empty_regions;
   int _empty_regions_pos;
@@ -308,6 +311,7 @@ public:
                                               GrowableArray<ShenandoahHeapRegion*>& empty_regions,
                                               ShenandoahHeapRegion* to_region) :
     _preserved_marks(preserved_marks),
+    _forwarding(ShenandoahHeap::heap()->forwarding()),
     _heap(ShenandoahHeap::heap()),
     _empty_regions(empty_regions),
     _empty_regions_pos(0),
@@ -361,7 +365,7 @@ public:
     assert(_compact_point + obj_size <= _to_region->end(), "must fit");
     shenandoah_assert_not_forwarded(NULL, p);
     _preserved_marks->push_if_necessary(p, p->mark());
-    p->forward_to(cast_to_oop(_compact_point));
+    _forwarding->forward_to(p, cast_to_oop(_compact_point));
     _compact_point += obj_size;
   }
 };
@@ -373,7 +377,7 @@ private:
   ShenandoahHeapRegionSet** const _worker_slices;
 
 public:
-  ShenandoahPrepareForCompactionTask(PreservedMarksSet *preserved_marks, ShenandoahHeapRegionSet **worker_slices) :
+  ShenandoahPrepareForCompactionTask(PreservedMarksSet* preserved_marks, ShenandoahHeapRegionSet **worker_slices) :
     AbstractGangTask("Shenandoah Prepare For Compaction"),
     _preserved_marks(preserved_marks),
     _heap(ShenandoahHeap::heap()), _worker_slices(worker_slices) {
@@ -435,6 +439,7 @@ public:
 
 void ShenandoahFullGC::calculate_target_humongous_objects() {
   ShenandoahHeap* heap = ShenandoahHeap::heap();
+  SlidingForwarding* forwarding = heap->forwarding();
 
   // Compute the new addresses for humongous objects. We need to do this after addresses
   // for regular objects are calculated, and we know what regions in heap suffix are
@@ -469,7 +474,7 @@ void ShenandoahFullGC::calculate_target_humongous_objects() {
       if (start >= to_begin && start != r->index()) {
         // Fits into current window, and the move is non-trivial. Record the move then, and continue scan.
         _preserved_marks->get(0)->push_if_necessary(old_obj, old_obj->mark());
-        old_obj->forward_to(cast_to_oop(heap->get_region(start)->bottom()));
+        forwarding->forward_to(old_obj, cast_to_oop(heap->get_region(start)->bottom()));
         to_end = start;
         continue;
       }
@@ -720,7 +725,8 @@ void ShenandoahFullGC::phase2_calculate_target_addresses(ShenandoahHeapRegionSet
 
 class ShenandoahAdjustPointersClosure : public MetadataVisitingOopIterateClosure {
 private:
-  ShenandoahHeap* const _heap;
+  ShenandoahHeap*           const _heap;
+  SlidingForwarding*        const _forwarding;
   ShenandoahMarkingContext* const _ctx;
 
   template <class T>
@@ -730,7 +736,7 @@ private:
       oop obj = CompressedOops::decode_not_null(o);
       assert(_ctx->is_marked(obj), "must be marked");
       if (obj->is_forwarded()) {
-        oop forw = obj->forwardee();
+        oop forw = _forwarding->forwardee(obj);
         RawAccess<IS_NOT_NULL>::oop_store(p, forw);
       }
     }
@@ -739,6 +745,7 @@ private:
 public:
   ShenandoahAdjustPointersClosure() :
     _heap(ShenandoahHeap::heap()),
+    _forwarding(_heap->forwarding()),
     _ctx(ShenandoahHeap::heap()->complete_marking_context()) {}
 
   void do_oop(oop* p)       { do_oop_work(p); }
@@ -798,7 +805,8 @@ public:
     ShenandoahParallelWorkerSession worker_session(worker_id);
     ShenandoahAdjustPointersClosure cl;
     _rp->roots_do(worker_id, &cl);
-    _preserved_marks->get(worker_id)->adjust_during_full_gc();
+    SlidingForwarding* forwarding = ShenandoahHeap::heap()->forwarding();
+    _preserved_marks->get(worker_id)->adjust_during_full_gc(forwarding);
   }
 };
 
@@ -828,19 +836,20 @@ void ShenandoahFullGC::phase3_update_references() {
 
 class ShenandoahCompactObjectsClosure : public ObjectClosure {
 private:
-  ShenandoahHeap* const _heap;
-  uint            const _worker_id;
+  ShenandoahHeap*    const _heap;
+  SlidingForwarding* const _forwarding;
+  uint               const _worker_id;
 
 public:
   ShenandoahCompactObjectsClosure(uint worker_id) :
-    _heap(ShenandoahHeap::heap()), _worker_id(worker_id) {}
+    _heap(ShenandoahHeap::heap()), _forwarding(_heap->forwarding()), _worker_id(worker_id) {}
 
   void do_object(oop p) {
     assert(_heap->complete_marking_context()->is_marked(p), "must be marked");
     size_t size = (size_t)p->size();
     if (p->is_forwarded()) {
       HeapWord* compact_from = cast_from_oop<HeapWord*>(p);
-      HeapWord* compact_to = cast_from_oop<HeapWord*>(p->forwardee());
+      HeapWord* compact_to = cast_from_oop<HeapWord*>(_forwarding->forwardee(p));
       Copy::aligned_conjoint_words(compact_from, compact_to, size);
       oop new_obj = cast_to_oop(compact_to);
       new_obj->init_mark();
@@ -935,6 +944,7 @@ void ShenandoahFullGC::compact_humongous_objects() {
   // sliding costs. We may consider doing this in parallel in future.
 
   ShenandoahHeap* heap = ShenandoahHeap::heap();
+  SlidingForwarding* forwarding = heap->forwarding();
 
   for (size_t c = heap->num_regions(); c > 0; c--) {
     ShenandoahHeapRegion* r = heap->get_region(c - 1);
@@ -949,7 +959,7 @@ void ShenandoahFullGC::compact_humongous_objects() {
 
       size_t old_start = r->index();
       size_t old_end   = old_start + num_regions - 1;
-      size_t new_start = heap->heap_region_index_containing(old_obj->forwardee());
+      size_t new_start = heap->heap_region_index_containing(forwarding->forwardee(old_obj));
       size_t new_end   = new_start + num_regions - 1;
       assert(old_start != new_start, "must be real move");
       assert(r->is_stw_move_allowed(), "Region " SIZE_FORMAT " should be movable", r->index());

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -32,6 +32,7 @@
 #include "gc/shared/locationPrinter.inline.hpp"
 #include "gc/shared/memAllocator.hpp"
 #include "gc/shared/plab.hpp"
+#include "gc/shared/slidingForwarding.hpp"
 #include "gc/shared/tlab_globals.hpp"
 
 #include "gc/shenandoah/shenandoahBarrierSet.hpp"
@@ -188,6 +189,8 @@ jint ShenandoahHeap::initialize() {
 
   assert((((size_t) base()) & ShenandoahHeapRegion::region_size_bytes_mask()) == 0,
          "Misaligned heap: " PTR_FORMAT, p2i(base()));
+
+  _forwarding = new SlidingForwarding(_heap_region, ShenandoahHeapRegion::region_size_words_shift());
 
 #if SHENANDOAH_OPTIMIZED_MARKTASK
   // The optimized ShenandoahMarkTask takes some bits away from the full object bits.

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -62,6 +62,7 @@ class ShenandoahPacer;
 class ShenandoahReferenceProcessor;
 class ShenandoahVerifier;
 class ShenandoahWorkGang;
+class SlidingForwarding;
 class VMStructs;
 
 // Used for buffering per-region liveness data.
@@ -227,6 +228,7 @@ private:
   size_t    _num_regions;
   ShenandoahHeapRegion** _regions;
   ShenandoahRegionIterator _update_refs_iterator;
+  SlidingForwarding* _forwarding;
 
 public:
 
@@ -242,6 +244,8 @@ public:
 
   void heap_region_iterate(ShenandoahHeapRegionClosure* blk) const;
   void parallel_heap_region_iterate(ShenandoahHeapRegionClosure* blk) const;
+
+  SlidingForwarding* forwarding() const { return _forwarding; }
 
 // ---------- GC state machinery
 //


### PR DESCRIPTION
Serial GC is a sliding compaction collector and must use the sliding forwarding scheme in order to preserve the upper bits of the header.

Testing:
 - [x] tier1 (x86_32/x86_64)
 - [x] tier2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/lilliput pull/9/head:pull/9` \
`$ git checkout pull/9`

Update a local copy of the PR: \
`$ git checkout pull/9` \
`$ git pull https://git.openjdk.java.net/lilliput pull/9/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9`

View PR using the GUI difftool: \
`$ git pr show -t 9`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/lilliput/pull/9.diff">https://git.openjdk.java.net/lilliput/pull/9.diff</a>

</details>
