### PR TITLE
Use hashtable for obj->edge mapping in JFR, instead of mark-word

### DIFF
--- a/src/hotspot/share/jfr/leakprofiler/checkpoint/eventEmitter.cpp
+++ b/src/hotspot/share/jfr/leakprofiler/checkpoint/eventEmitter.cpp
@@ -141,9 +141,7 @@ void EventEmitter::write_event(const ObjectSample* sample, EdgeStore* edge_store
   traceid gc_root_id = 0;
   const Edge* edge = NULL;
   if (SafepointSynchronize::is_at_safepoint()) {
-    if (!sample->object()->mark().is_marked()) {
-      edge = (const Edge*)(sample->object())->mark().to_pointer();
-    }
+    edge = edge_store->get_edge_for_object(sample->object());
   }
   if (edge == NULL) {
     edge = edge_store->get(UnifiedOopRef::encode_in_native(sample->object_addr()));


### PR DESCRIPTION
JFR overrides the mark-word to (temporarily) store a mapping from object to Edge*. This disturbs the Klass* that we need while tracing for leaks and for later emitting object information. Let's use a hashtable for this, instead, and leave the upper half of the mark-word alone. (The lower half is still used for marking.)

Testing:
 - [x] tier1
 - [x] tier2
 - [x] jdk/jfr (together with #17 most tests pass, needs one more follow-up test fix)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/lilliput pull/18/head:pull/18` \
`$ git checkout pull/18`

Update a local copy of the PR: \
`$ git checkout pull/18` \
`$ git pull https://git.openjdk.java.net/lilliput pull/18/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18`

View PR using the GUI difftool: \
`$ git pr show -t 18`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/lilliput/pull/18.diff">https://git.openjdk.java.net/lilliput/pull/18.diff</a>

</details>
