### PR TITLE
Jump/stub length failures in x86_64 release builds

### DIFF
--- a/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
@@ -3632,12 +3632,9 @@ void LIR_Assembler::emit_profile_type(LIR_OpProfileType* op) {
       __ orptr(mdo_addr, TypeEntries::null_seen);
     }
     if (do_update) {
-#ifndef ASSERT
-      __ jmpb(next);
-    }
-#else
       __ jmp(next);
     }
+#ifdef ASSERT
   } else {
     __ testptr(tmp, tmp);
     __ jcc(Assembler::notZero, update);

--- a/src/hotspot/share/code/vtableStubs.cpp
+++ b/src/hotspot/share/code/vtableStubs.cpp
@@ -102,8 +102,8 @@ int VtableStubs::_itab_stub_size = 0;
 
 #if defined(PRODUCT)
   // These values are good for the PRODUCT case (no tracing).
-  static const int first_vtableStub_size =  64;
-  static const int first_itableStub_size = 256;
+  static const int first_vtableStub_size = 128;
+  static const int first_itableStub_size = 512;
 #else
   // These values are good for the non-PRODUCT case (when tracing can be switched on).
   // To find out, run test workload with


### PR DESCRIPTION
My CI reports many failures on `make bootcycle-images` on x86_64, but only in release modes:

```
#  Internal Error (macroAssembler_x86.hpp:120), pid=2457838, tid=2457856
#  guarantee(this->is8bit(imm8)) failed: Short forward jump exceeds 8-bit offset at <NULL>:0
```

```
#  Internal Error (vtableStubs.cpp:196), pid=1871037, tid=1871042
#  guarantee(masm->pc() <= s->code_end()) failed: itable #2: overflowed buffer, estimated len: 256, actual len: 295, overrun: 39
```

```
#  Internal Error (vtableStubs.cpp:196), pid=1871037, tid=1871042
#  guarantee(masm->pc() <= s->code_end()) failed: itable #2: overflowed buffer, estimated len: 256, actual len: 295, overrun: 39
```

Additional testing:
 - [x] Linux x86_64 release `make bootcycle-images` now works

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/lilliput pull/22/head:pull/22` \
`$ git checkout pull/22`

Update a local copy of the PR: \
`$ git checkout pull/22` \
`$ git pull https://git.openjdk.java.net/lilliput pull/22/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22`

View PR using the GUI difftool: \
`$ git pr show -t 22`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/lilliput/pull/22.diff">https://git.openjdk.java.net/lilliput/pull/22.diff</a>

</details>
