### PR TITLE
Deflate monitors of dead objects before they become unreachable

### DIFF
--- a/src/hotspot/share/gc/shared/oopStorage.inline.hpp
+++ b/src/hotspot/share/gc/shared/oopStorage.inline.hpp
@@ -31,6 +31,7 @@
 #include "metaprogramming/conditional.hpp"
 #include "metaprogramming/isConst.hpp"
 #include "oops/oop.hpp"
+#include "runtime/objectMonitor.hpp"
 #include "runtime/safepoint.hpp"
 #include "utilities/align.hpp"
 #include "utilities/count_trailing_zeros.hpp"
@@ -262,6 +263,7 @@ public:
       if (_is_alive->do_object_b(v)) {
         result = _f(ptr);
       } else {
+        ObjectMonitor::maybe_deflate_dead(ptr);
         *ptr = NULL;            // Clear dead value.
       }
     }

--- a/src/hotspot/share/gc/shared/weakProcessor.inline.hpp
+++ b/src/hotspot/share/gc/shared/weakProcessor.inline.hpp
@@ -65,6 +65,7 @@ public:
       _keep_alive->do_oop(p);
       ++_live;
     } else {
+      ObjectMonitor::maybe_deflate_dead(p);
       *p = NULL;
       ++_new_dead;
     }

--- a/src/hotspot/share/runtime/objectMonitor.cpp
+++ b/src/hotspot/share/runtime/objectMonitor.cpp
@@ -613,6 +613,20 @@ bool ObjectMonitor::deflate_monitor() {
   return true;  // Success, ObjectMonitor has been deflated.
 }
 
+void ObjectMonitor::maybe_deflate_dead(oop* p) {
+  oop obj = *p;
+  assert(obj != NULL, "must not yet been cleared");
+  markWord mark = obj->mark();
+  if (mark.has_monitor()) {
+    ObjectMonitor* monitor = mark.monitor();
+    if (p == monitor->_object.ptr_raw()) {
+      assert(monitor->object_peek() == obj, "lock object must match");
+      markWord dmw = monitor->header();
+      obj->set_mark(dmw);
+    }
+  }
+}
+
 // Install the displaced mark word (dmw) of a deflating ObjectMonitor
 // into the header of the object associated with the monitor. This
 // idempotent method is called by a thread that is deflating a

--- a/src/hotspot/share/runtime/objectMonitor.cpp
+++ b/src/hotspot/share/runtime/objectMonitor.cpp
@@ -613,6 +613,8 @@ bool ObjectMonitor::deflate_monitor() {
   return true;  // Success, ObjectMonitor has been deflated.
 }
 
+// We might access the dead object headers for parsable heap walk, make sure
+// headers are in correct shape, e.g. monitors deflated.
 void ObjectMonitor::maybe_deflate_dead(oop* p) {
   oop obj = *p;
   assert(obj != NULL, "must not yet been cleared");

--- a/src/hotspot/share/runtime/objectMonitor.hpp
+++ b/src/hotspot/share/runtime/objectMonitor.hpp
@@ -337,6 +337,8 @@ class ObjectMonitor : public CHeapObj<mtInternal> {
   intx      complete_exit(JavaThread* current);
   bool      reenter(intx recursions, JavaThread* current);
 
+  static void maybe_deflate_dead(oop* p);
+
  private:
   void      AddWaiter(ObjectWaiter* waiter);
   void      INotify(JavaThread* current);


### PR DESCRIPTION
I've seen occasional failures in G1, where the refinement thread tries to parse a heap region that has dead objects, and would sometimes see an object with a monitor that has already been deflated. And because deflation does not bother to restore the header of dead objects, it would reach to unknown memory and crash.

The fix is to restore the header of dead objects just before they become unreachable. This can be done in the closures used by WeakProcessor::weak_oops_do(), right before the weak root will be cleared.

Testing:
 - [x] tier1
 - [x] tier2
 - [x] tier3
 - [x] tier4

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - Committer) ⚠️ Review applies to 88a4392adf7da7c93be304064ab9b3eec893fdc6


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/lilliput pull/28/head:pull/28` \
`$ git checkout pull/28`

Update a local copy of the PR: \
`$ git checkout pull/28` \
`$ git pull https://git.openjdk.java.net/lilliput pull/28/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 28`

View PR using the GUI difftool: \
`$ git pr show -t 28`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/lilliput/pull/28.diff">https://git.openjdk.java.net/lilliput/pull/28.diff</a>

</details>
