### PR TITLE
Fix 32-bit Zero builds

### DIFF
--- a/src/hotspot/cpu/zero/compressedKlass_zero.cpp
+++ b/src/hotspot/cpu/zero/compressedKlass_zero.cpp
@@ -31,6 +31,8 @@
 #include "utilities/ostream.hpp"
 #include "runtime/globals.hpp"
 
+#ifdef _LP64
+
 // Given an address p, return true if p can be used as an encoding base.
 //  (Some platforms have restrictions of what constitutes a valid base address).
 bool CompressedKlassPointers::is_valid_base(address p) {
@@ -38,10 +40,10 @@ bool CompressedKlassPointers::is_valid_base(address p) {
 }
 
 void CompressedKlassPointers::print_mode(outputStream* st) {
-#ifdef _LP64
   st->print_cr("Narrow klass base: " PTR_FORMAT ", Narrow klass shift: %d, "
                "Narrow klass range: " UINT64_FORMAT, p2i(base()), shift(),
                KlassEncodingMetaspaceMax);
-#endif
 }
+
+#endif // _LP64
 


### PR DESCRIPTION
These two methods are already defined in `compressedKlass.cpp` when `!LP64`. So the build fails with duplicate definitions on 32-bit platforms. The patch does the same thing x86_32 does.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/lilliput pull/33/head:pull/33` \
`$ git checkout pull/33`

Update a local copy of the PR: \
`$ git checkout pull/33` \
`$ git pull https://git.openjdk.java.net/lilliput pull/33/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 33`

View PR using the GUI difftool: \
`$ git pr show -t 33`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/lilliput/pull/33.diff">https://git.openjdk.java.net/lilliput/pull/33.diff</a>

</details>
