### PR TITLE
Load narrowKlass from runtime, decode in generated code

### DIFF
--- a/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
@@ -2606,9 +2606,9 @@ void LIR_Assembler::emit_load_klass(LIR_OpLoadKlass* op) {
   // Fast-path: shift and decode Klass*.
   __ mov(result, tmp);
   __ lsr(result, result, markWord::klass_shift);
-  __ decode_klass_not_null(result);
 
   __ bind(*op->stub()->continuation());
+  __ decode_klass_not_null(result);
 }
 
 void LIR_Assembler::emit_profile_call(LIR_OpProfileCall* op) {

--- a/src/hotspot/cpu/aarch64/c1_Runtime1_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_Runtime1_aarch64.cpp
@@ -724,7 +724,7 @@ OopMapSet* Runtime1::generate_code_for(StubID id, StubAssembler* sasm) {
         StubFrame f(sasm, "load_klass", dont_gc_arguments);
         save_live_registers_no_oop_map(sasm, true);
         f.load_argument(0, r0); // obj
-        __ call_VM_leaf(CAST_FROM_FN_PTR(address, oopDesc::load_klass_runtime), r0);
+        __ call_VM_leaf(CAST_FROM_FN_PTR(address, oopDesc::load_nklass_runtime), r0);
         restore_live_registers_except_r0(sasm, true);
       }
       break;

--- a/src/hotspot/cpu/x86/c1_CodeStubs_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_CodeStubs_x86.cpp
@@ -302,6 +302,7 @@ void MonitorExitStub::emit_code(LIR_Assembler* ce) {
 
 void LoadKlassStub::emit_code(LIR_Assembler* ce) {
   __ bind(_entry);
+#ifdef _LP64
   Register res = _result->as_register();
   ce->store_parameter(_obj->as_register(), 0);
   if (res != rax) {
@@ -315,6 +316,9 @@ void LoadKlassStub::emit_code(LIR_Assembler* ce) {
     __ xchgptr(rax, res);
   }
   __ jmp(_continuation);
+#else
+  __ should_not_reach_here();
+#endif
 }
 
 // Implementation of patching:

--- a/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
@@ -3547,6 +3547,8 @@ void LIR_Assembler::emit_load_klass(LIR_OpLoadKlass* op) {
   __ decode_klass_not_null(result, tmp);
 #else
   __ movptr(result, Address(obj, oopDesc::klass_offset_in_bytes()));
+  // Not really needed, but bind the label anyway to make compiler happy.
+  __ bind(*op->stub()->continuation());
 #endif
 }
 

--- a/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
@@ -3542,6 +3542,8 @@ void LIR_Assembler::emit_load_klass(LIR_OpLoadKlass* op) {
   // Fast-path: shift and decode Klass*.
   __ movq(result, tmp);
   __ shrq(result, markWord::klass_shift);
+
+  __ bind(*op->stub()->continuation());
   __ decode_klass_not_null(result, tmp);
 #else
   __ movptr(result, Address(obj, oopDesc::klass_offset_in_bytes()));

--- a/src/hotspot/cpu/x86/c1_Runtime1_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_Runtime1_x86.cpp
@@ -1117,7 +1117,7 @@ OopMapSet* Runtime1::generate_code_for(StubID id, StubAssembler* sasm) {
         StubFrame f(sasm, "load_klass", dont_gc_arguments);
         sasm->save_live_registers_no_oop_map(true);
         f.load_argument(0, c_rarg0); // obj
-        __ call_VM_leaf(CAST_FROM_FN_PTR(address, oopDesc::load_klass_runtime), c_rarg0);
+        __ call_VM_leaf(CAST_FROM_FN_PTR(address, oopDesc::load_nklass_runtime), c_rarg0);
         sasm->restore_live_registers_except_rax(true);
       }
       break;

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -4570,7 +4570,6 @@ void MacroAssembler::load_klass(Register dst, Register src, Register tmp, bool n
 
   movq(dst, tmp);
   shrq(dst, markWord::klass_shift);
-  decode_klass_not_null(dst, tmp);
   jmp(done);
   bind(slow);
 
@@ -4586,7 +4585,7 @@ void MacroAssembler::load_klass(Register dst, Register src, Register tmp, bool n
   push(r10);
   push(r11);
 
-  MacroAssembler::call_VM_leaf(CAST_FROM_FN_PTR(address, oopDesc::load_klass_runtime), src);
+  MacroAssembler::call_VM_leaf(CAST_FROM_FN_PTR(address, oopDesc::load_nklass_runtime), src);
 
   pop(r11);
   pop(r10);
@@ -4602,6 +4601,7 @@ void MacroAssembler::load_klass(Register dst, Register src, Register tmp, bool n
   }
 
   bind(done);
+  decode_klass_not_null(dst, tmp);
 #else
   if (null_check_src) {
     null_check(src, oopDesc::klass_offset_in_bytes());

--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -1234,7 +1234,6 @@ void LIRGenerator::do_isInstance(Intrinsic* x) {
 void LIRGenerator::load_klass(LIR_Opr obj, LIR_Opr klass, CodeEmitInfo* null_check_info) {
   CodeStub* slow_path = new LoadKlassStub(obj, klass);
   __ load_klass(obj, klass, null_check_info, slow_path);
-  __ branch_destination(slow_path->continuation());
 }
 
 // Example: object.getClass ()

--- a/src/hotspot/share/oops/oop.cpp
+++ b/src/hotspot/share/oops/oop.cpp
@@ -175,6 +175,7 @@ void* oopDesc::load_oop_raw(oop obj, int offset) {
   }
 }
 
+#ifdef _LP64
 JRT_LEAF(narrowKlass, oopDesc::load_nklass_runtime(oopDesc* o))
   assert(o != NULL, "null-check");
   oop obj = oop(o);
@@ -187,6 +188,7 @@ JRT_LEAF(narrowKlass, oopDesc::load_nklass_runtime(oopDesc* o))
   narrowKlass nklass = header.narrow_klass();
   return nklass;
 JRT_END
+#endif
 
 oop oopDesc::obj_field_acquire(int offset) const                      { return HeapAccess<MO_ACQUIRE>::oop_load_at(as_oop(), offset); }
 

--- a/src/hotspot/share/oops/oop.hpp
+++ b/src/hotspot/share/oops/oop.hpp
@@ -318,7 +318,7 @@ class oopDesc {
   static void* load_oop_raw(oop obj, int offset);
 
   // Runtime entry
-  static Klass* load_klass_runtime(oopDesc* o);
+  static narrowKlass load_nklass_runtime(oopDesc* o);
 
   // Avoid include gc_globals.hpp in oop.inline.hpp
   DEBUG_ONLY(bool get_UseParallelGC();)

--- a/src/hotspot/share/oops/oop.hpp
+++ b/src/hotspot/share/oops/oop.hpp
@@ -318,7 +318,9 @@ class oopDesc {
   static void* load_oop_raw(oop obj, int offset);
 
   // Runtime entry
+#ifdef _LP64
   static narrowKlass load_nklass_runtime(oopDesc* o);
+#endif
 
   // Avoid include gc_globals.hpp in oop.inline.hpp
   DEBUG_ONLY(bool get_UseParallelGC();)


### PR DESCRIPTION
Current implementation of load_klass_runtime() call ensures stable header, loads the narrowKlass from it, decodes it, and returns the Klass* back to generated (interpreter, C1) code. However, C2 wants to load the narrowKlass and use it directly. Let's change current impl to not decode in runtime, but decode in generated code instead, and thus avoid a new entry points for  C2. This doesn't even make generated code larger -- we only need to move the decode_klass() into the common (fast & slow) path.

The change also contains some exlusions for 32bit builds - narrow_klass() doesn't make sense (and doesn't compile) on x86_32, and thus shouldn't be compiled.

Testing:
 - [x] tier1 (x86_64, aarch64)
 - [x] tier2 (x86_64, aarch64)
 - [x] tier2 (x86_64, aarch64)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/lilliput pull/35/head:pull/35` \
`$ git checkout pull/35`

Update a local copy of the PR: \
`$ git checkout pull/35` \
`$ git pull https://git.openjdk.java.net/lilliput pull/35/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 35`

View PR using the GUI difftool: \
`$ git pr show -t 35`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/lilliput/pull/35.diff">https://git.openjdk.java.net/lilliput/pull/35.diff</a>

</details>
