### PR TITLE
Fix CDS LotsOfClasses tests on 32-bit

### DIFF
--- a/src/hotspot/share/cds/archiveBuilder.cpp
+++ b/src/hotspot/share/cds/archiveBuilder.cpp
@@ -737,8 +737,12 @@ void ArchiveBuilder::make_klasses_shareable() {
     Klass* k = klasses()->at(i);
     k->remove_java_mirror();
     Klass* requested_k = to_requested(k);
+#ifdef _LP64
     narrowKlass nk = CompressedKlassPointers::encode_not_null(requested_k, _requested_static_archive_bottom);
-    k->set_prototype_header(markWord::prototype() LP64_ONLY(.set_narrow_klass(nk)));
+    k->set_prototype_header(markWord::prototype().set_narrow_klass(nk));
+#else
+    k->set_prototype_header(markWord::prototype());
+#endif
     if (k->is_objArray_klass()) {
       // InstanceKlass and TypeArrayKlass will in turn call remove_unshareable_info
       // on their array classes.


### PR DESCRIPTION
68fbdb32af390762a01380b277a3ae30f864fdb4 introduced class pointer reduction to 22-bit. Since that change, `CompressedKlassPointers::encode_not_null` validates the given Klass* - checks that it can be properly encoded with 22 bits. That means `CompressedKlassPointers::encode_not_null` should only be called if UseCompressedClassPointers is true (so, only but unconditionally on 64-bit).

Note that this asserts just puts our nose onto the question of what to do with Klass pointers on 32-bit. If we need to encode them into a smaller type, we need to find a way to do so for 32-bit too. There are several possibilities, ranging from introducing a class space (or class-space-like feature) for 32-bit too, allocating them wherever like today, but with a larger alignment, up to something completely different. But that is out of scope for this tiny fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Roman Kennke](https://openjdk.java.net/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/lilliput pull/38/head:pull/38` \
`$ git checkout pull/38`

Update a local copy of the PR: \
`$ git checkout pull/38` \
`$ git pull https://git.openjdk.java.net/lilliput pull/38/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 38`

View PR using the GUI difftool: \
`$ git pr show -t 38`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/lilliput/pull/38.diff">https://git.openjdk.java.net/lilliput/pull/38.diff</a>

</details>
