### PR TITLE
ObjectMonitor Storage

### DIFF
--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -2034,6 +2034,12 @@ const intx ObjectAlignmentInBytes = 8;
                                                                             \
   develop(bool, TraceOptimizedUpcallStubs, false,                           \
                 "Trace optimized upcall stub generation")                   \
+                                                                            \
+  product(uintx, MaxObjectMonitors, NOT_LP64(100000) LP64_ONLY(20 * M),     \
+                "Max. number of object monitors")                           \
+                                                                            \
+  product(uintx, PreallocatedObjectMonitors, NOT_LP64(8) LP64_ONLY(64),     \
+                "Max. thread local preallocated OMs")                       \
 
 // end of RUNTIME_FLAGS
 

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -716,6 +716,13 @@ const intx ObjectAlignmentInBytes = 8;
           "before adjusting the in_use_list_ceiling up (0 is off).")        \
           range(0, max_uintx)                                               \
                                                                             \
+                                                                            \
+  product(uintx, MaxObjectMonitors, NOT_LP64(100000) LP64_ONLY(20 * M),     \
+           "Max. number of object monitors")                                \
+                                                                            \
+  product(uintx, PreallocatedObjectMonitors, NOT_LP64(8) LP64_ONLY(64),     \
+           "Max. thread local preallocated OMs")                            \
+                                                                            \
   product(intx, hashCode, 5, EXPERIMENTAL,                                  \
                "(Unstable) select hashCode generation algorithm")           \
                                                                             \
@@ -2034,12 +2041,7 @@ const intx ObjectAlignmentInBytes = 8;
                                                                             \
   develop(bool, TraceOptimizedUpcallStubs, false,                           \
                 "Trace optimized upcall stub generation")                   \
-                                                                            \
-  product(uintx, MaxObjectMonitors, NOT_LP64(100000) LP64_ONLY(20 * M),     \
-                "Max. number of object monitors")                           \
-                                                                            \
-  product(uintx, PreallocatedObjectMonitors, NOT_LP64(8) LP64_ONLY(64),     \
-                "Max. thread local preallocated OMs")                       \
+
 
 // end of RUNTIME_FLAGS
 

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -716,9 +716,8 @@ const intx ObjectAlignmentInBytes = 8;
           "before adjusting the in_use_list_ceiling up (0 is off).")        \
           range(0, max_uintx)                                               \
                                                                             \
-                                                                            \
-  product(uintx, MaxObjectMonitors, NOT_LP64(100000) LP64_ONLY(20 * M),     \
-           "Max. number of object monitors")                                \
+  product(uintx, MonitorStorageSize, NOT_LP64(64*M) LP64_ONLY(4 * G),       \
+           "Size of object monitor store")                                  \
                                                                             \
   product(uintx, PreallocatedObjectMonitors, NOT_LP64(8) LP64_ONLY(64),     \
            "Max. thread local preallocated OMs")                            \

--- a/src/hotspot/share/runtime/mutexLocker.cpp
+++ b/src/hotspot/share/runtime/mutexLocker.cpp
@@ -247,7 +247,7 @@ void mutex_init() {
 
   def(Metaspace_lock               , PaddedMutex  , nosafepoint-3);
   def(MetaspaceCritical_lock       , PaddedMonitor, nosafepoint-1);
-  def(ObjectMonitorStorage_lock    , PaddedMutex,   nosafepoint);
+  def(ObjectMonitorStorage_lock    , PaddedMutex,   nosafepoint-3);
 
   def(Patching_lock                , PaddedMutex  , nosafepoint);      // used for safepointing and code patching.
   def(MonitorDeflation_lock        , PaddedMonitor, nosafepoint);      // used for monitor deflation thread operations

--- a/src/hotspot/share/runtime/mutexLocker.cpp
+++ b/src/hotspot/share/runtime/mutexLocker.cpp
@@ -153,6 +153,7 @@ Mutex*   UnregisteredClassesTable_lock= NULL;
 Mutex*   LambdaFormInvokers_lock      = NULL;
 #endif // INCLUDE_CDS
 Mutex*   Bootclasspath_lock           = NULL;
+Mutex*   ObjectMonitorStorage_lock    = NULL;
 
 #if INCLUDE_JVMCI
 Monitor* JVMCI_lock                   = NULL;
@@ -246,6 +247,7 @@ void mutex_init() {
 
   def(Metaspace_lock               , PaddedMutex  , nosafepoint-3);
   def(MetaspaceCritical_lock       , PaddedMonitor, nosafepoint-1);
+  def(ObjectMonitorStorage_lock    , PaddedMutex,   nosafepoint);
 
   def(Patching_lock                , PaddedMutex  , nosafepoint);      // used for safepointing and code patching.
   def(MonitorDeflation_lock        , PaddedMonitor, nosafepoint);      // used for monitor deflation thread operations

--- a/src/hotspot/share/runtime/mutexLocker.hpp
+++ b/src/hotspot/share/runtime/mutexLocker.hpp
@@ -147,6 +147,8 @@ extern Mutex*   ClassLoaderDataGraph_lock;       // protects CLDG list, needed f
 extern Mutex*   CodeHeapStateAnalytics_lock;     // lock print functions against concurrent analyze functions.
                                                  // Only used locally in PrintCodeCacheLayout processing.
 
+extern Mutex*   ObjectMonitorStorage_lock;       // protects ObjectMonitorStorage
+
 #if INCLUDE_JVMCI
 extern Monitor* JVMCI_lock;                      // Monitor to control initialization of JVMCI
 #endif

--- a/src/hotspot/share/runtime/objectMonitor.hpp
+++ b/src/hotspot/share/runtime/objectMonitor.hpp
@@ -127,7 +127,7 @@ class ObjectWaiter : public StackObj {
 #define OM_CACHE_LINE_SIZE DEFAULT_CACHE_LINE_SIZE
 #endif
 
-class ObjectMonitor : public CHeapObj<mtObjectMonitor> {
+class ObjectMonitor : public StackObj {
   friend class ObjectSynchronizer;
   friend class ObjectWaiter;
   friend class VMStructs;
@@ -202,6 +202,8 @@ class ObjectMonitor : public CHeapObj<mtObjectMonitor> {
   static PerfLongVariable * _sync_MonExtant;
 
   static int Knob_SpinLimit;
+
+  void* operator new (size_t size, void* p) throw() { return p; }
 
   // TODO-FIXME: the "offset" routines should return a type of off_t instead of int ...
   // ByteSize would also be an appropriate type.

--- a/src/hotspot/share/runtime/objectMonitorStorage.cpp
+++ b/src/hotspot/share/runtime/objectMonitorStorage.cpp
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2022 SAP SE. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+#include "precompiled.hpp"
+
+#include "logging/log.hpp"
+#include "logging/logStream.hpp"
+#include "memory/allocation.hpp"
+#include "runtime/globals.hpp"
+#include "runtime/objectMonitorStorage.hpp"
+#include "services/memTracker.hpp"
+#include "utilities/debug.hpp"
+#include "utilities/globalDefinitions.hpp"
+
+//static const bool be_paranoid = true;
+static const bool be_paranoid = false;
+
+ObjectMonitorStorage::ArrayType* ObjectMonitorStorage::_array = NULL;
+
+// re-build a new list of newly allocated free monitors and return its head
+void ObjectMonitorStorage::bulk_allocate_new_list(OMFreeListType& freelist_to_fill) {
+
+  MutexLocker ml(ObjectMonitorStorage_lock, Mutex::_no_safepoint_check_flag);
+
+  for (int i = 0; i < (int)PreallocatedObjectMonitors - 1; i ++) {
+    ObjectMonitor* m = _array->allocate();
+    if (m == NULL) {
+      fatal("Maximum number of object monitors allocated (" UINTX_FORMAT "), increase MaxObjectMonitors.",
+            _array->capacity());
+    }
+    freelist_to_fill.prepend(m);
+  }
+  DEBUG_ONLY(freelist_to_fill.verify(be_paranoid);)
+  DEBUG_ONLY(verify();)
+
+  LogTarget(Debug, monitorinflation) lt;
+  if (lt.is_enabled()) {
+    LogStream ls(lt);
+    ls.print("bulk_allocate_new_list ");
+    _array->print_on(&ls);
+    ls.cr();
+  }
+}
+
+// When a thread dies, return OMs left unused to the global store.
+void ObjectMonitorStorage::cleanup_before_thread_death(Thread* t) {
+  // Note that the ObjectMonitors we are about to return to the storage are
+  // not yet initialized, so no need to destroy them.
+  OMFreeListType& tl_list = t->_om_freelist;
+  if (tl_list.empty() == false) {
+    MutexLocker ml(ObjectMonitorStorage_lock, Mutex::_no_safepoint_check_flag);
+    _array->bulk_deallocate(tl_list);
+    DEBUG_ONLY(verify();)
+
+    LogTarget(Debug, monitorinflation) lt;
+    if (lt.is_enabled()) {
+      LogStream ls(lt);
+      ls.print("cleanup_before_thread_death ");
+      _array->print_on(&ls);
+      ls.cr();
+    }
+
+  }
+  assert(tl_list.empty(), "thread local list should now be empty");
+}
+
+// deallocate a list of monitors
+void ObjectMonitorStorage::bulk_deallocate(const GrowableArray<ObjectMonitor*>& list) {
+  // Build up freelist off-lock, then prepend the whole list under lock protection
+  OMFreeListType omlist;
+  for (ObjectMonitor* m : list) {
+    // Call ObjectMonitor destructor explicitely, then add OM to freelist. Note that the
+    // latter destroys OM's content, so order matters.
+    m->~ObjectMonitor();
+    omlist.prepend(m);
+  }
+  if (omlist.empty() == false) {
+    MutexLocker ml(ObjectMonitorStorage_lock, Mutex::_no_safepoint_check_flag);
+    _array->bulk_deallocate(omlist);
+    // log log log
+    LogTarget(Debug, monitorinflation) lt;
+    if (lt.is_enabled()) {
+      LogStream ls(lt);
+      ls.print("bulk_deallocate %d oms: ", list.length());
+      _array->print_on(&ls);
+      ls.cr();
+    }
+
+  }
+  DEBUG_ONLY(verify();)
+}
+
+void ObjectMonitorStorage::initialize() {
+  assert(_array == NULL, "Already initialized?");
+  _array = new ArrayType(MAX2(MaxObjectMonitors, (uintx)1024), 1024);
+  MemTracker::record_virtual_memory_type((address)_array->base(), mtObjectMonitor);
+}
+
+void ObjectMonitorStorage::print(outputStream* st) {
+  if (_array != NULL) {
+    _array->print_on(st);
+    st->cr();
+  } else {
+    st->print_cr("Not initialized");
+  }
+}
+
+#ifdef ASSERT
+void ObjectMonitorStorage::verify() {
+  if (_array != NULL) {
+    _array->verify(be_paranoid);
+  }
+}
+#endif

--- a/src/hotspot/share/runtime/objectMonitorStorage.cpp
+++ b/src/hotspot/share/runtime/objectMonitorStorage.cpp
@@ -87,8 +87,7 @@ void ObjectMonitorStorage::initialize() {
   const uintx initial_cap = 1024;
   const uintx max_object_monitors = MonitorStorageSize / sizeof(ObjectMonitor);
   const uintx max_cap = clamp(max_object_monitors, (uintx)1024, (uintx)UINT_MAX - 1);
-  const uintx cap_increase = 1024;
-  _array = new ArrayType(initial_cap, cap_increase, max_cap);
+  _array = new ArrayType(initial_cap, max_cap);
   MemTracker::record_virtual_memory_type((address)_array->base(), mtObjectMonitor);
 }
 

--- a/src/hotspot/share/runtime/objectMonitorStorage.cpp
+++ b/src/hotspot/share/runtime/objectMonitorStorage.cpp
@@ -53,7 +53,7 @@ void ObjectMonitorStorage::bulk_allocate_new_list(OMFreeListType& freelist_to_fi
   for (int i = 0; i < (int)PreallocatedObjectMonitors - 1; i ++) {
     ObjectMonitor* m = _array->allocate();
     if (m == NULL) {
-      fatal("Maximum number of object monitors allocated (" UINTX_FORMAT "), increase MaxObjectMonitors.",
+      fatal("Maximum number of object monitors allocated (" UINTX_FORMAT "), increase MonitorStorageSize.",
             _array->capacity());
     }
     freelist_to_fill.prepend(m);
@@ -92,7 +92,8 @@ void ObjectMonitorStorage::bulk_deallocate(OMFreeListType& omlist) {
 void ObjectMonitorStorage::initialize() {
   assert(_array == NULL, "Already initialized?");
   const uintx initial_cap = 1024;
-  const uintx max_cap = clamp(MaxObjectMonitors, (uintx)1024, (uintx)UINT_MAX - 1);
+  const uintx max_object_monitors = MonitorStorageSize / sizeof(ObjectMonitor);
+  const uintx max_cap = clamp(max_object_monitors, (uintx)1024, (uintx)UINT_MAX - 1);
   const uintx cap_increase = 1024;
   _array = new ArrayType(initial_cap, cap_increase, max_cap);
   MemTracker::record_virtual_memory_type((address)_array->base(), mtObjectMonitor);

--- a/src/hotspot/share/runtime/objectMonitorStorage.cpp
+++ b/src/hotspot/share/runtime/objectMonitorStorage.cpp
@@ -38,10 +38,10 @@ static const bool be_paranoid = false;
 
 ObjectMonitorStorage::ArrayType* ObjectMonitorStorage::_array = NULL;
 
-#define LOG(...) {                        \
+#define LOG(fmt, ...) {                   \
 	LogTarget(Info, monitorinflation) lt;   \
   if (lt.is_enabled()) {                  \
-    log_with_state(__VA_ARGS__);          \
+    log_with_state(fmt, __VA_ARGS__);     \
   }                                       \
 }
 

--- a/src/hotspot/share/runtime/objectMonitorStorage.cpp
+++ b/src/hotspot/share/runtime/objectMonitorStorage.cpp
@@ -112,7 +112,10 @@ void ObjectMonitorStorage::bulk_deallocate(const GrowableArray<ObjectMonitor*>& 
 
 void ObjectMonitorStorage::initialize() {
   assert(_array == NULL, "Already initialized?");
-  _array = new ArrayType(MAX2(MaxObjectMonitors, (uintx)1024), 1024);
+  const uintx initial_cap = 1024;
+  const uintx max_cap = clamp(MaxObjectMonitors, (uintx)1024, (uintx)UINT_MAX - 1);
+  const uintx cap_increase = 1024;
+  _array = new ArrayType(initial_cap, cap_increase, max_cap);
   MemTracker::record_virtual_memory_type((address)_array->base(), mtObjectMonitor);
 }
 

--- a/src/hotspot/share/runtime/objectMonitorStorage.cpp
+++ b/src/hotspot/share/runtime/objectMonitorStorage.cpp
@@ -38,6 +38,8 @@ static const bool be_paranoid = false;
 
 ReservedSpace ObjectMonitorStorage::_rs;
 ObjectMonitorStorage::ArrayType ObjectMonitorStorage::_array;
+address ObjectMonitorStorage::_base = NULL;
+uintx ObjectMonitorStorage::_max_capacity = 0;
 
 // re-build a new list of newly allocated free monitors and return its head
 void ObjectMonitorStorage::bulk_allocate_new_list(OMFreeListType& freelist_to_fill) {
@@ -101,6 +103,8 @@ void ObjectMonitorStorage::initialize() {
     log_with_state("Reserved: [" PTR_FORMAT "-" PTR_FORMAT "), " SIZE_FORMAT " bytes (" UINTX_FORMAT " monitors).",
                    p2i(_rs.base()), p2i(_rs.end()), _rs.size(), max_capacity);
     _array.initialize((ObjectMonitor*)_rs.base(), min_object_monitors, max_capacity);
+    _base = (address) _rs.base();
+    _max_capacity = max_capacity;
   } else {
     vm_exit_out_of_memory(range_size, OOM_MMAP_ERROR, "Failed to reserve Object Monitor Store");
   }

--- a/src/hotspot/share/runtime/objectMonitorStorage.cpp
+++ b/src/hotspot/share/runtime/objectMonitorStorage.cpp
@@ -106,9 +106,8 @@ void ObjectMonitorStorage::bulk_deallocate(const GrowableArray<ObjectMonitor*>& 
       _array->print_on(&ls);
       ls.cr();
     }
-
+    DEBUG_ONLY(verify();)
   }
-  DEBUG_ONLY(verify();)
 }
 
 void ObjectMonitorStorage::initialize() {
@@ -128,6 +127,7 @@ void ObjectMonitorStorage::print(outputStream* st) {
 
 #ifdef ASSERT
 void ObjectMonitorStorage::verify() {
+  assert_lock_strong(ObjectMonitorStorage_lock);
   if (_array != NULL) {
     _array->verify(be_paranoid);
   }

--- a/src/hotspot/share/runtime/objectMonitorStorage.hpp
+++ b/src/hotspot/share/runtime/objectMonitorStorage.hpp
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2022 SAP SE. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef SHARE_RUNTIME_OBJECTMONITORSTORAGE_HPP
+#define SHARE_RUNTIME_OBJECTMONITORSTORAGE_HPP
+
+#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
+#include "oops/oop.hpp"
+#include "runtime/mutexLocker.hpp"
+#include "runtime/objectMonitor.hpp"
+#include "runtime/thread.hpp"
+#include "utilities/addressStableArray.inline.hpp"
+#include "utilities/globalDefinitions.hpp"
+
+class outputStream;
+
+typedef FreeList<ObjectMonitor> OMFreeListType;
+
+typedef uint32_t OMRef;
+#define INVALID_OMREF ((OMRef)-1)
+
+class ObjectMonitorStorage : public AllStatic {
+
+  typedef AddressStableHeap<ObjectMonitor> ArrayType;
+  static ArrayType* _array;
+
+  // re-build a new list of newly allocated free monitors and return its head
+  static void bulk_allocate_new_list(OMFreeListType& freelist_to_fill);
+
+  // Return the current thread's om freelist
+  static OMFreeListType& current_omlist() {
+    // Note: monitors in this list are not initialized.
+    return Thread::current()->_om_freelist;
+  }
+
+public:
+
+  // On behalf of the current thread allocate a single monitor, preferably from
+  // thread local freelist
+  static ObjectMonitor* allocate_monitor(oop object) {
+    OMFreeListType& tl_list = current_omlist();
+    ObjectMonitor* om = tl_list.take_top();
+    if (om == NULL) {
+      bulk_allocate_new_list(tl_list);
+      om = tl_list.take_top();
+      assert(om != NULL, "sanity");
+    }
+    om = new (om) ObjectMonitor(object);
+    return om; // done
+  }
+
+  // On behalf of the current thread deallocate a single monitor
+  static void deallocate_monitor(ObjectMonitor* m) {
+    m->~ObjectMonitor(); // de-initialize.
+    OMFreeListType& tl_list = current_omlist();
+    tl_list.prepend(m);
+  }
+
+  // deallocate a list of monitors
+  static void bulk_deallocate(const GrowableArray<ObjectMonitor*>& list);
+
+  static void cleanup_before_thread_death(Thread* t);
+
+  static ObjectMonitor* ref_to_om(OMRef ref)       { return _array->index_to_obj((uintx)ref); }
+  static OMRef om_to_ref(const ObjectMonitor* om)  { return (OMRef)_array->obj_to_index(om); }
+
+  static void initialize();
+
+  static void print(outputStream* st);
+
+  DEBUG_ONLY(static void verify();)
+
+};
+
+#endif // SHARE_RUNTIME_OBJECTMONITORSTORAGE_HPP

--- a/src/hotspot/share/runtime/objectMonitorStorage.hpp
+++ b/src/hotspot/share/runtime/objectMonitorStorage.hpp
@@ -56,7 +56,7 @@ class ObjectMonitorStorage : public AllStatic {
     return Thread::current()->_om_freelist;
   }
 
-  static void log_with_state(const char* fmt, ...);
+  static void log_with_state(const char* fmt, ...) ATTRIBUTE_PRINTF(1, 2);
 
 public:
 

--- a/src/hotspot/share/runtime/objectMonitorStorage.hpp
+++ b/src/hotspot/share/runtime/objectMonitorStorage.hpp
@@ -44,7 +44,7 @@ typedef uint32_t OMRef;
 
 class ObjectMonitorStorage : public AllStatic {
 
-  typedef AddressStableHeap<ObjectMonitor> ArrayType;
+  typedef AddressStableArrayWithFreeList<ObjectMonitor> ArrayType;
   static ArrayType* _array;
 
   static ReservedSpace _rs;

--- a/src/hotspot/share/runtime/objectMonitorStorage.hpp
+++ b/src/hotspot/share/runtime/objectMonitorStorage.hpp
@@ -45,7 +45,7 @@ typedef uint32_t OMRef;
 class ObjectMonitorStorage : public AllStatic {
 
   typedef AddressStableArrayWithFreeList<ObjectMonitor> ArrayType;
-  static ArrayType* _array;
+  static ArrayType _array;
 
   static ReservedSpace _rs;
 

--- a/src/hotspot/share/runtime/objectMonitorStorage.hpp
+++ b/src/hotspot/share/runtime/objectMonitorStorage.hpp
@@ -88,8 +88,9 @@ public:
 
   static void cleanup_before_thread_death(Thread* t);
 
-  static ObjectMonitor* ref_to_om(OMRef ref)       { return _array->index_to_obj((uintx)ref); }
-  static OMRef om_to_ref(const ObjectMonitor* om)  { return (OMRef)_array->obj_to_index(om); }
+  // IMplement Todo
+  //static ObjectMonitor* ref_to_om(OMRef ref);
+  //static OMRef om_to_ref(const ObjectMonitor* om);
 
   static void initialize();
 

--- a/src/hotspot/share/runtime/objectMonitorStorage.hpp
+++ b/src/hotspot/share/runtime/objectMonitorStorage.hpp
@@ -79,8 +79,8 @@ public:
     tl_list.prepend(m);
   }
 
-  // deallocate a list of monitors
-  static void bulk_deallocate(const GrowableArray<ObjectMonitor*>& list);
+  // deallocate a list of monitors; empties out the donor list.
+  static void bulk_deallocate(OMFreeListType& omlist);
 
   static void cleanup_before_thread_death(Thread* t);
 

--- a/src/hotspot/share/runtime/objectMonitorStorage.hpp
+++ b/src/hotspot/share/runtime/objectMonitorStorage.hpp
@@ -56,6 +56,8 @@ class ObjectMonitorStorage : public AllStatic {
     return Thread::current()->_om_freelist;
   }
 
+  static void log_with_state(const char* fmt, ...);
+
 public:
 
   // On behalf of the current thread allocate a single monitor, preferably from

--- a/src/hotspot/share/runtime/objectMonitorStorage.hpp
+++ b/src/hotspot/share/runtime/objectMonitorStorage.hpp
@@ -47,6 +47,8 @@ class ObjectMonitorStorage : public AllStatic {
   typedef AddressStableHeap<ObjectMonitor> ArrayType;
   static ArrayType* _array;
 
+  static ReservedSpace _rs;
+
   // re-build a new list of newly allocated free monitors and return its head
   static void bulk_allocate_new_list(OMFreeListType& freelist_to_fill);
 

--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -1636,19 +1636,13 @@ size_t ObjectSynchronizer::deflate_idle_monitors(ObjectMonitorsHashtable* table)
 
     // After the handshake, safely free the ObjectMonitors that were
     // deflated in this cycle.
-    ObjectMonitorStorage::bulk_deallocate(delete_list);
-
+    ObjectMonitorStorage::bulk_deallocate(delete_list); // Todo: safepoint check inside?
     size_t deleted_count = delete_list.length();
-//    for (ObjectMonitor* monitor: delete_list) {
-//      delete monitor;
-//      deleted_count++;
-
-      if (current->is_Java_thread()) {
-        // A JavaThread must check for a safepoint/handshake and honor it.
-        chk_for_block_req(JavaThread::cast(current), "deletion", "deleted_count",
-                          deleted_count, ls, &timer);
-      }
-//    }
+    if (current->is_Java_thread()) {
+      // A JavaThread must check for a safepoint/handshake and honor it.
+      chk_for_block_req(JavaThread::cast(current), "deletion", "deleted_count",
+                        deleted_count, ls, &timer);
+    }
   }
 
   if (ls != NULL) {

--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -41,6 +41,7 @@
 #include "runtime/mutexLocker.hpp"
 #include "runtime/objectMonitor.hpp"
 #include "runtime/objectMonitor.inline.hpp"
+#include "runtime/objectMonitorStorage.hpp"
 #include "runtime/os.inline.hpp"
 #include "runtime/osThread.hpp"
 #include "runtime/perfData.hpp"
@@ -1342,14 +1343,14 @@ ObjectMonitor* ObjectSynchronizer::inflate(Thread* current, oop object,
     LogStreamHandle(Trace, monitorinflation) lsh;
 
     if (mark.has_locker()) {
-      ObjectMonitor* m = new ObjectMonitor(object);
+      ObjectMonitor* m = ObjectMonitorStorage::allocate_monitor(object);
       // Optimistically prepare the ObjectMonitor - anticipate successful CAS
       // We do this before the CAS in order to minimize the length of time
       // in which INFLATING appears in the mark.
 
       markWord cmp = object->cas_set_mark(markWord::INFLATING(), mark);
       if (cmp != mark) {
-        delete m;
+        ObjectMonitorStorage::deallocate_monitor(m);
         continue;       // Interference -- just retry
       }
 
@@ -1436,12 +1437,12 @@ ObjectMonitor* ObjectSynchronizer::inflate(Thread* current, oop object,
     // Catch if the object's header is not neutral (not locked and
     // not marked is what we care about here).
     assert(mark.is_neutral(), "invariant: header=" INTPTR_FORMAT, mark.value());
-    ObjectMonitor* m = new ObjectMonitor(object);
+    ObjectMonitor* m = ObjectMonitorStorage::allocate_monitor(object);
     // prepare m for installation - set monitor to initial state
     m->set_header(mark);
 
     if (object->cas_set_mark(markWord::encode(m), mark) != mark) {
-      delete m;
+      ObjectMonitorStorage::deallocate_monitor(m);
       m = NULL;
       continue;
       // interference - the markword changed - just retry.
@@ -1635,17 +1636,19 @@ size_t ObjectSynchronizer::deflate_idle_monitors(ObjectMonitorsHashtable* table)
 
     // After the handshake, safely free the ObjectMonitors that were
     // deflated in this cycle.
-    size_t deleted_count = 0;
-    for (ObjectMonitor* monitor: delete_list) {
-      delete monitor;
-      deleted_count++;
+    ObjectMonitorStorage::bulk_deallocate(delete_list);
+
+    size_t deleted_count = delete_list.length();
+//    for (ObjectMonitor* monitor: delete_list) {
+//      delete monitor;
+//      deleted_count++;
 
       if (current->is_Java_thread()) {
         // A JavaThread must check for a safepoint/handshake and honor it.
         chk_for_block_req(JavaThread::cast(current), "deletion", "deleted_count",
                           deleted_count, ls, &timer);
       }
-    }
+//    }
   }
 
   if (ls != NULL) {

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -92,6 +92,7 @@
 #include "runtime/mutexLocker.hpp"
 #include "runtime/nonJavaThread.hpp"
 #include "runtime/objectMonitor.hpp"
+#include "runtime/objectMonitorStorage.hpp"
 #include "runtime/orderAccess.hpp"
 #include "runtime/osThread.hpp"
 #include "runtime/safepoint.hpp"
@@ -377,6 +378,8 @@ void Thread::call_run() {
 
 Thread::~Thread() {
 
+  ObjectMonitorStorage::cleanup_before_thread_death(this);
+
   // Attached threads will remain in PRE_CALL_RUN, as will threads that don't actually
   // get started due to errors etc. Any active thread should at least reach post_run
   // before it is deleted (usually in post_run()).
@@ -417,6 +420,7 @@ Thread::~Thread() {
   }
 
   CHECK_UNHANDLED_OOPS_ONLY(if (CheckUnhandledOops) delete unhandled_oops();)
+
 }
 
 #ifdef ASSERT
@@ -2803,6 +2807,7 @@ jint Threads::create_vm(JavaVMInitArgs* args, bool* canTryAgain) {
   main_thread->stack_overflow_state()->create_stack_guard_pages();
 
   // Initialize Java-Level synchronization subsystem
+  ObjectMonitorStorage::initialize();
   ObjectMonitor::Initialize();
   ObjectSynchronizer::initialize();
 

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -48,6 +48,7 @@
 #include "runtime/unhandledOops.hpp"
 #include "utilities/align.hpp"
 #include "utilities/exceptions.hpp"
+#include "utilities/freeList.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/macros.hpp"
 #if INCLUDE_JFR
@@ -83,6 +84,8 @@ class Metadata;
 class ResourceArea;
 
 class OopStorage;
+
+class ObjectMonitor;
 
 DEBUG_ONLY(class ResourceMark;)
 
@@ -640,6 +643,10 @@ protected:
     assert(_wx_state == expected, "wrong state");
   }
 #endif // __APPLE__ && AARCH64
+
+ public:
+  FreeList<ObjectMonitor> _om_freelist;
+
 };
 
 // Inline implementation of Thread::current()

--- a/src/hotspot/share/services/memReporter.cpp
+++ b/src/hotspot/share/services/memReporter.cpp
@@ -25,6 +25,7 @@
 #include "memory/allocation.hpp"
 #include "memory/metaspace.hpp"
 #include "memory/metaspaceUtils.hpp"
+#include "runtime/objectMonitorStorage.hpp"
 #include "services/mallocTracker.hpp"
 #include "services/memReporter.hpp"
 #include "services/threadStackTracker.hpp"
@@ -98,6 +99,10 @@ void MemReporterBase::print_virtual_memory_region(const char* type, address base
 
 void MemSummaryReporter::report() {
   outputStream* out = output();
+
+  // Sneak in here for now
+  ObjectMonitorStorage::print(out);
+
   const size_t total_malloced_bytes = _malloc_snapshot->total();
   const size_t total_mmap_reserved_bytes = _vm_snapshot->total_reserved();
   const size_t total_mmap_committed_bytes = _vm_snapshot->total_committed();

--- a/src/hotspot/share/services/memTracker.cpp
+++ b/src/hotspot/share/services/memTracker.cpp
@@ -28,6 +28,7 @@
 #include "memory/metaspaceUtils.hpp"
 #include "runtime/atomic.hpp"
 #include "runtime/globals.hpp"
+#include "runtime/objectMonitorStorage.hpp"
 #include "runtime/orderAccess.hpp"
 #include "runtime/vmThread.hpp"
 #include "runtime/vmOperations.hpp"
@@ -142,6 +143,7 @@ void MemTracker::report(bool summary_only, outputStream* output, size_t scale) {
       MetaspaceUtils::print_basic_report(output, scale);
     }
   }
+  output->cr();
 }
 
 void MemTracker::tuning_statistics(outputStream* out) {

--- a/src/hotspot/share/utilities/addressStableArray.hpp
+++ b/src/hotspot/share/utilities/addressStableArray.hpp
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2022 SAP SE. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef SHARE_UTILITIES_ADDRESSSTABLEARRAY_HPP
+#define SHARE_UTILITIES_ADDRESSSTABLEARRAY_HPP
+
+#include "memory/allocation.hpp"
+#include "memory/virtualspace.hpp"
+#include "runtime/os.hpp"
+#include "utilities/align.hpp"
+#include "utilities/debug.hpp"
+#include "utilities/freeList.hpp"
+#include "utilities/globalDefinitions.hpp"
+
+class outputStream;
+
+// An growable array of homogenous things, living in a pre-reserved address range
+//  (and hence ultimately limited in size). Does its own on-demand committing/uncommitting.
+
+template <class T>
+class AddressStableArray : public CHeapObj<mtInternal> {
+  STATIC_ASSERT(sizeof(T) >= sizeof(T*));              // (1)
+  STATIC_ASSERT(is_aligned(sizeof(T), sizeof(T*)));    // (2)
+
+  ReservedSpace _rs;              // Underlying address range
+  T* const _elements;
+  const uintx _max_capacity;      // max number of slots
+  uintx _capacity;                // number of slots usable without committing additional memory
+  uintx _used;                    // number of slots used (includes those in freelist)
+
+  static uintx capacity_of(size_t bytes)  { return bytes / sizeof(T); }
+
+  T* at(uintx idx) const                  { return _elements + idx; }
+
+  static size_t bytes_needed(uintx n)               { return sizeof(T) * n; }
+  static size_t page_align(size_t s)                { return align_up(s, os::vm_page_size()); }
+  static size_t bytes_needed_page_aligned(uintx n)  { return page_align(bytes_needed(n)); }
+  static size_t pages_needed(uintx n)               { return bytes_needed_page_aligned(n) / os::vm_page_size(); }
+
+  // Enlarge committed capacity
+  void enlarge_capacity(uintx min_needed_capacity);
+
+  void check_index(uintx index) const {
+    assert(index < _used, "invalid index (" UINTX_FORMAT ")", index);
+  }
+
+public:
+
+  AddressStableArray(uintx max_capacity, uintx initial_capacity) :
+    _rs(align_up(bytes_needed(max_capacity), os::vm_allocation_granularity())),
+    _elements((T*)_rs.base()),
+    _max_capacity(max_capacity),
+    _capacity(0), _used(0)
+  {
+    assert(_max_capacity >= initial_capacity, "sanity");
+    if ((initial_capacity) > 0) {
+      enlarge_capacity(initial_capacity);
+    }
+  }
+
+  bool contains(const T* v) const {
+    return _elements <= v && (_elements + _used) > v;
+  }
+
+  T* allocate() {
+    if (_used == _capacity) {
+      if (_capacity == _max_capacity) {
+        return NULL;
+      }
+      enlarge_capacity(_capacity + 1);
+    }
+    assert(_used < _capacity, "enlarge failed?");
+    T* p = at(_used);
+    _used ++;
+    return p;
+  }
+
+  uintx obj_to_index(const T* t) const {
+    assert(t != NULL, "element is NULL");
+    assert(contains(t), "elements outside this heap");
+    return (uintx)(t - _elements);
+  }
+
+  T* index_to_obj(uintx idx) {
+    check_index(idx);
+    return _elements + idx;
+  }
+
+  const T* index_to_obj(uintx idx) const {
+    check_index(idx);
+    return _elements + idx;
+  }
+
+  size_t committed_bytes() const {
+    return bytes_needed_page_aligned(_capacity);
+  }
+
+  uintx capacity() const {
+    return _capacity;
+  }
+
+  DEBUG_ONLY(void verify() const;)
+  void print_on(outputStream* st) const;
+
+  // Base address (exposed to set NMT cat; TODO: this is annoying, should be done better
+  const T* base() const { return _elements; }
+
+}; // AddressStableArray
+
+// Same, but with freelist supporting deallocation
+template <class T>
+class AddressStableHeap : public CHeapObj<mtInternal> {
+
+  typedef AddressStableArray<T> ArrayType;
+  typedef FreeList<T> FreeListType;
+
+  ArrayType _array;
+  FreeListType _freelist;
+
+public:
+
+  AddressStableHeap(uintx max_capacity, uintx initial_capacity) :
+    _array(max_capacity, initial_capacity),
+    _freelist()
+  {}
+
+  T* allocate() {
+    T* p = _freelist.take_top();
+    if (p == NULL) {
+      p = _array.allocate();
+    }
+    return p;
+  }
+
+  void deallocate(T* t) {
+    _freelist.prepend(t);
+  }
+
+  // Add all elements to freelist and empties out the donor list
+  void bulk_deallocate(FreeListType& list) {
+    _freelist.prepend_list(list);
+  }
+
+  uintx obj_to_index(const T* t) const   { return _array.obj_to_index(t); }
+  T* index_to_obj(uintx idx)             { return _array.index_to_obj(idx); }
+  const T* index_to_obj(uintx idx) const { return _array.index_to_obj(idx); }
+  size_t committed_bytes() const         { return _array.committed_bytes(); }
+  uintx capacity() const                 { return _array.capacity(); }
+  bool contains(const T* v) const        { return _array.contains(v); }
+
+  DEBUG_ONLY(void verify(bool paranoid = false) const;)
+  void print_on(outputStream* st) const;
+
+  // Base address (exposed to set NMT cat; TODO: this is annoying, should be done better
+  const T* base() const { return _array.base(); }
+
+};
+
+#endif // SHARE_UTILITIES_ADDRESSSTABLEARRAY_HPP

--- a/src/hotspot/share/utilities/addressStableArray.hpp
+++ b/src/hotspot/share/utilities/addressStableArray.hpp
@@ -46,7 +46,8 @@ class AddressStableArray : public CHeapObj<mtInternal> {
 
   ReservedSpace _rs;              // Underlying address range
   T* const _elements;
-  const uintx _max_capacity;      // max number of slots
+  const uintx _cap_increase;      // step width of capacity increase
+  const uintx _max_capacity;      // max number of slots (determines size of underlying address range)
   uintx _capacity;                // number of slots usable without committing additional memory
   uintx _used;                    // number of slots used (includes those in freelist)
 
@@ -68,13 +69,15 @@ class AddressStableArray : public CHeapObj<mtInternal> {
 
 public:
 
-  AddressStableArray(uintx max_capacity, uintx initial_capacity) :
+  AddressStableArray(uintx initial_capacity, uintx cap_increase, uintx max_capacity) :
     _rs(align_up(bytes_needed(max_capacity), os::vm_allocation_granularity())),
     _elements((T*)_rs.base()),
+    _cap_increase(cap_increase),
     _max_capacity(max_capacity),
     _capacity(0), _used(0)
   {
     assert(_max_capacity >= initial_capacity, "sanity");
+    assert(_cap_increase <= max_capacity, "sanity");
     if ((initial_capacity) > 0) {
       enlarge_capacity(initial_capacity);
     }
@@ -141,8 +144,8 @@ class AddressStableHeap : public CHeapObj<mtInternal> {
 
 public:
 
-  AddressStableHeap(uintx max_capacity, uintx initial_capacity) :
-    _array(max_capacity, initial_capacity),
+  AddressStableHeap(uintx initial_capacity, uintx cap_increase, uintx max_capacity) :
+    _array(initial_capacity, cap_increase, max_capacity),
     _freelist()
   {}
 

--- a/src/hotspot/share/utilities/addressStableArray.hpp
+++ b/src/hotspot/share/utilities/addressStableArray.hpp
@@ -78,6 +78,7 @@ public:
   {
     assert(_max_capacity >= initial_capacity, "sanity");
     assert(_cap_increase <= max_capacity, "sanity");
+    assert(_rs.is_reserved(), "Failed to reserve memory");
     if ((initial_capacity) > 0) {
       enlarge_capacity(initial_capacity);
     }

--- a/src/hotspot/share/utilities/addressStableArray.hpp
+++ b/src/hotspot/share/utilities/addressStableArray.hpp
@@ -106,22 +106,6 @@ public:
     return p;
   }
 
-  uintx obj_to_index(const T* t) const {
-    assert(t != NULL, "element is NULL");
-    assert(contains(t), "elements outside this heap");
-    return (uintx)(t - _elements);
-  }
-
-  T* index_to_obj(uintx idx) {
-    check_index(idx);
-    return _elements + idx;
-  }
-
-  const T* index_to_obj(uintx idx) const {
-    check_index(idx);
-    return _elements + idx;
-  }
-
   size_t reserved_bytes() const {
     return bytes_needed_page_aligned(_max_capacity);
   }
@@ -184,9 +168,6 @@ public:
   // freelist. Returns true if that worked, false otherwise.
   bool try_uncommit();
 
-  uintx obj_to_index(const T* t) const   { return _array.obj_to_index(t); }
-  T* index_to_obj(uintx idx)             { return _array.index_to_obj(idx); }
-  const T* index_to_obj(uintx idx) const { return _array.index_to_obj(idx); }
   size_t committed_bytes() const         { return _array.committed_bytes(); }
   bool contains(const T* v) const        { return _array.contains(v); }
 
@@ -199,9 +180,6 @@ public:
 
   DEBUG_ONLY(void verify(bool paranoid = false) const;)
   void print_on(outputStream* st) const;
-
-  // Base address (exposed to set NMT cat; TODO: this is annoying, should be done better
-  const T* base() const { return _array.base(); }
 
 };
 

--- a/src/hotspot/share/utilities/addressStableArray.hpp
+++ b/src/hotspot/share/utilities/addressStableArray.hpp
@@ -131,7 +131,7 @@ public:
 
 // Same, but with freelist supporting deallocation
 template <class T>
-class AddressStableHeap : public CHeapObj<mtInternal> {
+class AddressStableArrayWithFreeList : public CHeapObj<mtInternal> {
 
   typedef AddressStableArray<T> ArrayType;
   typedef FreeList<T> FreeListType;
@@ -141,7 +141,7 @@ class AddressStableHeap : public CHeapObj<mtInternal> {
 
 public:
 
-  AddressStableHeap(T* elements, uintx initial_capacity, uintx max_capacity) :
+  AddressStableArrayWithFreeList(T* elements, uintx initial_capacity, uintx max_capacity) :
     _array(elements, initial_capacity, max_capacity),
     _freelist()
   {}

--- a/src/hotspot/share/utilities/addressStableArray.hpp
+++ b/src/hotspot/share/utilities/addressStableArray.hpp
@@ -46,7 +46,6 @@ class AddressStableArray : public CHeapObj<mtInternal> {
 
   ReservedSpace _rs;              // Underlying address range
   T* const _elements;
-  const uintx _cap_increase;      // step width of capacity increase
   const uintx _max_capacity;      // max number of slots (determines size of underlying address range)
   uintx _capacity;                // number of slots usable without committing additional memory
   uintx _used;                    // number of slots used (includes those in freelist)
@@ -69,17 +68,13 @@ class AddressStableArray : public CHeapObj<mtInternal> {
 
 public:
 
-  AddressStableArray(uintx initial_capacity, uintx cap_increase, uintx max_capacity) :
+  AddressStableArray(uintx initial_capacity, uintx max_capacity) :
     _rs(align_up(bytes_needed(max_capacity), os::vm_allocation_granularity())),
     _elements((T*)_rs.base()),
-    _cap_increase(cap_increase),
     _max_capacity(max_capacity),
     _capacity(0), _used(0)
   {
     assert(_max_capacity >= initial_capacity, "sanity");
-    assert(_cap_increase <= max_capacity, "sanity");
-    assert(initial_capacity == _max_capacity ||
-           _cap_increase >= 1, "increase must be larger than 0 if we don't fully commit upfront");
     if ((initial_capacity) > 0) {
       enlarge_capacity(initial_capacity);
     }
@@ -149,8 +144,8 @@ class AddressStableHeap : public CHeapObj<mtInternal> {
 
 public:
 
-  AddressStableHeap(uintx initial_capacity, uintx cap_increase, uintx max_capacity) :
-    _array(initial_capacity, cap_increase, max_capacity),
+  AddressStableHeap(uintx initial_capacity, uintx max_capacity) :
+    _array(initial_capacity, max_capacity),
     _freelist()
   {}
 

--- a/src/hotspot/share/utilities/addressStableArray.inline.hpp
+++ b/src/hotspot/share/utilities/addressStableArray.inline.hpp
@@ -38,7 +38,7 @@ void AddressStableArray<T>::enlarge_capacity(uintx min_needed_capacity) {
 
   assert(_capacity < _max_capacity, "cannot enlarge capacity");
   const uintx new_capacity =
-      clamp((uintx)(_capacity * 1.25), min_needed_capacity, _max_capacity);
+      clamp((uintx)(_capacity + _cap_increase), min_needed_capacity, _max_capacity);
 
   const size_t committed_bytes = bytes_needed_page_aligned(_capacity);
   const size_t new_committed_bytes = bytes_needed_page_aligned(new_capacity);

--- a/src/hotspot/share/utilities/addressStableArray.inline.hpp
+++ b/src/hotspot/share/utilities/addressStableArray.inline.hpp
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2022 SAP SE. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef SHARE_UTILITIES_ADDRESSSTABLEARRAY_INLINE_HPP
+#define SHARE_UTILITIES_ADDRESSSTABLEARRAY_INLINE_HPP
+
+#include "runtime/os.hpp"
+#include "utilities/addressStableArray.hpp"
+#include "utilities/align.hpp"
+#include "utilities/debug.hpp"
+#include "utilities/freeList.inline.hpp"
+#include "utilities/globalDefinitions.hpp"
+
+template <class T>
+void AddressStableArray<T>::enlarge_capacity(uintx min_needed_capacity) {
+
+  assert(_capacity < _max_capacity, "cannot enlarge capacity");
+  const uintx new_capacity =
+      clamp((uintx)(_capacity * 1.25), min_needed_capacity, _max_capacity);
+
+  const size_t committed_bytes = bytes_needed_page_aligned(_capacity);
+  const size_t new_committed_bytes = bytes_needed_page_aligned(new_capacity);
+
+  // Since we always set _capacity to either _max_capacity or the limit of what is
+  // committed, this should hold always true:
+  assert(new_committed_bytes > committed_bytes, "_capacity not at commit boundary");
+
+  os::commit_memory_or_exit(_rs.base() + committed_bytes,
+                        new_committed_bytes - committed_bytes,
+                        false, "");
+  _capacity = MIN2(capacity_of(new_committed_bytes), _max_capacity);
+
+  DEBUG_ONLY(verify();)
+}
+
+#ifdef ASSERT
+template <class T>
+void AddressStableArray<T>::verify() const {
+  assert(_rs.is_reserved(), "no space");
+  assert(_elements != NULL, "elements null");
+  assert(_capacity <= _max_capacity, "Sanity");
+  assert(_max_capacity <= capacity_of(_rs.size()), "Space too small?");
+  assert(_used <= _capacity, "Sanity");
+}
+#endif // ASSERT
+
+template <class T>
+void AddressStableArray<T>::print_on(outputStream* st) const {
+  st->print("elem size: " SIZE_FORMAT ", "
+      "[" PTR_FORMAT "-" PTR_FORMAT "), res/comm " SIZE_FORMAT "/" SIZE_FORMAT ", "
+      "used/capacity/max: " UINTX_FORMAT "/" UINTX_FORMAT "/" UINTX_FORMAT
+      ,
+      sizeof(T),
+      p2i(_rs.base()), p2i(_rs.base() + _rs.size()),
+      _rs.size(), bytes_needed_page_aligned(_capacity),
+      _used, _capacity, _max_capacity
+      );
+}
+
+// AddressStableHeap = AddressStableArray + freelist
+
+template <class T>
+struct VerifyFreeListClosure : public FreeList<T>::Closure {
+  const AddressStableHeap<T>* _container;
+  bool do_it(const T* p) override {
+    assert(_container->contains(p), "kukuck");
+    return true;
+  }
+};
+
+#ifdef ASSERT
+template <class T>
+void AddressStableHeap<T>::verify(bool paranoid) const {
+  _array.verify();
+  _freelist.verify(paranoid);
+  // verify that all elements are part of the array
+  VerifyFreeListClosure<T> verifier;
+  verifier._container = this;
+  _freelist.iterate(verifier);
+}
+#endif // ASSERT
+
+template <class T>
+void AddressStableHeap<T>::print_on(outputStream* st) const {
+  _array.print_on(st);
+  st->print(", freelist: ");
+  _freelist.print_on(st, false);
+}
+
+
+#endif // SHARE_UTILITIES_ADDRESSSTABLEARRAY_INLINE_HPP

--- a/src/hotspot/share/utilities/addressStableArray.inline.hpp
+++ b/src/hotspot/share/utilities/addressStableArray.inline.hpp
@@ -45,8 +45,13 @@ void AddressStableArray<T>::enlarge_capacity(uintx min_needed_capacity) {
   assert(_rs.is_reserved(), "address space not reserved");
 
   assert(_capacity < _max_capacity, "cannot enlarge capacity");
+
+  // We increase by a quarter, but at least 4 pages.
+  const uintx cap_increase =
+      MAX2(_capacity / 4, capacity_of(os::vm_page_size() * 4));
+
   const uintx new_capacity =
-      clamp((uintx)(_capacity + _cap_increase), min_needed_capacity, _max_capacity);
+      clamp((uintx)(_capacity + cap_increase), min_needed_capacity, _max_capacity);
 
   const size_t committed_bytes = bytes_needed_page_aligned(_capacity);
   const size_t new_committed_bytes = bytes_needed_page_aligned(new_capacity);

--- a/src/hotspot/share/utilities/addressStableArray.inline.hpp
+++ b/src/hotspot/share/utilities/addressStableArray.inline.hpp
@@ -105,13 +105,13 @@ void AddressStableArray<T>::print_on(outputStream* st) const {
 
 //
 //
-/////// AddressStableHeap /////////////////////////////////////
+/////// AddressStableArrayWithFreeList /////////////////////////////////////
 //
 //
 
 template <class T>
 struct VerifyFreeListClosure : public FreeList<T>::Closure {
-  const AddressStableHeap<T>* _container;
+  const AddressStableArrayWithFreeList<T>* _container;
   bool do_it(const T* p) override {
     assert(_container->contains(p), "kukuck");
     return true;
@@ -120,7 +120,7 @@ struct VerifyFreeListClosure : public FreeList<T>::Closure {
 
 #ifdef ASSERT
 template <class T>
-void AddressStableHeap<T>::verify(bool paranoid) const {
+void AddressStableArrayWithFreeList<T>::verify(bool paranoid) const {
   assert((used() + free()) <= capacity(),
          "number mismatch (" UINTX_FORMAT ", " UINTX_FORMAT ", " UINTX_FORMAT ")",
          capacity(), used(), free());
@@ -134,7 +134,7 @@ void AddressStableHeap<T>::verify(bool paranoid) const {
 #endif // ASSERT
 
 template <class T>
-void AddressStableHeap<T>::print_on(outputStream* st) const {
+void AddressStableArrayWithFreeList<T>::print_on(outputStream* st) const {
   _array.print_on(st);
   st->print(", freelist: ");
   _freelist.print_on(st, false);
@@ -144,7 +144,7 @@ void AddressStableHeap<T>::print_on(outputStream* st) const {
 // returned to the freelist), uncommit the underlying memory range and reset the
 // freelist. Returns true if that worked, false otherwise.
 template <class T>
-bool AddressStableHeap<T>::try_uncommit() {
+bool AddressStableArrayWithFreeList<T>::try_uncommit() {
   // if we are already completely uncommitted, its a benign noop.
   if (_array.used() == 0) {
     assert(_array.committed_bytes() == 0, "sanity");

--- a/src/hotspot/share/utilities/freeList.hpp
+++ b/src/hotspot/share/utilities/freeList.hpp
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2022 SAP SE. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef SHARE_UTILITIES_FREELIST_HPP
+#define SHARE_UTILITIES_FREELIST_HPP
+
+#include "utilities/debug.hpp"
+#include "utilities/globalDefinitions.hpp"
+
+class outputStream;
+
+// Simple classic double-headed, self-counting (optional), freelist of dead elements
+
+template <class T>
+static T* Tptr_at(T* p)                   { return *((T**)p); }
+
+template <class T>
+static void set_Tptr_at(T* p, T* newval)  { *((T**)p) = newval; }
+
+template <class T>
+static void set_Tptr_at_null(T* p)        { set_Tptr_at(p, (T*) NULL); }
+
+template <class T>
+class FreeList {
+
+  static const bool _counting = true;//DEBUG_ONLY(true) NOT_DEBUG(false);
+
+  T* _head;
+  T* _tail;
+  uintx _count;
+  uintx _peak_count;
+
+#ifdef ASSERT
+  void quick_verify() const {
+    assert((_head == NULL) == (_tail == NULL), "malformed list");
+    if (_counting) {
+      assert( (_count == 0 && _head == NULL && _tail == NULL) ||
+              (_count == 1 && _head == _tail) ||
+              (_count > 1 && _head != _tail), "malformed list");
+    }
+  }
+#endif
+
+public:
+
+  FreeList() :
+    _head(NULL), _tail(NULL),
+    _count(0), _peak_count(0)
+  {}
+
+  FreeList(T* head, T* tail, uintx count) :
+    _head(head), _tail(tail),
+    _count(count), _peak_count(count)
+  {}
+
+  T* head() const { return _head; }
+  T* tail() const { return _tail; }
+
+  // Remove the topmost element from the freelist; NULL if empty
+  T* take_top() {
+    T* p = _head;
+    if (p != NULL) {
+      _head = Tptr_at(_head);
+      if (_head == NULL) {
+        _tail = NULL;
+      }
+      if (_counting) {
+        assert(_count > 0, "sanity");
+        _count --;
+      }
+      DEBUG_ONLY(set_Tptr_at_null(p);)
+      DEBUG_ONLY(quick_verify();)
+    }
+    return p;
+  }
+
+  void prepend(T* elem) {
+    if (_head == NULL) {
+      assert(!_counting || 0 == _count, "invalid freelist count");
+      _head = _tail = elem;
+      set_Tptr_at_null(_head);
+    } else {
+      assert(!_counting || 0 < _count, "invalid freelist count");
+      set_Tptr_at(elem, _head);
+      _head = elem;
+    }
+    if (_counting) {
+      _count ++;
+      _peak_count = MAX2(_peak_count, _count);
+    }
+    DEBUG_ONLY(quick_verify();)
+  }
+
+  // Take over other list, reset other list
+  void take_elements(FreeList& other) {
+    assert(empty(), "must be empty");
+    if (!other.empty()) {
+      _head = other.head();
+      _tail = other.tail();
+      if (_counting) {
+        _count = other.count();
+        _peak_count = other.peak_count();
+      }
+      other.reset();
+      DEBUG_ONLY(verify();)
+    }
+  }
+
+  // Prepends list items to this list and resets the other list.
+  void prepend_list(FreeList& other) {
+    DEBUG_ONLY(other.quick_verify();)
+    if (!other.empty()) {
+      if (empty()) {
+        take_elements(other);
+      } else {
+        set_Tptr_at(other.tail(), _head);
+        _head = other.head();
+        if (_counting) {
+          _count += other.count();
+          _peak_count = MAX2(_peak_count, _count);
+        }
+        DEBUG_ONLY(verify();)
+        other.reset();
+      }
+    }
+  }
+
+  void prepend_list(T* head, T* tail, uintx count) {
+    FreeList tmp(head, tail, count);
+    add_list_to_front(tmp);
+  }
+
+  // Reset also resets the peak count, so the history is lost.
+  void reset() {
+    _head = _tail = NULL;
+    if (_counting) {
+      _count = _peak_count = 0;
+    }
+  }
+
+  bool empty() const { return _head == NULL; }
+
+  // True if list counts itself
+  bool counting() const       { return _counting; }
+  uintx count() const         { return _count; }      // Note: only if counting
+  uintx peak_count() const    { return _peak_count; } // Note: only if counting
+
+  struct Closure {
+    // return false to stop iterating
+    virtual bool do_it(const T* element) = 0;
+  };
+  // Call Closure.doit(). If that returns false, iteration is cancelled at that point.
+  uintx iterate(Closure& closure) const;
+
+#ifdef ASSERT
+  // paranoid = true: dup check
+  void verify(bool paranoid = false) const;
+#endif
+
+  void print_on(outputStream* st, bool print_elems = false) const;
+
+}; // Freelist
+
+#endif // SHARE_UTILITIES_FREELIST_HPP

--- a/src/hotspot/share/utilities/freeList.inline.hpp
+++ b/src/hotspot/share/utilities/freeList.inline.hpp
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2022 SAP SE. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef SHARE_UTILITIES_FREELIST_INLINE_HPP
+#define SHARE_UTILITIES_FREELIST_INLINE_HPP
+
+#include "utilities/freeList.hpp"
+#include "utilities/globalDefinitions.hpp"
+#include "utilities/ostream.hpp"
+
+class outputStream;
+
+template <class T>
+uintx FreeList<T>::iterate(FreeList<T>::Closure& closure) const {
+  uintx processed = 0;
+  bool go_on = true;
+  for (const T* p = head(); go_on && p != NULL; p = Tptr_at(p)) {
+    processed ++;
+    go_on = closure.do_it(p);
+  }
+  return processed;
+}
+
+#ifdef ASSERT
+template <class T>
+void FreeList<T>::verify(bool paranoid) const {
+
+  STATIC_ASSERT(sizeof(T) >= sizeof(T*));
+
+  quick_verify();
+
+  // Simple verify list and list length. Also call verify_closure if it is set.
+  if (_counting) {
+    uintx counted = 0;
+    for (const T* p = head(); p != NULL; p = Tptr_at(p)) {
+      assert(counted < _count, "too many elements (more than " UINTX_FORMAT ")?", _count);
+      counted ++;
+    }
+    assert(!_counting || _count == counted, "count is off");
+  }
+
+  // In paranoid mode, or if we have know we have fewer than n elements,
+  // we check for duplicates. Slow (O(n^2)/2).
+  if (paranoid || (_counting && _count < 10)) {
+    for (const T* p = head(); p != NULL; p = Tptr_at(p)) {
+      for (const T* p2 = Tptr_at(p); p2 != NULL; p2 = Tptr_at(p2)) {
+        assert(p2 != p, "duplicate in list");
+      }
+    }
+  }
+}
+#endif // ASSERT
+
+template <class T>
+void FreeList<T>::print_on(outputStream* st, bool print_elems) const {
+  if (_counting) {
+    st->print(UINTX_FORMAT " elems (peak: " UINTX_FORMAT " elems)", _count, _peak_count);
+  } else {
+    // No count, do the best we can
+    if (_head == NULL) {
+      st->print("0 elems");
+    } else if (_head == _tail) {
+      st->print("1 elems");
+    } else {
+      st->print(">1 elems");
+    }
+  }
+  if (print_elems) {
+    st->cr();
+    for (const T* p = head(); p != NULL; p = Tptr_at(p)) {
+      st->print(PTR_FORMAT "->", p2i(p));
+    }
+    st->cr();
+  }
+}
+
+#endif // SHARE_UTILITIES_FREELIST_INLINE_HPP

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -43,6 +43,7 @@
 #include "runtime/atomic.hpp"
 #include "runtime/frame.inline.hpp"
 #include "runtime/init.hpp"
+#include "runtime/objectMonitorStorage.hpp"
 #include "runtime/os.hpp"
 #include "runtime/osThread.hpp"
 #include "runtime/safefetch.inline.hpp"
@@ -1077,6 +1078,13 @@ void VMError::report(outputStream* st, bool _verbose) {
        st->cr();
      }
 
+  STEP("printing objmon storage information")
+
+     if (_verbose && Universe::is_fully_initialized()) {
+       st->print_cr("ObjectMonitorStorage:");
+       ObjectMonitorStorage::print(st);
+     }
+
   STEP("printing ring buffers")
 
      if (_verbose) {
@@ -1284,6 +1292,13 @@ void VMError::print_vm_info(outputStream* st) {
     // print code cache information before vm abort
     CodeCache::print_summary(st);
     st->cr();
+  }
+
+  // STEP("printing objmon storage information")
+
+  if (Universe::is_fully_initialized()) {
+    st->print_cr("ObjectMonitorStorage:");
+    ObjectMonitorStorage::print(st);
   }
 
   // STEP("printing ring buffers")

--- a/test/hotspot/gtest/utilities/test_addressStableArray.cpp
+++ b/test/hotspot/gtest/utilities/test_addressStableArray.cpp
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+
+ */
+
+#include "precompiled.hpp"
+
+#include "runtime/os.hpp"
+#include "utilities/addressStableArray.inline.hpp"
+#include "utilities/align.hpp"
+#include "utilities/debug.hpp"
+#include "utilities/globalDefinitions.hpp"
+
+#include "unittest.hpp"
+#include "testutils.hpp"
+
+template <class T>
+static void test_fill_empty_repeat(uintx max_size, uintx initialsize) {
+  AddressStableHeap<T> a1(max_size, initialsize);
+  T** elems = NEW_C_HEAP_ARRAY(T*, max_size, mtTest);
+  memset(elems, 0, sizeof(T*) * max_size);
+  if (initialsize == 0) {
+    ASSERT_EQ(a1.committed_bytes(), (size_t)0);
+  }
+  DEBUG_ONLY(a1.verify();)
+  const size_t fully_committed_size = align_up(sizeof(T) * max_size, os::vm_page_size());
+  for (int cycle = 0; cycle < 3; cycle ++) {
+    // (Re)fill
+    for (uintx i = 0; i < max_size; i ++) {
+      T* p = a1.allocate();
+      if (i < max_size) {
+        ASSERT_NE(p, (T*)NULL);
+        elems[i] = p;
+      }
+    }
+    // We should be right at the limit now
+    ASSERT_EQ(a1.allocate(), (T*)NULL);
+    ASSERT_EQ(a1.committed_bytes(), fully_committed_size);
+    DEBUG_ONLY(a1.verify(true);)
+    // Empty out
+    for (uintx i = 0; i < max_size; i ++) {
+      a1.deallocate(elems[i]);
+    }
+    ASSERT_EQ(a1.committed_bytes(), fully_committed_size);
+    DEBUG_ONLY(a1.verify();)
+  }
+  FREE_C_HEAP_ARRAY(T, elems);
+}
+
+template <class T>
+static void test_fill_empty_randomly(uintx max_size, uintx initialsize) {
+  AddressStableHeap<T> a1(max_size, initialsize);
+  T** elems = NEW_C_HEAP_ARRAY(T*, max_size, mtTest);
+  memset(elems, 0, sizeof(T*) * max_size);
+  DEBUG_ONLY(a1.verify();)
+  for (uintx iter = 0; iter < MIN2(max_size * 4, (uintx)1024); iter ++) {
+    const int idx = os::random() % max_size;
+    if (elems[idx] == NULL) {
+      T* p = a1.allocate();
+      ASSERT_NE(p, (T*)NULL);
+      elems[idx] = p;
+    } else {
+      a1.deallocate(elems[idx]);
+      elems[idx] = NULL;
+    }
+    if ((iter % 256) == 0) {
+      DEBUG_ONLY(a1.verify(iter % 1024 == 0);)
+    }
+  }
+  DEBUG_ONLY(a1.verify(true);)
+  // Now allocate the full complement, just what we think is the container fill grade is right
+  for (uintx i = 0; i < max_size; i++) {
+    if (elems[i] == 0) {
+      T* p = a1.allocate();
+      ASSERT_NE(p, (T*)NULL);
+      elems[i] = p;
+    }
+  }
+  // We should be right at the limit now
+  ASSERT_EQ(a1.allocate(), (T*)NULL);
+  FREE_C_HEAP_ARRAY(T, elems);
+}
+
+template <class T>
+static void run_all_tests(uintx max_capacity, uintx initial_capacity) {
+  test_fill_empty_repeat<T>(max_capacity, initial_capacity);
+  test_fill_empty_randomly<T>(max_capacity, initial_capacity);
+}
+
+template <class T>
+static void run_all_tests() {
+  uintx max_max = (10 * M) / sizeof(T);           // don't use more than 10M in total
+  max_max = MIN2(max_max, (uintx)100000);         // and limit to 100000 entries
+  run_all_tests<T>(1, 0);
+  run_all_tests<T>(10, 0);
+  run_all_tests<T>(max_max, 0);
+  run_all_tests<T>(max_max, max_max/2);
+}
+
+#define test_stable_array(T) \
+TEST_VM(AddressStableArray, fill_empty_repeat_##T) \
+{ \
+	run_all_tests<T>(); \
+}
+
+test_stable_array(uint64_t);
+
+struct s3 { void* p[3]; };
+test_stable_array(s3);
+
+struct s216 { char p[216]; };
+test_stable_array(s216);
+
+// almost, but not quite, a page
+struct almost_one_page { char m[4096 - 8]; };
+test_stable_array(almost_one_page);

--- a/test/hotspot/gtest/utilities/test_addressStableArray.cpp
+++ b/test/hotspot/gtest/utilities/test_addressStableArray.cpp
@@ -34,8 +34,8 @@
 #include "testutils.hpp"
 
 template <class T>
-static void test_fill_empty_repeat(uintx max_size, uintx initialsize) {
-  AddressStableHeap<T> a1(max_size, initialsize);
+static void test_fill_empty_repeat(uintx initialsize, uintx cap_increase, uintx max_size) {
+  AddressStableHeap<T> a1(initialsize, cap_increase, max_size);
   T** elems = NEW_C_HEAP_ARRAY(T*, max_size, mtTest);
   memset(elems, 0, sizeof(T*) * max_size);
   if (initialsize == 0) {
@@ -67,8 +67,8 @@ static void test_fill_empty_repeat(uintx max_size, uintx initialsize) {
 }
 
 template <class T>
-static void test_fill_empty_randomly(uintx max_size, uintx initialsize) {
-  AddressStableHeap<T> a1(max_size, initialsize);
+static void test_fill_empty_randomly(uintx initialsize, uintx cap_increase, uintx max_size) {
+  AddressStableHeap<T> a1(initialsize, cap_increase, max_size);
   T** elems = NEW_C_HEAP_ARRAY(T*, max_size, mtTest);
   memset(elems, 0, sizeof(T*) * max_size);
   DEBUG_ONLY(a1.verify();)
@@ -101,19 +101,21 @@ static void test_fill_empty_randomly(uintx max_size, uintx initialsize) {
 }
 
 template <class T>
-static void run_all_tests(uintx max_capacity, uintx initial_capacity) {
-  test_fill_empty_repeat<T>(max_capacity, initial_capacity);
-  test_fill_empty_randomly<T>(max_capacity, initial_capacity);
+static void run_all_tests(uintx initialsize, uintx cap_increase, uintx max_size) {
+  test_fill_empty_repeat<T>(initialsize, cap_increase, max_size);
+  test_fill_empty_randomly<T>(initialsize, cap_increase, max_size);
 }
 
 template <class T>
 static void run_all_tests() {
   uintx max_max = (10 * M) / sizeof(T);           // don't use more than 10M in total
   max_max = MIN2(max_max, (uintx)100000);         // and limit to 100000 entries
-  run_all_tests<T>(1, 0);
-  run_all_tests<T>(10, 0);
-  run_all_tests<T>(max_max, 0);
-  run_all_tests<T>(max_max, max_max/2);
+  run_all_tests<T>(0, 1, 1);
+  run_all_tests<T>(1, 1, 10);
+  run_all_tests<T>(10, 1, 10);
+  run_all_tests<T>(0, 1, max_max);
+  run_all_tests<T>(0, max_max/100, max_max);
+  run_all_tests<T>(max_max/2, max_max/100, max_max);
 }
 
 #define test_stable_array(T) \

--- a/test/hotspot/gtest/utilities/test_addressStableArray.cpp
+++ b/test/hotspot/gtest/utilities/test_addressStableArray.cpp
@@ -49,7 +49,7 @@ static size_t expected_committed_bytes(uintx elems) {
 
 // Range check for cap. Note range is including on both ends ([])
 #define ASSERT_CAP_IN_RANGE(array, n1, n2)                             \
-	ASSERT_GE(array.capacity(), (uintx)n1);                              \
+  ASSERT_GE(array.capacity(), (uintx)n1);                              \
   ASSERT_LE(array.capacity(), (uintx)n2);                              \
   ASSERT_GE(array.committed_bytes(), expected_committed_bytes<T>(n1)); \
   ASSERT_LE(array.committed_bytes(), expected_committed_bytes<T>(n2)); \
@@ -58,17 +58,17 @@ static size_t expected_committed_bytes(uintx elems) {
 #define ASSERT_FREE(array, n)   ASSERT_EQ(array.free(), (uintx)n)
 
 #define ASSERT_USED_FREE(array, used, free) \
-	  ASSERT_USED(array, used);               \
-	  ASSERT_FREE(array, free);
+    ASSERT_USED(array, used);               \
+    ASSERT_FREE(array, free);
 
 // Test expectation that heap is completely filled. Stats should reflect that.
 // Allocation should return NULL and leave stats unchanged.
 #define ASSERT_ARRAY_IS_FULL(a1)        \
-		ASSERT_USED_FREE(a1, max_size, 0);  \
-		ASSERT_CAP_EQ(a1, max_size);        \
-		ASSERT_EQ(a1.allocate(), (T*)NULL); \
-		ASSERT_USED_FREE(a1, max_size, 0);  \
-		ASSERT_CAP_EQ(a1, max_size);
+    ASSERT_USED_FREE(a1, max_size, 0);  \
+    ASSERT_CAP_EQ(a1, max_size);        \
+    ASSERT_EQ(a1.allocate(), (T*)NULL); \
+    ASSERT_USED_FREE(a1, max_size, 0);  \
+    ASSERT_CAP_EQ(a1, max_size);
 
 // Allocate from array a single element, and if not null, stamp it
 template <class T> T* allocate_from_array(AddressStableHeap<T>& a) {
@@ -280,8 +280,8 @@ static const size_t max_memory = 10 * M; // a single test should not use more th
 #define TEST_single(T, function, initialsize, max_size)                         \
 TEST_VM(AddressStableArray, function##_##T##_##initialsize##_##max_size)        \
 {                                                                               \
-	ASSERT_LT(expected_committed_bytes<T>(max_size), max_memory);                 \
-	function<T>(initialsize, max_size);                                           \
+  ASSERT_LT(expected_committed_bytes<T>(max_size), max_memory);                 \
+  function<T>(initialsize, max_size);                                           \
 }
 
 #define TEST_all_functions(T, initialsize, max_size)                            \
@@ -290,17 +290,17 @@ TEST_VM(AddressStableArray, function##_##T##_##initialsize##_##max_size)        
   TEST_single(T, test_commit_and_uncommit, initialsize, max_size)
 
 #define TEST_all_functions_small_sizes(T)                                       \
-		TEST_all_functions(T, 0, 1)                                                 \
-    TEST_all_functions(T, 1, 1)                                                 \
-    TEST_all_functions(T, 0, 100)                                               \
-    TEST_all_functions(T, 10, 100)
+  TEST_all_functions(T, 0, 1)                                                   \
+  TEST_all_functions(T, 1, 1)                                                   \
+  TEST_all_functions(T, 0, 100)                                                 \
+  TEST_all_functions(T, 10, 100)
 
 
 // This we only execute for small types
 #define TEST_all_functions_all_sizes(T)                                         \
-		TEST_all_functions_small_sizes(T)                                           \
-		TEST_all_functions(T, 0, 10000)                                             \
-		TEST_all_functions(T, 1000, 10000)
+  TEST_all_functions_small_sizes(T)                                             \
+  TEST_all_functions(T, 0, 10000)                                               \
+  TEST_all_functions(T, 1000, 10000)
 
 struct s3 { void* p[3]; };
 

--- a/test/hotspot/gtest/utilities/test_addressStableArray.cpp
+++ b/test/hotspot/gtest/utilities/test_addressStableArray.cpp
@@ -87,7 +87,7 @@ static size_t expected_committed_bytes(uintx elems) {
     ASSERT_CAP_EQ(a1, max_size);
 
 // Allocate from array a single element, and if not null, stamp it
-template <class T> T* allocate_from_array(AddressStableHeap<T>& a) {
+template <class T> T* allocate_from_array(AddressStableArrayWithFreeList<T>& a) {
   T* p = a.allocate();
   if (p != NULL) {
     GtestUtils::mark_range(p, sizeof(T));
@@ -96,7 +96,7 @@ template <class T> T* allocate_from_array(AddressStableHeap<T>& a) {
 }
 
 // Return an element to the array. Before doing that, check stamp.
-template <class T> void deallocate_to_array(AddressStableHeap<T>& a, T* elem) {
+template <class T> void deallocate_to_array(AddressStableArrayWithFreeList<T>& a, T* elem) {
   ASSERT_TRUE(GtestUtils::check_range(elem, sizeof(T)));
   a.deallocate(elem);
 }
@@ -112,7 +112,7 @@ public:
 };
 
 template <class T>
-static void test_fill_empty_repeat(AddressStableHeap<T>& a1, uintx initialsize, uintx max_size) {
+static void test_fill_empty_repeat(AddressStableArrayWithFreeList<T>& a1, uintx initialsize, uintx max_size) {
 
   ASSERT_USED_FREE(a1, 0, 0);
   ASSERT_CAP_IN_RANGE(a1, initialsize, max_size);
@@ -165,7 +165,7 @@ static void test_fill_empty_repeat(AddressStableHeap<T>& a1, uintx initialsize, 
 }
 
 template <class T>
-static void test_fill_empty_randomly(AddressStableHeap<T>& a1, uintx initialsize, uintx max_size) {
+static void test_fill_empty_randomly(AddressStableArrayWithFreeList<T>& a1, uintx initialsize, uintx max_size) {
 
   ASSERT_USED_FREE(a1, 0, 0);
   ASSERT_CAP_IN_RANGE(a1, initialsize, max_size);
@@ -225,7 +225,7 @@ static void test_fill_empty_randomly(AddressStableHeap<T>& a1, uintx initialsize
 }
 
 template <class T>
-static void test_commit_and_uncommit(AddressStableHeap<T>& a1, uintx initialsize, uintx max_size) {
+static void test_commit_and_uncommit(AddressStableArrayWithFreeList<T>& a1, uintx initialsize, uintx max_size) {
 
   ASSERT_USED_FREE(a1, 0, 0);
   ASSERT_CAP_IN_RANGE(a1, initialsize, max_size);
@@ -295,7 +295,7 @@ static void test_commit_and_uncommit(AddressStableHeap<T>& a1, uintx initialsize
 TEST_VM(AddressStableArray, function##_##T##_##initialsize##_##max_size)        \
 {                                                                               \
   MemoryReserver<T> reserver(max_size);                                         \
-  AddressStableHeap<T> a(reserver.elements(), initialsize, max_size);           \
+  AddressStableArrayWithFreeList<T> a(reserver.elements(), initialsize, max_size);           \
   function<T>(a, initialsize, max_size);                                        \
 }
 

--- a/test/hotspot/gtest/utilities/test_addressStableArray.cpp
+++ b/test/hotspot/gtest/utilities/test_addressStableArray.cpp
@@ -295,7 +295,8 @@ static void test_commit_and_uncommit(AddressStableArrayWithFreeList<T>& a1, uint
 TEST_VM(AddressStableArray, function##_##T##_##initialsize##_##max_size)        \
 {                                                                               \
   MemoryReserver<T> reserver(max_size);                                         \
-  AddressStableArrayWithFreeList<T> a(reserver.elements(), initialsize, max_size);           \
+  AddressStableArrayWithFreeList<T> a;                                          \
+  a.initialize(reserver.elements(), initialsize, max_size);                     \
   function<T>(a, initialsize, max_size);                                        \
 }
 

--- a/test/hotspot/gtest/utilities/test_freelist.cpp
+++ b/test/hotspot/gtest/utilities/test_freelist.cpp
@@ -1,0 +1,272 @@
+/*
+ * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+
+ */
+
+#include "precompiled.hpp"
+
+#include "runtime/os.hpp"
+#include "utilities/freeList.inline.hpp"
+#include "utilities/debug.hpp"
+#include "utilities/globalDefinitions.hpp"
+#include "utilities/ostream.hpp"
+
+#include "unittest.hpp"
+#include "testutils.hpp"
+
+#define ASSERT_LIST_COUNT(list, n)            \
+  if (list.counting()) {                      \
+    ASSERT_EQ(list.count(), (uintx)n);        \
+  }
+
+#define ASSERT_LIST_PEAK(list, n)             \
+  if (list.counting()) {                      \
+    ASSERT_EQ(list.peak_count(), (uintx)n);   \
+  }
+
+#define ASSERT_LIST_EMPTY(list)    \
+  ASSERT_TRUE(list.empty());       \
+  ASSERT_LIST_COUNT(list, 0)
+
+template <class T>
+static void prepend_all_with_checks(FreeList<T>& list, T* elems, int num, int expected_start_count) {
+  ASSERT_LIST_COUNT(list, expected_start_count);
+  if (expected_start_count == 0) {
+    ASSERT_TRUE(list.empty());
+  }
+  for (int i = 0; i < num; i ++) {
+    list.prepend(elems + i);
+    ASSERT_LIST_COUNT(list, expected_start_count + i + 1);
+    ASSERT_FALSE(list.empty());
+  }
+}
+
+template <class T>
+static void safely_print_list(FreeList<T>& list) {
+  char tmp[1024];
+  stringStream ss(tmp, sizeof(tmp));
+  list.print_on(&ss, true);
+  printf("%s\n", tmp);
+}
+
+
+#define NUM_ELEMS 30
+
+template <class T>
+static void test_empty_list() {
+  FreeList<T> list;
+  ASSERT_LIST_EMPTY(list);
+  DEBUG_ONLY(list.verify(true);)
+}
+
+template <class T>
+static void prepare_new_list_with_checks(FreeList<T>& list, T* elems) {
+  prepend_all_with_checks(list, elems, NUM_ELEMS, 0);
+  ASSERT_LIST_COUNT(list, NUM_ELEMS);
+  ASSERT_LIST_PEAK(list, NUM_ELEMS);
+  DEBUG_ONLY(list.verify(true);)
+}
+
+template <class T>
+static void test_single_prepend() {
+
+  FreeList<T> list;
+  ASSERT_LIST_EMPTY(list);
+  DEBUG_ONLY(list.verify(true);)
+
+  T t[NUM_ELEMS];
+  prepare_new_list_with_checks<T>(list, t);
+
+  for (int i = NUM_ELEMS - 1; i >= 0; i --) {
+    T* p = list.take_top();
+    ASSERT_EQ(p, t + i);
+    ASSERT_LIST_COUNT(list, i);
+  }
+  ASSERT_LIST_EMPTY(list);
+  ASSERT_LIST_PEAK(list, NUM_ELEMS);
+  DEBUG_ONLY(list.verify(true);)
+}
+
+template <class T, int max_expected>
+struct TestIterator : public FreeList<T>::Closure {
+
+  const T* t[max_expected];
+  const int _stop_after;
+  int _found;
+
+  TestIterator(int stop_after = max_expected * 2)
+    : _stop_after(stop_after),
+      _found(0)
+  {
+    for (int i = 0; i < max_expected; i ++) {
+      t[i] = NULL;
+    }
+  }
+
+  bool do_it(const T* p) override {
+    if (_found == max_expected) {
+     return false;
+    }
+    t[_found] = p;
+    _found ++;
+    return _found < _stop_after;
+  }
+
+};
+
+template <class T>
+static void test_iteration(bool premature_stop) {
+
+  FreeList<T> list;
+  ASSERT_LIST_EMPTY(list);
+  DEBUG_ONLY(list.verify(true);)
+
+  T t[NUM_ELEMS];
+  prepare_new_list_with_checks<T>(list, t);
+
+  const int stop_after = premature_stop ? 3 : INT_MAX;
+  const int expected_stop_at = premature_stop ? 3 : NUM_ELEMS;
+  TestIterator<T, NUM_ELEMS> it(stop_after);
+
+  ASSERT_EQ(list.iterate(it), (uintx)expected_stop_at);
+  ASSERT_EQ(it._found, expected_stop_at);
+  for (int i = 0; i < NUM_ELEMS; i++) {
+//safely_print_list<T>(list);
+    if (i < expected_stop_at) {
+      ASSERT_EQ(it.t[i], t + (NUM_ELEMS - i - 1)) << i; // we prepended, so FIFO
+    } else {
+      ASSERT_NULL(it.t[i]) << i;
+    }
+  }
+}
+
+template <class T>
+static void test_iteration_full()         { test_iteration<T>(false); }
+
+template <class T>
+static void test_iteration_interrupted()  { test_iteration<T>(true); }
+
+template <class T>
+static void test_reset() {
+  FreeList<T> list;
+
+  T t[NUM_ELEMS];
+  prepare_new_list_with_checks<T>(list, t);
+
+  list.reset();
+  ASSERT_LIST_EMPTY(list);
+  ASSERT_LIST_PEAK(list, 0); // Reset also should reset peak
+  DEBUG_ONLY(list.verify(true);)
+}
+
+template <class T>
+static void test_take_over() {
+  FreeList<T> list1;
+  ASSERT_LIST_EMPTY(list1);
+
+  FreeList<T> list2;
+  T t[NUM_ELEMS];
+  prepare_new_list_with_checks<T>(list2, t);
+
+  list1.take_elements(list2);
+  ASSERT_LIST_EMPTY(list2);
+  ASSERT_LIST_COUNT(list1, NUM_ELEMS);
+  ASSERT_LIST_PEAK(list1, NUM_ELEMS);
+}
+
+template <class T>
+static void test_prepend_list(bool empty_receiver, bool empty_donor) {
+  FreeList<T> list1;
+  FreeList<T> list2;
+
+  T t1[NUM_ELEMS];
+  uintx num1 = 0;
+  T t2[NUM_ELEMS];
+  uintx num2 = 0;
+
+  if (!empty_receiver) {
+    prepare_new_list_with_checks<T>(list1, t1);
+    num1 = NUM_ELEMS;
+  }
+
+  if (!empty_donor) {
+    prepare_new_list_with_checks<T>(list2, t2);
+    num2 = NUM_ELEMS;
+  }
+
+  list1.prepend_list(list2);
+  ASSERT_LIST_COUNT(list1, num1 + num2);
+  ASSERT_LIST_PEAK(list1, num1 + num2);
+  DEBUG_ONLY(list1.verify(true);)
+
+  ASSERT_LIST_EMPTY(list2);
+  DEBUG_ONLY(list2.verify(true);)
+
+  // Prepends prepends the list2 elems in front of list1
+  // and since prepare_new_list_with_checks also prepends the individual
+  // elements, we expect elements to be in inverse address order
+  for (int i = num2 - 1; i >= 0; i --) {
+    T* p = list1.take_top();
+    ASSERT_EQ(p, t2 + i);
+    ASSERT_LIST_COUNT(list1, num1 + i);
+  }
+
+  for (int i = num1 - 1; i >= 0; i --) {
+    T* p = list1.take_top();
+    ASSERT_EQ(p, t1 + i);
+    ASSERT_LIST_COUNT(list1, i);
+  }
+
+  ASSERT_LIST_COUNT(list1, 0);
+  ASSERT_LIST_PEAK(list1, num1 + num2);
+  DEBUG_ONLY(list1.verify(true);)
+}
+
+template <class T> static void test_prepend_list_both_empty()     { test_prepend_list<T>(true, true); }
+template <class T> static void test_prepend_list_both_nonempty()  { test_prepend_list<T>(false, false); }
+template <class T> static void test_prepend_list_receiver_empty() { test_prepend_list<T>(true, false); }
+template <class T> static void test_prepend_list_donor_empty()    { test_prepend_list<T>(false, true); }
+
+#define DO_ONE_TEST(T, testname)      \
+TEST(FreeList, test_##testname##_##T) \
+{                                     \
+  testname<T>();                      \
+}
+
+#define DO_ALL_TESTS(T)                               \
+  DO_ONE_TEST(T, test_empty_list)                     \
+  DO_ONE_TEST(T, test_single_prepend)                 \
+  DO_ONE_TEST(T, test_reset)                          \
+  DO_ONE_TEST(T, test_prepend_list_both_empty)        \
+  DO_ONE_TEST(T, test_prepend_list_both_nonempty)     \
+  DO_ONE_TEST(T, test_prepend_list_receiver_empty)    \
+  DO_ONE_TEST(T, test_prepend_list_donor_empty)       \
+  DO_ONE_TEST(T, test_iteration_full)                 \
+  DO_ONE_TEST(T, test_iteration_interrupted)          \
+
+DO_ALL_TESTS(uint64_t);
+
+struct s3 { void* p[3]; };
+DO_ALL_TESTS(s3);
+
+struct s216 { char p[216]; };
+DO_ALL_TESTS(s216);

--- a/test/hotspot/gtest/utilities/test_freelist.cpp
+++ b/test/hotspot/gtest/utilities/test_freelist.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022 SAP SE. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/gtest/utilities/test_freelist.cpp
+++ b/test/hotspot/gtest/utilities/test_freelist.cpp
@@ -33,15 +33,13 @@
 #include "unittest.hpp"
 #include "testutils.hpp"
 
-#define ASSERT_LIST_COUNT(list, n)            \
-  if (list.counting()) {                      \
-    ASSERT_EQ(list.count(), (uintx)n);        \
-  }
+#define ASSERT_LIST_COUNT(list, n) ASSERT_EQ(list.count(), (uintx)n);
 
-#define ASSERT_LIST_PEAK(list, n)             \
-  if (list.counting()) {                      \
-    ASSERT_EQ(list.peak_count(), (uintx)n);   \
-  }
+#ifdef ASSERT
+#define ASSERT_LIST_PEAK(list, n)  ASSERT_EQ(list.peak_count(), (uintx)n);
+#else
+#define ASSERT_LIST_PEAK(list, n)
+#endif
 
 #define ASSERT_LIST_EMPTY(list)    \
   ASSERT_TRUE(list.empty());       \

--- a/test/hotspot/jtreg/serviceability/jvmti/SuspendWithRawMonitorEnter/SuspendWithRawMonitorEnter.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/SuspendWithRawMonitorEnter/SuspendWithRawMonitorEnter.java
@@ -28,7 +28,7 @@
  * @requires vm.jvmti
  * @library /test/lib
  * @compile SuspendWithRawMonitorEnter.java
- * @run main/othervm/native -agentlib:SuspendWithRawMonitorEnter SuspendWithRawMonitorEnter
+ * @run main/othervm/native -XX:+ErrorFileToStdout -agentlib:SuspendWithRawMonitorEnter SuspendWithRawMonitorEnter
  */
 
 import java.io.PrintStream;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/Allocate/alloc001/alloc001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/Allocate/alloc001/alloc001.java
@@ -85,6 +85,7 @@ public class alloc001 {
                 "-Djava.library.path=" + Utils.TEST_NATIVE_PATH,
                 "-agentpath:" + Utils.TEST_NATIVE_PATH + File.separator + System.mapLibraryName("alloc001"),
                 "-XX:CompressedClassSpaceSize=64m",
+                "-XX:MonitorStorageSize=64m",
                 Test.class.getName()
         ));
         cmd = escapeCmd(cmd);


### PR DESCRIPTION
Hi,

This prepares the way for an idea Roman had last year: to store OM references in a compressed form in the header, instead of as 64-bit pointer. Similar to narrow Klass pointers, we need an index or an offset into a memory region.

With this patch, OMs live in an array now. That new OM array is pre-reserved, gets committed on demand, has a freelist to manage released OMs. In a way, it is very similar to the old TSM solution before [JDK-8253064](https://bugs.openjdk.java.net/browse/JDK-8253064). Thanks a lot to @dcubed-ojdk for patiently explaining the details of the old solution to me([1], [2], [3]).

### Performance and memory use

I found that the renaissance "philosophers" benchmark is a good tool for measuring ObjectMonitor memory usage and performance. The benchmark, if you run with default VM options, does a lot of synchronization and creates millions of OMs. Running with a lower value for `-XX:MonitorUsedDeflationThreshold` diminishes the effect, and according to Dan [3] it would be a typical case for threshold reduction too.

This is not a typical use case. Typically we have only a few thousand OMs, and OM storage management does not matter that much. But we don't want huge performance drops in these outlier scenarios.

The first version of my patch was very naive and used a single global allocator and synchronized each access. Performance loss was brutal, about 15% compared to malloc.

I improved the patch to reduce contention:
- OMs are now preallocated in bulk on a per thread base (by default, 64, adjustable via `-XX:PreallocatedObjectMonitors`).
- OMs are released in bulk by preparing the OM freelist off-lock and only drawing the lock when appending the list to the central free list.

Again, all somewhat similar to the old TSM solution.

The improved version now has similar or even better performance and memory use than the stock VM, see below.

#### Measurements

Running renaissance philosphers benchmark with both Stock (Lilliput) VM and patched lilliput VM.

Options: `-XX:+UnlockDiagnosticVMOptions -Xmx2g -Xms2g -XX:NativeMemoryTracking=summary -XX:+PrintNMTStatistics -XX:+DumpVitalsAtExit`

We compare two allocators, one outside our control, in the libc. So I measure RSS, not Committed memory use, because I have no idea how much memory the libc commits in order to fulfill its mallocs. It may actually be a lot - to prevent contention, at least the glibc uses thread local arenas, which can get huge but are often mostly unused.

For the same reason I do not use `AlwaysPretouch`: we would pretouch committed mmaped memory in the patched version, but neither os::malloc() nor whatever overhead the libc produces would be touched. `AlwaysPretouch` would hence bias against stock. 

The performance numbers and RSS numbers wobbled a bit, but the following run is average (smaller numbers better):

##### Default run (`-XX:MonitorUsedDeflationThreshold=90`, `-XX:PreallocatedObjectMonitors=64`)

1) Stock

Benchmark result: 	4333,61537
Highest rss: 		3,7g

2) New ObjectMonitorStorage

Benchmark result: 	4122,14034 (+4.9%)
Highest rss: 		3,7g


##### Run with `-XX:MonitorUsedDeflationThreshold=50`

1) Stock

Benchmark result: 	4202,40876
Highest rss: 		rss=2,1g

2) New ObjectMonitorStorage

Benchmark result: 	4142,66361 (+1.4%)
Highest rss: 		1.9g (-9%)


##### Run with `-XX:PreallocatedObjectMonitors=1024`

2) New ObjectMonitorStorage

Benchmark result: 	4322,59806 (-2.8%)
Highest rss: 		3.5g (+66%)

#### Analysis

Patched version uses a bit less RSS and is 1..5% faster than unpatched version.

Enlarging the number of thread local preallocated OMs to 1024 was not so hot. Reduced contention comes at a high memory price and an actual performance loss too. There is an optimal point, maybe even the default of 64 is too high. I ran out of time though, but this is certainly a knob to optimize.

I suspect that if we go down this road, we'll need to spend more time optimizing memory and performance of OM storage. Even though my results are encouraging. But this is an area where a lot of tweaking happened upstream over time.

### Patch details:

The patch introduces the general-purpose classes `AddressStableArray`. A templatified array that is pre-reserved, is address stable, contiguous, committed on demand, keeps a freelist of released items. Code is well tested (see the new gtests) and can serve as building block for similar uses. E.g. Roman played with the idea of placing Thread into such an array too.

### What this patch does not:

This patch does not change the way OMs are stored in the markword. I had a quick glance, but its not trivial to find all places in generated code that read OMs from the mark word (e.g. `C2_MacroAssembler::rtm_inflated_locking`). I ran out of time and leave this for another day.

### Tests:

- GHAs
- SAP nightlies (scheduled)
- manual test on Linux X64, x86, aarch64, Windows x64

[1] https://mail.openjdk.java.net/pipermail/hotspot-runtime-dev/2022-January/053683.html
[2] https://mail.openjdk.java.net/pipermail/hotspot-runtime-dev/2022-February/053903.html
[3] https://mail.openjdk.java.net/pipermail/hotspot-runtime-dev/2022-March/054187.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/lilliput pull/39/head:pull/39` \
`$ git checkout pull/39`

Update a local copy of the PR: \
`$ git checkout pull/39` \
`$ git pull https://git.openjdk.java.net/lilliput pull/39/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 39`

View PR using the GUI difftool: \
`$ git pr show -t 39`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/lilliput/pull/39.diff">https://git.openjdk.java.net/lilliput/pull/39.diff</a>

</details>
