### PR TITLE
JVMTI: Don't use object header for marking

### DIFF
--- a/src/hotspot/share/gc/shared/collectedHeap.cpp
+++ b/src/hotspot/share/gc/shared/collectedHeap.cpp
@@ -38,6 +38,7 @@
 #include "gc/shared/gcWhen.hpp"
 #include "gc/shared/gc_globals.hpp"
 #include "gc/shared/memAllocator.hpp"
+#include "gc/shared/objectMarker.hpp"
 #include "gc/shared/tlab_globals.hpp"
 #include "logging/log.hpp"
 #include "logging/logStream.hpp"
@@ -47,7 +48,6 @@
 #include "memory/universe.hpp"
 #include "oops/instanceMirrorKlass.hpp"
 #include "oops/oop.inline.hpp"
-#include "prims/jvmtiTagMap.hpp"
 #include "runtime/handles.inline.hpp"
 #include "runtime/init.hpp"
 #include "runtime/perfData.hpp"
@@ -587,7 +587,6 @@ void CollectedHeap::initialize_reserved_region(const ReservedHeapSpace& rs) {
 void CollectedHeap::post_initialize() {
   StringDedup::initialize();
   initialize_serviceability();
-  ObjectMarker::initialize(_reserved);
 }
 
 #ifndef PRODUCT
@@ -652,4 +651,12 @@ uint32_t CollectedHeap::hash_oop(oop obj) const {
 void CollectedHeap::update_capacity_and_used_at_gc() {
   _capacity_at_last_gc = capacity();
   _used_at_last_gc     = used();
+}
+
+ObjectMarker* CollectedHeap::init_object_marker() {
+  if (UseBitmapObjectMarker) {
+    return new BitmapObjectMarker(_reserved);
+  } else {
+    return new HeaderObjectMarker();
+  }
 }

--- a/src/hotspot/share/gc/shared/collectedHeap.cpp
+++ b/src/hotspot/share/gc/shared/collectedHeap.cpp
@@ -47,6 +47,7 @@
 #include "memory/universe.hpp"
 #include "oops/instanceMirrorKlass.hpp"
 #include "oops/oop.inline.hpp"
+#include "prims/jvmtiTagMap.hpp"
 #include "runtime/handles.inline.hpp"
 #include "runtime/init.hpp"
 #include "runtime/perfData.hpp"
@@ -586,6 +587,7 @@ void CollectedHeap::initialize_reserved_region(const ReservedHeapSpace& rs) {
 void CollectedHeap::post_initialize() {
   StringDedup::initialize();
   initialize_serviceability();
+  ObjectMarker::initialize(_reserved);
 }
 
 #ifndef PRODUCT

--- a/src/hotspot/share/gc/shared/collectedHeap.hpp
+++ b/src/hotspot/share/gc/shared/collectedHeap.hpp
@@ -54,6 +54,8 @@ class GCTracer;
 class GCMemoryManager;
 class MemoryPool;
 class MetaspaceSummary;
+class ObjectMarker;
+class ObjectMarkerController;
 class ReservedHeapSpace;
 class SoftRefPolicy;
 class Thread;
@@ -96,6 +98,7 @@ class CollectedHeap : public CHeapObj<mtGC> {
   friend class IsGCActiveMark; // Block structured external access to _is_gc_active
   friend class MemAllocator;
   friend class ParallelObjectIterator;
+  friend class ObjectMarkerController;
 
  private:
   GCHeapLog* _gc_heap_log;
@@ -426,6 +429,8 @@ class CollectedHeap : public CHeapObj<mtGC> {
   void full_gc_dump(GCTimer* timer, bool before);
 
   virtual void initialize_serviceability() = 0;
+
+  virtual ObjectMarker* init_object_marker();
 
  public:
   void pre_full_gc_dump(GCTimer* timer);

--- a/src/hotspot/share/gc/shared/gc_globals.hpp
+++ b/src/hotspot/share/gc/shared/gc_globals.hpp
@@ -693,7 +693,11 @@
   product(uint, GCCardSizeInBytes, 512,                                     \
           "Card table entry size (in bytes) for card based collectors")     \
           range(128, NOT_LP64(512) LP64_ONLY(1024))                         \
-          constraint(GCCardSizeInBytesConstraintFunc,AtParse)
+          constraint(GCCardSizeInBytesConstraintFunc,AtParse)               \
+                                                                            \
+  develop(bool, UseBitmapObjectMarker, false,                               \
+          "Use bitmap based ObjectMarker")                                  \
+
   // end of GC_FLAGS
 
 DECLARE_FLAGS(GC_FLAGS)

--- a/src/hotspot/share/gc/shared/objectMarker.cpp
+++ b/src/hotspot/share/gc/shared/objectMarker.cpp
@@ -78,7 +78,7 @@ public:
 HeaderObjectMarker::HeaderObjectMarker() :
  _saved_oop_stack(new (ResourceObj::C_HEAP, mtGC) GrowableArray<oop>(4000, mtGC)),
  _saved_mark_stack(new (ResourceObj::C_HEAP, mtGC) GrowableArray<markWord>(4000, mtGC)),
- _needs_reset(true) {
+ _needs_reset(false) {
 }
 
 // object marking done, so restore headers

--- a/src/hotspot/share/gc/shared/objectMarker.cpp
+++ b/src/hotspot/share/gc/shared/objectMarker.cpp
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "gc/shared/collectedHeap.hpp"
+#include "gc/shared/markBitMap.inline.hpp"
+#include "gc/shared/objectMarker.hpp"
+#include "logging/log.hpp"
+#include "memory/virtualspace.hpp"
+#include "memory/universe.hpp"
+#include "oops/klass.hpp"
+#include "oops/markWord.hpp"
+#include "oops/oop.inline.hpp"
+#include "runtime/os.hpp"
+#include "utilities/growableArray.hpp"
+
+ObjectMarker* ObjectMarkerController::_marker = NULL;
+
+ObjectMarkerController::ObjectMarkerController() {
+  // prepare heap for iteration
+  CollectedHeap* heap = Universe::heap();
+  heap->ensure_parsability(false);  // no need to retire TLABs
+  _marker = heap->init_object_marker();
+}
+
+ObjectMarkerController::~ObjectMarkerController() {
+  delete _marker;
+  _marker = NULL;
+}
+
+void ObjectMarkerController::mark(oop o) {
+  assert(_marker != NULL, "need object marker");
+  _marker->mark(o);
+}
+
+bool ObjectMarkerController::is_marked(oop o) {
+  assert(_marker != NULL, "need object marker");
+  return _marker->is_marked(o);
+}
+
+void ObjectMarkerController::set_needs_reset(bool needs_reset) {
+  assert(_marker != NULL, "need object marker");
+  return _marker->set_needs_reset(needs_reset);
+}
+
+class RestoreMarksClosure : public ObjectClosure {
+public:
+  void do_object(oop o) {
+    if (o != NULL) {
+      markWord mark = o->mark();
+      if (mark.is_marked()) {
+        o->init_mark();
+      }
+    }
+  }
+};
+
+HeaderObjectMarker::HeaderObjectMarker() :
+ _saved_oop_stack(new (ResourceObj::C_HEAP, mtGC) GrowableArray<oop>(4000, mtGC)),
+ _saved_mark_stack(new (ResourceObj::C_HEAP, mtGC) GrowableArray<markWord>(4000, mtGC)),
+ _needs_reset(true) {
+}
+
+// object marking done, so restore headers
+HeaderObjectMarker::~HeaderObjectMarker() {
+  // iterate over all objects and restore the mark bits to
+  // their initial value
+  RestoreMarksClosure blk;
+  if (_needs_reset) {
+    Universe::heap()->object_iterate(&blk);
+  }
+
+  // Now restore the interesting headers
+  for (int i = 0; i < _saved_oop_stack->length(); i++) {
+    oop o = _saved_oop_stack->at(i);
+    markWord mark = _saved_mark_stack->at(i);
+    o->set_mark(mark);
+  }
+
+  // free the stacks
+  delete _saved_oop_stack;
+  delete _saved_mark_stack;
+}
+
+void HeaderObjectMarker::set_needs_reset(bool needs_reset) {
+  _needs_reset = needs_reset;
+}
+
+// mark an object
+void HeaderObjectMarker::mark(oop o) {
+  assert(Universe::heap()->is_in(o), "sanity check");
+  assert(!o->mark().is_marked(), "should only mark an object once");
+
+  // object's mark word
+  markWord mark = o->mark();
+
+  if (o->mark_must_be_preserved(mark)) {
+    _saved_mark_stack->push(mark);
+    _saved_oop_stack->push(o);
+  }
+
+  // mark the object
+  o->set_mark(o->klass()->prototype_header().set_marked());
+}
+
+// return true if object is marked
+bool HeaderObjectMarker::is_marked(oop o) {
+  return o->mark().is_marked();
+}
+
+BitmapObjectMarker::BitmapObjectMarker(MemRegion heap_region) :
+  _mark_bit_map(),
+  _bitmap_region() {
+  size_t bitmap_size = MarkBitMap::compute_size(heap_region.byte_size());
+  ReservedSpace bitmap(bitmap_size);
+  _bitmap_region = MemRegion((HeapWord*) bitmap.base(), bitmap.size() / HeapWordSize);
+  _mark_bit_map.initialize(heap_region, _bitmap_region);
+
+  os::commit_memory_or_exit((char*)_bitmap_region.start(), _bitmap_region.byte_size(), false,
+                          "Could not commit native memory for auxiliary marking bitmap for JVMTI object marking");
+  _mark_bit_map.clear();
+}
+
+BitmapObjectMarker::~BitmapObjectMarker() {
+  if (!os::uncommit_memory((char*)_bitmap_region.start(), _bitmap_region.byte_size())) {
+    log_warning(gc)("Could not uncommit native memory for auxiliary marking bitmap for JVMTI object marking");
+  }
+}
+
+void BitmapObjectMarker::mark(oop o) {
+  assert(Universe::heap()->is_in(o), "sanity check");
+  assert(!is_marked(o), "should only mark an object once");
+  _mark_bit_map.mark(o);
+}
+
+bool BitmapObjectMarker::is_marked(oop o) {
+  assert(Universe::heap()->is_in(o), "sanity check");
+  return _mark_bit_map.is_marked(o);
+}

--- a/src/hotspot/share/gc/shared/objectMarker.hpp
+++ b/src/hotspot/share/gc/shared/objectMarker.hpp
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef SHARE_GC_SHARED_OBJECTMARKER_HPP
+#define SHARE_GC_SHARED_OBJECTMARKER_HPP
+
+#include "gc/shared/markBitMap.hpp"
+#include "memory/allocation.hpp"
+#include "oops/oopsHierarchy.hpp"
+
+// ObjectMarker is used to support the marking objects when walking the
+// heap.
+class ObjectMarker : public CHeapObj<mtGC>{
+public:
+  virtual ~ObjectMarker() {};
+  virtual void mark(oop o) = 0;
+  virtual bool is_marked(oop o) = 0;
+
+  virtual void set_needs_reset(bool needs_reset) {};
+};
+
+// Stack allocated class to help ensure that ObjectMarker is used
+// correctly. Constructor initializes ObjectMarker, destructor calls
+// ObjectMarker's done() function to restore object headers.
+class ObjectMarkerController : public StackObj {
+private:
+  static ObjectMarker* _marker;
+public:
+  ObjectMarkerController();
+  ~ObjectMarkerController();
+
+  static void mark(oop o);
+  static bool is_marked(oop o);
+
+  static void set_needs_reset(bool needs_reset);
+};
+
+// ObjectMarker is used to support the marking objects when walking the
+// heap.
+//
+// This implementation uses the existing mark bits in an object for
+// marking. Objects that are marked must later have their headers restored.
+// As most objects are unlocked and don't have their identity hash computed
+// we don't have to save their headers. Instead we save the headers that
+// are "interesting". Later when the headers are restored this implementation
+// restores all headers to their initial value and then restores the few
+// objects that had interesting headers.
+//
+// Future work: This implementation currently uses growable arrays to save
+// the oop and header of interesting objects. As an optimization we could
+// use the same technique as the GC and make use of the unused area
+// between top() and end().
+class HeaderObjectMarker : public ObjectMarker {
+private:
+  GrowableArray<oop>* _saved_oop_stack;
+  GrowableArray<markWord>* _saved_mark_stack;
+  bool _needs_reset;
+public:
+  HeaderObjectMarker();
+  ~HeaderObjectMarker();
+  void mark(oop o) override;
+  bool is_marked(oop o) override;
+  void set_needs_reset(bool needs_reset) override;
+};
+
+// Implementation that uses a bitmap.
+class BitmapObjectMarker : public ObjectMarker {
+private:
+  MarkBitMap _mark_bit_map;
+  MemRegion  _bitmap_region;
+public:
+  BitmapObjectMarker(MemRegion heap_region);
+  ~BitmapObjectMarker();
+
+  void mark(oop o) override;
+  bool is_marked(oop o) override;
+};
+
+#endif // SHARE_GC_SHARED_OBJECTMARKER_HPP

--- a/src/hotspot/share/prims/jvmtiTagMap.cpp
+++ b/src/hotspot/share/prims/jvmtiTagMap.cpp
@@ -28,8 +28,7 @@
 #include "classfile/symbolTable.hpp"
 #include "classfile/vmClasses.hpp"
 #include "classfile/vmSymbols.hpp"
-#include "gc/shared/collectedHeap.hpp"
-#include "gc/shared/markBitMap.inline.hpp"
+#include "gc/shared/objectMarker.hpp"
 #include "jvmtifiles/jvmtiEnv.hpp"
 #include "logging/log.hpp"
 #include "memory/allocation.inline.hpp"
@@ -1332,97 +1331,6 @@ jvmtiError JvmtiTagMap::get_objects_with_tags(const jlong* tags,
   return collector.result(count_ptr, object_result_ptr, tag_result_ptr);
 }
 
-
-// ObjectMarker is used to support the marking objects when walking the
-// heap.
-//
-// This implementation uses the existing mark bits in an object for
-// marking. Objects that are marked must later have their headers restored.
-// As most objects are unlocked and don't have their identity hash computed
-// we don't have to save their headers. Instead we save the headers that
-// are "interesting". Later when the headers are restored this implementation
-// restores all headers to their initial value and then restores the few
-// objects that had interesting headers.
-//
-// Future work: This implementation currently uses growable arrays to save
-// the oop and header of interesting objects. As an optimization we could
-// use the same technique as the GC and make use of the unused area
-// between top() and end().
-//
-
-// An ObjectClosure used to restore the mark bits of an object
-class RestoreMarksClosure : public ObjectClosure {
- public:
-  void do_object(oop o) {
-    if (o != NULL) {
-      markWord mark = o->mark();
-      if (mark.is_marked()) {
-        o->init_mark();
-      }
-    }
-  }
-};
-
-MarkBitMap ObjectMarker::_mark_bit_map;
-MemRegion  ObjectMarker::_bitmap_region;
-
-void ObjectMarker::initialize(MemRegion heap_region) {
-  new (&_mark_bit_map) MarkBitMap();
-  size_t bitmap_size = MarkBitMap::compute_size(heap_region.byte_size());
-  ReservedSpace bitmap(bitmap_size);
-  _bitmap_region = MemRegion((HeapWord*) bitmap.base(), bitmap.size() / HeapWordSize);
-  _mark_bit_map.initialize(heap_region, _bitmap_region);
-}
-
-// initialize ObjectMarker - prepares for object marking
-void ObjectMarker::init() {
-  assert(Thread::current()->is_VM_thread(), "must be VMThread");
-  assert(SafepointSynchronize::is_at_safepoint(), "must be at a safepoint");
-
-  // prepare heap for iteration
-  Universe::heap()->ensure_parsability(false);  // no need to retire TLABs
-
-  // create stacks for interesting headers
-  if (!os::commit_memory((char*)_bitmap_region.start(), _bitmap_region.byte_size(), false)) {
-    vm_exit_out_of_memory(_bitmap_region.byte_size(), OOM_MALLOC_ERROR,
-                          "Could not commit native memory for auxiliary marking bitmap for JVMTI object marking");
-  }
-  _mark_bit_map.clear();
-}
-
-// Object marking is done so restore object headers
-void ObjectMarker::done() {
-  if (!os::uncommit_memory((char*)_bitmap_region.start(), _bitmap_region.byte_size())) {
-    log_warning(gc)("Could not uncommit native memory for auxiliary marking bitmap for JVMTI object marking");
-  }
-}
-
-// mark an object
-inline void ObjectMarker::mark(oop o) {
-  assert(Universe::heap()->is_in(o), "sanity check");
-  assert(!o->mark().is_marked(), "should only mark an object once");
-  _mark_bit_map.mark(o);
-}
-
-// return true if object is marked
-inline bool ObjectMarker::visited(oop o) {
-  return _mark_bit_map.is_marked(o);
-}
-
-// Stack allocated class to help ensure that ObjectMarker is used
-// correctly. Constructor initializes ObjectMarker, destructor calls
-// ObjectMarker's done() function to restore object headers.
-class ObjectMarkerController : public StackObj {
- public:
-  ObjectMarkerController() {
-    ObjectMarker::init();
-  }
-  ~ObjectMarkerController() {
-    ObjectMarker::done();
-  }
-};
-
-
 // helper to map a jvmtiHeapReferenceKind to an old style jvmtiHeapRootKind
 // (not performance critical as only used for roots)
 static jvmtiHeapRootKind toJvmtiHeapRootKind(jvmtiHeapReferenceKind kind) {
@@ -1564,7 +1472,7 @@ class CallbackInvoker : AllStatic {
   // if the object hasn't been visited then push it onto the visit stack
   // so that it will be visited later
   static inline bool check_for_visit(oop obj) {
-    if (!ObjectMarker::visited(obj)) visit_stack()->push(obj);
+    if (!ObjectMarkerController::is_marked(obj)) visit_stack()->push(obj);
     return true;
   }
 
@@ -2851,8 +2759,8 @@ inline bool VM_HeapWalkOperation::collect_stack_roots() {
 //
 bool VM_HeapWalkOperation::visit(oop o) {
   // mark object as visited
-  assert(!ObjectMarker::visited(o), "can't visit same object more than once");
-  ObjectMarker::mark(o);
+  assert(!ObjectMarkerController::is_marked(o), "can't visit same object more than once");
+  ObjectMarkerController::mark(o);
 
   // instance
   if (o->is_instance()) {
@@ -2890,12 +2798,19 @@ void VM_HeapWalkOperation::doit() {
 
   // the heap walk starts with an initial object or the heap roots
   if (initial_object().is_null()) {
-    // Calling collect_stack_roots() before collect_simple_roots()
+    // If either collect_stack_roots() or collect_simple_roots()
+    // returns false at this point, then there are no mark bits
+    // to reset.
+    ObjectMarkerController::set_needs_reset(false);    // Calling collect_stack_roots() before collect_simple_roots()
+
     // can result in a big performance boost for an agent that is
     // focused on analyzing references in the thread stacks.
     if (!collect_stack_roots()) return;
 
     if (!collect_simple_roots()) return;
+
+    // no early return so enable heap traversal to reset the mark bits
+    ObjectMarkerController::set_needs_reset(true);
   } else {
     visit_stack()->push(initial_object()());
   }
@@ -2907,7 +2822,7 @@ void VM_HeapWalkOperation::doit() {
     // visited or the callback asked to terminate the iteration.
     while (!visit_stack()->is_empty()) {
       oop o = visit_stack()->pop();
-      if (!ObjectMarker::visited(o)) {
+      if (!ObjectMarkerController::is_marked(o)) {
         if (!visit(o)) {
           break;
         }

--- a/src/hotspot/share/prims/jvmtiTagMap.cpp
+++ b/src/hotspot/share/prims/jvmtiTagMap.cpp
@@ -2798,11 +2798,6 @@ void VM_HeapWalkOperation::doit() {
 
   // the heap walk starts with an initial object or the heap roots
   if (initial_object().is_null()) {
-    // If either collect_stack_roots() or collect_simple_roots()
-    // returns false at this point, then there are no mark bits
-    // to reset.
-    ObjectMarkerController::set_needs_reset(false);    // Calling collect_stack_roots() before collect_simple_roots()
-
     // can result in a big performance boost for an agent that is
     // focused on analyzing references in the thread stacks.
     if (!collect_stack_roots()) return;

--- a/src/hotspot/share/prims/jvmtiTagMap.hpp
+++ b/src/hotspot/share/prims/jvmtiTagMap.hpp
@@ -34,8 +34,6 @@ class JvmtiEnv;
 class JvmtiTagMapTable;
 class JvmtiTagMapEntryClosure;
 
-// ObjectMarker provides the mark and visited functions
-
 class JvmtiTagMap :  public CHeapObj<mtInternal> {
  private:
 

--- a/src/hotspot/share/prims/jvmtiTagMap.hpp
+++ b/src/hotspot/share/prims/jvmtiTagMap.hpp
@@ -27,7 +27,6 @@
 #ifndef SHARE_PRIMS_JVMTITAGMAP_HPP
 #define SHARE_PRIMS_JVMTITAGMAP_HPP
 
-#include "gc/shared/markBitMap.hpp"
 #include "jvmtifiles/jvmti.h"
 #include "memory/allocation.hpp"
 
@@ -36,18 +35,6 @@ class JvmtiTagMapTable;
 class JvmtiTagMapEntryClosure;
 
 // ObjectMarker provides the mark and visited functions
-class ObjectMarker : AllStatic {
-private:
-  static MarkBitMap _mark_bit_map;
-  static MemRegion  _bitmap_region;
-public:
-  static void initialize(MemRegion heap_region);
-  static void init();                       // initialize
-  static void done();                       // clean-up
-
-  static inline void mark(oop o);           // mark an object
-  static inline bool visited(oop o);        // check if object has been visited
-};
 
 class JvmtiTagMap :  public CHeapObj<mtInternal> {
  private:

--- a/src/hotspot/share/prims/jvmtiTagMap.hpp
+++ b/src/hotspot/share/prims/jvmtiTagMap.hpp
@@ -27,12 +27,27 @@
 #ifndef SHARE_PRIMS_JVMTITAGMAP_HPP
 #define SHARE_PRIMS_JVMTITAGMAP_HPP
 
+#include "gc/shared/markBitMap.hpp"
 #include "jvmtifiles/jvmti.h"
 #include "memory/allocation.hpp"
 
 class JvmtiEnv;
 class JvmtiTagMapTable;
 class JvmtiTagMapEntryClosure;
+
+// ObjectMarker provides the mark and visited functions
+class ObjectMarker : AllStatic {
+private:
+  static MarkBitMap _mark_bit_map;
+  static MemRegion  _bitmap_region;
+public:
+  static void initialize(MemRegion heap_region);
+  static void init();                       // initialize
+  static void done();                       // clean-up
+
+  static inline void mark(oop o);           // mark an object
+  static inline bool visited(oop o);        // check if object has been visited
+};
 
 class JvmtiTagMap :  public CHeapObj<mtInternal> {
  private:


### PR DESCRIPTION
JVMTI marks objects in order to track whether or not it has already visited objects during heap walking. This uses the usual GC marking bits in the object header. However, this proves to be confusing and brittle because some GCs also uses those header bits for marking and/or indicating forwarded objects. In particular, it becomes unreliable for Shenandoah GC to distinguish JVMTI marked objects from forwarded objects.

JVMTI should have no business in marking objects in their header. This change proposes to let JVMTI use its own (temporary) marking bitmap instead. This decouples JVMTI better from GCs.

Testing:
 - [x] tier1
 - [x] tier2
 - [ ] tier3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/lilliput pull/45/head:pull/45` \
`$ git checkout pull/45`

Update a local copy of the PR: \
`$ git checkout pull/45` \
`$ git pull https://git.openjdk.java.net/lilliput pull/45/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 45`

View PR using the GUI difftool: \
`$ git pr show -t 45`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/lilliput/pull/45.diff">https://git.openjdk.java.net/lilliput/pull/45.diff</a>

</details>
