### PR TITLE
Only include Mark Word when required

### DIFF
--- a/src/hotspot/share/oops/oop.hpp
+++ b/src/hotspot/share/oops/oop.hpp
@@ -67,6 +67,8 @@ class oopDesc {
   // Must be trivial; see verifying static assert after the class.
   oopDesc() = default;
 
+  inline bool      supportsMark()  const;
+
   inline markWord  mark()          const;
   inline markWord  mark_acquire()  const;
   inline markWord* mark_addr() const;

--- a/src/hotspot/share/oops/oop.inline.hpp
+++ b/src/hotspot/share/oops/oop.inline.hpp
@@ -47,6 +47,10 @@
 // Implementation of all inlined member functions defined in oop.hpp
 // We need a separate file to avoid circular references
 
+bool oopDesc::supportsMark() const {
+  return true; // Placeholder
+}
+
 markWord oopDesc::mark() const {
   return Atomic::load(&_mark);
 }


### PR DESCRIPTION
WIP, some code here is meant as a placeholder

Discussion: https://bugs.openjdk.java.net/browse/JDK-8198331

Current goals and dependencies (To help keep track)
- [x] 2 bit identity Hash Code
- [ ] Elimination of locking from the Mark Word entirely (Hopefully)
- [ ] 5 bit GC section (4 bit object age, 1 bit forwarding state)
- [ ] No Mark Word in header until required
- [ ] Support and optimizations for objects guaranteed to not have a Mark Word (May depend on Valhalla for the GC section)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput.git pull/47/head:pull/47` \
`$ git checkout pull/47`

Update a local copy of the PR: \
`$ git checkout pull/47` \
`$ git pull https://git.openjdk.org/lilliput.git pull/47/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 47`

View PR using the GUI difftool: \
`$ git pr show -t 47`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput/pull/47.diff">https://git.openjdk.org/lilliput/pull/47.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput/pull/47#issuecomment-1108080776)