### PR TITLE
8300440: [Lilliput] Implement alternative fast-locking scheme

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -1784,6 +1784,18 @@ void MachPrologNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
 
   __ build_frame(framesize);
 
+  int max_monitors = C->method() != NULL ? C->max_monitors() : 0;
+  if (UseFastLocking && max_monitors > 0) {
+    C2CheckLockStackStub* stub = new (C->comp_arena()) C2CheckLockStackStub();
+    C->output()->add_stub(stub);
+    __ ldr(r9, Address(rthread, JavaThread::lock_stack_current_offset()));
+    __ ldr(r10, Address(rthread, JavaThread::lock_stack_limit_offset()));
+    __ add(r9, r9, max_monitors * oopSize);
+    __ cmp(r9, r10);
+    __ br(Assembler::GE, stub->entry());
+    __ bind(stub->continuation());
+  }
+
   if (C->stub_function() == NULL) {
     BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
     if (BarrierSet::barrier_set()->barrier_set_nmethod() != NULL) {
@@ -3782,33 +3794,40 @@ encode %{
     __ tbnz(disp_hdr, exact_log2(markWord::monitor_value), object_has_monitor);
 
     if (!UseHeavyMonitors) {
-      // Set tmp to be (markWord of object | UNLOCK_VALUE).
-      __ orr(tmp, disp_hdr, markWord::unlocked_value);
+      if (UseFastLocking) {
+        __ fast_lock(oop, disp_hdr, tmp, rscratch1, cont, false);
 
-      // Initialize the box. (Must happen before we update the object mark!)
-      __ str(tmp, Address(box, BasicLock::displaced_header_offset_in_bytes()));
+        // Indicate success at cont.
+        __ cmp(oop, oop);
+      } else {
+        // Set tmp to be (markWord of object | UNLOCK_VALUE).
+        __ orr(tmp, disp_hdr, markWord::unlocked_value);
 
-      // Compare object markWord with an unlocked value (tmp) and if
-      // equal exchange the stack address of our box with object markWord.
-      // On failure disp_hdr contains the possibly locked markWord.
-      __ cmpxchg(oop, tmp, box, Assembler::xword, /*acquire*/ true,
-                 /*release*/ true, /*weak*/ false, disp_hdr);
-      __ br(Assembler::EQ, cont);
+        // Initialize the box. (Must happen before we update the object mark!)
+        __ str(tmp, Address(box, BasicLock::displaced_header_offset_in_bytes()));
 
-      assert(oopDesc::mark_offset_in_bytes() == 0, "offset of _mark is not 0");
+        // Compare object markWord with an unlocked value (tmp) and if
+        // equal exchange the stack address of our box with object markWord.
+        // On failure disp_hdr contains the possibly locked markWord.
+        __ cmpxchg(oop, tmp, box, Assembler::xword, /*acquire*/ true,
+                   /*release*/ true, /*weak*/ false, disp_hdr);
+        __ br(Assembler::EQ, cont);
 
-      // If the compare-and-exchange succeeded, then we found an unlocked
-      // object, will have now locked it will continue at label cont
+        assert(oopDesc::mark_offset_in_bytes() == 0, "offset of _mark is not 0");
 
-      // Check if the owner is self by comparing the value in the
-      // markWord of object (disp_hdr) with the stack pointer.
-      __ mov(rscratch1, sp);
-      __ sub(disp_hdr, disp_hdr, rscratch1);
-      __ mov(tmp, (address) (~(os::vm_page_size()-1) | markWord::lock_mask_in_place));
-      // If condition is true we are cont and hence we can store 0 as the
-      // displaced header in the box, which indicates that it is a recursive lock.
-      __ ands(tmp/*==0?*/, disp_hdr, tmp);   // Sets flags for result
-      __ str(tmp/*==0, perhaps*/, Address(box, BasicLock::displaced_header_offset_in_bytes()));
+        // If the compare-and-exchange succeeded, then we found an unlocked
+        // object, will have now locked it will continue at label cont
+
+        // Check if the owner is self by comparing the value in the
+        // markWord of object (disp_hdr) with the stack pointer.
+        __ mov(rscratch1, sp);
+        __ sub(disp_hdr, disp_hdr, rscratch1);
+        __ mov(tmp, (address) (~(os::vm_page_size()-1) | markWord::lock_mask_in_place));
+        // If condition is true we are cont and hence we can store 0 as the
+        // displaced header in the box, which indicates that it is a recursive lock.
+        __ ands(tmp/*==0?*/, disp_hdr, tmp);   // Sets flags for result
+        __ str(tmp/*==0, perhaps*/, Address(box, BasicLock::displaced_header_offset_in_bytes()));
+      }
     } else {
       __ tst(oop, oop); // Set NE to indicate 'failure' -> take slow-path. We know that oop != 0.
     }
@@ -3825,13 +3844,14 @@ encode %{
     __ cmpxchg(tmp, zr, rthread, Assembler::xword, /*acquire*/ true,
                /*release*/ true, /*weak*/ false, rscratch1); // Sets flags for result
 
-    // Store a non-null value into the box to avoid looking like a re-entrant
-    // lock. The fast-path monitor unlock code checks for
-    // markWord::monitor_value so use markWord::unused_mark which has the
-    // relevant bit set, and also matches ObjectSynchronizer::enter.
-    __ mov(tmp, (address)markWord::unused_mark().value());
-    __ str(tmp, Address(box, BasicLock::displaced_header_offset_in_bytes()));
-
+    if (!UseFastLocking) {
+      // Store a non-null value into the box to avoid looking like a re-entrant
+      // lock. The fast-path monitor unlock code checks for
+      // markWord::monitor_value so use markWord::unused_mark which has the
+      // relevant bit set, and also matches ObjectSynchronizer::enter.
+      __ mov(tmp, (address)markWord::unused_mark().value());
+      __ str(tmp, Address(box, BasicLock::displaced_header_offset_in_bytes()));
+    }
     __ br(Assembler::EQ, cont); // CAS success means locking succeeded
 
     __ cmp(rscratch1, rthread);
@@ -3863,7 +3883,7 @@ encode %{
 
     assert_different_registers(oop, box, tmp, disp_hdr);
 
-    if (!UseHeavyMonitors) {
+    if (!UseHeavyMonitors && !UseFastLocking) {
       // Find the lock address and load the displaced header from the stack.
       __ ldr(disp_hdr, Address(box, BasicLock::displaced_header_offset_in_bytes()));
 
@@ -3877,12 +3897,19 @@ encode %{
     __ tbnz(tmp, exact_log2(markWord::monitor_value), object_has_monitor);
 
     if (!UseHeavyMonitors) {
-      // Check if it is still a light weight lock, this is is true if we
-      // see the stack address of the basicLock in the markWord of the
-      // object.
+      if (UseFastLocking) {
+        __ fast_unlock(oop, tmp, box, disp_hdr, cont);
 
-      __ cmpxchg(oop, box, disp_hdr, Assembler::xword, /*acquire*/ false,
-                 /*release*/ true, /*weak*/ false, tmp);
+        // Indicate success at cont.
+        __ cmp(oop, oop);
+      } else {
+        // Check if it is still a light weight lock, this is is true if we
+        // see the stack address of the basicLock in the markWord of the
+        // object.
+
+        __ cmpxchg(oop, box, disp_hdr, Assembler::xword, /*acquire*/ false,
+                   /*release*/ true, /*weak*/ false, tmp);
+      }
     } else {
       __ tst(oop, oop); // Set NE to indicate 'failure' -> take slow-path. We know that oop != 0.
     }
@@ -3894,6 +3921,13 @@ encode %{
     __ bind(object_has_monitor);
     STATIC_ASSERT(markWord::monitor_value <= INT_MAX);
     __ add(tmp, tmp, -(int)markWord::monitor_value); // monitor
+
+    if (UseFastLocking) {
+      // If the owner is anonymous, we need to fix it -- in the slow-path.
+      __ ldr(disp_hdr, Address(tmp, ObjectMonitor::owner_offset_in_bytes()));
+      __ tbnz(disp_hdr, (unsigned char)(intptr_t) ANONYMOUS_OWNER, cont);
+    }
+
     __ ldr(disp_hdr, Address(tmp, ObjectMonitor::recursions_offset_in_bytes()));
 
     Label notRecursive;

--- a/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
@@ -242,7 +242,7 @@ void LIR_Assembler::osr_entry() {
 
   // build frame
   ciMethod* m = compilation()->method();
-  __ build_frame(initial_frame_size_in_bytes(), bang_size_in_bytes());
+  __ build_frame(initial_frame_size_in_bytes(), bang_size_in_bytes(), compilation()->max_monitors());
 
   // OSR buffer is
   //

--- a/src/hotspot/cpu/aarch64/c1_MacroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_MacroAssembler_aarch64.cpp
@@ -83,37 +83,41 @@ int C1_MacroAssembler::lock_object(Register hdr, Register obj, Register disp_hdr
 
   // Load object header
   ldr(hdr, Address(obj, hdr_offset));
-  // and mark it as unlocked
-  orr(hdr, hdr, markWord::unlocked_value);
-  // save unlocked object header into the displaced header location on the stack
-  str(hdr, Address(disp_hdr, 0));
-  // test if object header is still the same (i.e. unlocked), and if so, store the
-  // displaced header address in the object header - if it is not the same, get the
-  // object header instead
-  lea(rscratch2, Address(obj, hdr_offset));
-  cmpxchgptr(hdr, disp_hdr, rscratch2, rscratch1, done, /*fallthough*/NULL);
-  // if the object header was the same, we're done
-  // if the object header was not the same, it is now in the hdr register
-  // => test if it is a stack pointer into the same stack (recursive locking), i.e.:
-  //
-  // 1) (hdr & aligned_mask) == 0
-  // 2) sp <= hdr
-  // 3) hdr <= sp + page_size
-  //
-  // these 3 tests can be done by evaluating the following expression:
-  //
-  // (hdr - sp) & (aligned_mask - page_size)
-  //
-  // assuming both the stack pointer and page_size have their least
-  // significant 2 bits cleared and page_size is a power of 2
-  mov(rscratch1, sp);
-  sub(hdr, hdr, rscratch1);
-  ands(hdr, hdr, aligned_mask - os::vm_page_size());
-  // for recursive locking, the result is zero => save it in the displaced header
-  // location (NULL in the displaced hdr location indicates recursive locking)
-  str(hdr, Address(disp_hdr, 0));
-  // otherwise we don't care about the result and handle locking via runtime call
-  cbnz(hdr, slow_case);
+  if (UseFastLocking) {
+    fast_lock(obj, hdr, rscratch1, rscratch2, slow_case, false);
+  } else {
+    // and mark it as unlocked
+    orr(hdr, hdr, markWord::unlocked_value);
+    // save unlocked object header into the displaced header location on the stack
+    str(hdr, Address(disp_hdr, 0));
+    // test if object header is still the same (i.e. unlocked), and if so, store the
+    // displaced header address in the object header - if it is not the same, get the
+    // object header instead
+    lea(rscratch2, Address(obj, hdr_offset));
+    cmpxchgptr(hdr, disp_hdr, rscratch2, rscratch1, done, /*fallthough*/NULL);
+    // if the object header was the same, we're done
+    // if the object header was not the same, it is now in the hdr register
+    // => test if it is a stack pointer into the same stack (recursive locking), i.e.:
+    //
+    // 1) (hdr & aligned_mask) == 0
+    // 2) sp <= hdr
+    // 3) hdr <= sp + page_size
+    //
+    // these 3 tests can be done by evaluating the following expression:
+    //
+    // (hdr - sp) & (aligned_mask - page_size)
+    //
+    // assuming both the stack pointer and page_size have their least
+    // significant 2 bits cleared and page_size is a power of 2
+    mov(rscratch1, sp);
+    sub(hdr, hdr, rscratch1);
+    ands(hdr, hdr, aligned_mask - os::vm_page_size());
+    // for recursive locking, the result is zero => save it in the displaced header
+    // location (NULL in the displaced hdr location indicates recursive locking)
+    str(hdr, Address(disp_hdr, 0));
+    // otherwise we don't care about the result and handle locking via runtime call
+    cbnz(hdr, slow_case);
+  }
   // done
   bind(done);
   increment(Address(rthread, JavaThread::held_monitor_count_offset()));
@@ -127,27 +131,36 @@ void C1_MacroAssembler::unlock_object(Register hdr, Register obj, Register disp_
   assert(hdr != obj && hdr != disp_hdr && obj != disp_hdr, "registers must be different");
   Label done;
 
-  // load displaced header
-  ldr(hdr, Address(disp_hdr, 0));
-  // if the loaded hdr is NULL we had recursive locking
-  // if we had recursive locking, we are done
-  cbz(hdr, done);
+  if (!UseFastLocking) {
+    // load displaced header
+    ldr(hdr, Address(disp_hdr, 0));
+    // if the loaded hdr is NULL we had recursive locking
+    // if we had recursive locking, we are done
+    cbz(hdr, done);
+  }
+
   // load object
   ldr(obj, Address(disp_hdr, BasicObjectLock::obj_offset_in_bytes()));
   verify_oop(obj);
-  // test if object header is pointing to the displaced header, and if so, restore
-  // the displaced header in the object - if the object header is not pointing to
-  // the displaced header, get the object header instead
-  // if the object header was not pointing to the displaced header,
-  // we do unlocking via runtime call
-  if (hdr_offset) {
-    lea(rscratch1, Address(obj, hdr_offset));
-    cmpxchgptr(disp_hdr, hdr, rscratch1, rscratch2, done, &slow_case);
+
+  if (UseFastLocking) {
+    ldr(hdr, Address(obj, oopDesc::mark_offset_in_bytes()));
+    fast_unlock(obj, hdr, rscratch1, rscratch2, slow_case);
   } else {
-    cmpxchgptr(disp_hdr, hdr, obj, rscratch2, done, &slow_case);
+    // test if object header is pointing to the displaced header, and if so, restore
+    // the displaced header in the object - if the object header is not pointing to
+    // the displaced header, get the object header instead
+    // if the object header was not pointing to the displaced header,
+    // we do unlocking via runtime call
+    if (hdr_offset) {
+      lea(rscratch1, Address(obj, hdr_offset));
+      cmpxchgptr(disp_hdr, hdr, rscratch1, rscratch2, done, &slow_case);
+    } else {
+      cmpxchgptr(disp_hdr, hdr, obj, rscratch2, done, &slow_case);
+    }
+    // done
+    bind(done);
   }
-  // done
-  bind(done);
   decrement(Address(rthread, JavaThread::held_monitor_count_offset()));
 }
 
@@ -285,12 +298,24 @@ void C1_MacroAssembler::inline_cache_check(Register receiver, Register iCache) {
 }
 
 
-void C1_MacroAssembler::build_frame(int framesize, int bang_size_in_bytes) {
+void C1_MacroAssembler::build_frame(int framesize, int bang_size_in_bytes, int max_monitors) {
   assert(bang_size_in_bytes >= framesize, "stack bang size incorrect");
   // Make sure there is enough stack space for this method's activation.
   // Note that we do this before creating a frame.
   generate_stack_overflow_check(bang_size_in_bytes);
   MacroAssembler::build_frame(framesize);
+
+  if (UseFastLocking && max_monitors > 0) {
+    Label ok;
+    ldr(r9, Address(rthread, JavaThread::lock_stack_current_offset()));
+    ldr(r10, Address(rthread, JavaThread::lock_stack_limit_offset()));
+    add(r9, r9, max_monitors * oopSize);
+    cmp(r9, r10);
+    br(Assembler::LT, ok);
+    assert(StubRoutines::aarch64::check_lock_stack() != NULL, "need runtime call stub");
+    far_call(StubRoutines::aarch64::check_lock_stack());
+    bind(ok);
+  }
 
   // Insert nmethod entry barrier into frame.
   BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();

--- a/src/hotspot/cpu/aarch64/c2_CodeStubs_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c2_CodeStubs_aarch64.cpp
@@ -63,4 +63,15 @@ void C2EntryBarrierStub::emit(C2_MacroAssembler& masm) {
   __ emit_int32(0);   // nmethod guard value
 }
 
+int C2CheckLockStackStub::max_size() const {
+  return 20;
+}
+
+void C2CheckLockStackStub::emit(C2_MacroAssembler& masm) {
+  __ bind(entry());
+  assert(StubRoutines::aarch64::check_lock_stack() != NULL, "need runtime call stub");
+  __ far_call(StubRoutines::aarch64::check_lock_stack());
+  __ b(continuation());
+}
+
 #undef __

--- a/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
@@ -758,62 +758,67 @@ void InterpreterMacroAssembler::lock_object(Register lock_reg)
       br(Assembler::NE, slow_case);
     }
 
-    // Load (object->mark() | 1) into swap_reg
-    ldr(rscratch1, Address(obj_reg, oopDesc::mark_offset_in_bytes()));
-    orr(swap_reg, rscratch1, 1);
+    if (UseFastLocking) {
+      ldr(tmp, Address(obj_reg, oopDesc::mark_offset_in_bytes()));
+      fast_lock(obj_reg, tmp, rscratch1, rscratch2, slow_case);
+      b(count);
+    } else {
+      // Load (object->mark() | 1) into swap_reg
+      ldr(rscratch1, Address(obj_reg, oopDesc::mark_offset_in_bytes()));
+      orr(swap_reg, rscratch1, 1);
 
-    // Save (object->mark() | 1) into BasicLock's displaced header
-    str(swap_reg, Address(lock_reg, mark_offset));
+      // Save (object->mark() | 1) into BasicLock's displaced header
+      str(swap_reg, Address(lock_reg, mark_offset));
 
-    assert(lock_offset == 0,
-           "displached header must be first word in BasicObjectLock");
+      assert(lock_offset == 0,
+             "displached header must be first word in BasicObjectLock");
 
-    Label fail;
-    cmpxchg_obj_header(swap_reg, lock_reg, obj_reg, rscratch1, count, /*fallthrough*/NULL);
+      Label fail;
+      cmpxchg_obj_header(swap_reg, lock_reg, obj_reg, rscratch1, count, /*fallthrough*/NULL);
 
-    // Fast check for recursive lock.
-    //
-    // Can apply the optimization only if this is a stack lock
-    // allocated in this thread. For efficiency, we can focus on
-    // recently allocated stack locks (instead of reading the stack
-    // base and checking whether 'mark' points inside the current
-    // thread stack):
-    //  1) (mark & 7) == 0, and
-    //  2) sp <= mark < mark + os::pagesize()
-    //
-    // Warning: sp + os::pagesize can overflow the stack base. We must
-    // neither apply the optimization for an inflated lock allocated
-    // just above the thread stack (this is why condition 1 matters)
-    // nor apply the optimization if the stack lock is inside the stack
-    // of another thread. The latter is avoided even in case of overflow
-    // because we have guard pages at the end of all stacks. Hence, if
-    // we go over the stack base and hit the stack of another thread,
-    // this should not be in a writeable area that could contain a
-    // stack lock allocated by that thread. As a consequence, a stack
-    // lock less than page size away from sp is guaranteed to be
-    // owned by the current thread.
-    //
-    // These 3 tests can be done by evaluating the following
-    // expression: ((mark - sp) & (7 - os::vm_page_size())),
-    // assuming both stack pointer and pagesize have their
-    // least significant 3 bits clear.
-    // NOTE: the mark is in swap_reg %r0 as the result of cmpxchg
-    // NOTE2: aarch64 does not like to subtract sp from rn so take a
-    // copy
-    mov(rscratch1, sp);
-    sub(swap_reg, swap_reg, rscratch1);
-    ands(swap_reg, swap_reg, (uint64_t)(7 - os::vm_page_size()));
+      // Fast check for recursive lock.
+      //
+      // Can apply the optimization only if this is a stack lock
+      // allocated in this thread. For efficiency, we can focus on
+      // recently allocated stack locks (instead of reading the stack
+      // base and checking whether 'mark' points inside the current
+      // thread stack):
+      //  1) (mark & 7) == 0, and
+      //  2) sp <= mark < mark + os::pagesize()
+      //
+      // Warning: sp + os::pagesize can overflow the stack base. We must
+      // neither apply the optimization for an inflated lock allocated
+      // just above the thread stack (this is why condition 1 matters)
+      // nor apply the optimization if the stack lock is inside the stack
+      // of another thread. The latter is avoided even in case of overflow
+      // because we have guard pages at the end of all stacks. Hence, if
+      // we go over the stack base and hit the stack of another thread,
+      // this should not be in a writeable area that could contain a
+      // stack lock allocated by that thread. As a consequence, a stack
+      // lock less than page size away from sp is guaranteed to be
+      // owned by the current thread.
+      //
+      // These 3 tests can be done by evaluating the following
+      // expression: ((mark - sp) & (7 - os::vm_page_size())),
+      // assuming both stack pointer and pagesize have their
+      // least significant 3 bits clear.
+      // NOTE: the mark is in swap_reg %r0 as the result of cmpxchg
+      // NOTE2: aarch64 does not like to subtract sp from rn so take a
+      // copy
+      mov(rscratch1, sp);
+      sub(swap_reg, swap_reg, rscratch1);
+      ands(swap_reg, swap_reg, (uint64_t) (7 - os::vm_page_size()));
 
-    // Save the test result, for recursive case, the result is zero
-    str(swap_reg, Address(lock_reg, mark_offset));
-    br(Assembler::EQ, count);
-
+      // Save the test result, for recursive case, the result is zero
+      str(swap_reg, Address(lock_reg, mark_offset));
+      br(Assembler::EQ, count);
+    }
     bind(slow_case);
 
     // Call the runtime routine for slow case
     call_VM(noreg,
             CAST_FROM_FN_PTR(address, InterpreterRuntime::monitorenter),
-            lock_reg);
+            UseFastLocking ? obj_reg : lock_reg);
     b(done);
 
     bind(count);
@@ -850,9 +855,11 @@ void InterpreterMacroAssembler::unlock_object(Register lock_reg)
 
     save_bcp(); // Save in case of exception
 
-    // Convert from BasicObjectLock structure to object and BasicLock
-    // structure Store the BasicLock address into %r0
-    lea(swap_reg, Address(lock_reg, BasicObjectLock::lock_offset_in_bytes()));
+    if (!UseFastLocking) {
+      // Convert from BasicObjectLock structure to object and BasicLock
+      // structure Store the BasicLock address into %r0
+      lea(swap_reg, Address(lock_reg, BasicObjectLock::lock_offset_in_bytes()));
+    }
 
     // Load oop into obj_reg(%c_rarg3)
     ldr(obj_reg, Address(lock_reg, BasicObjectLock::obj_offset_in_bytes()));
@@ -860,16 +867,30 @@ void InterpreterMacroAssembler::unlock_object(Register lock_reg)
     // Free entry
     str(zr, Address(lock_reg, BasicObjectLock::obj_offset_in_bytes()));
 
-    // Load the old header from BasicLock structure
-    ldr(header_reg, Address(swap_reg,
-                            BasicLock::displaced_header_offset_in_bytes()));
+    if (UseFastLocking) {
+      Label slow_case;
 
-    // Test for recursion
-    cbz(header_reg, count);
+      // Check for non-symmetric locking. This is allowed by the spec and the interpreter
+      // must handle it.
+      ldr(header_reg, Address(rthread, JavaThread::lock_stack_current_offset()));
+      cmpoop(header_reg, obj_reg);
+      br(Assembler::NE, slow_case);
 
-    // Atomic swap back the old header
-    cmpxchg_obj_header(swap_reg, header_reg, obj_reg, rscratch1, count, /*fallthrough*/NULL);
+      ldr(header_reg, Address(obj_reg, oopDesc::mark_offset_in_bytes()));
+      fast_unlock(obj_reg, header_reg, swap_reg, rscratch1, slow_case);
+      b(count);
+      bind(slow_case);
+    } else {
+      // Load the old header from BasicLock structure
+      ldr(header_reg, Address(swap_reg,
+                              BasicLock::displaced_header_offset_in_bytes()));
 
+      // Test for recursion
+      cbz(header_reg, count);
+
+      // Atomic swap back the old header
+      cmpxchg_obj_header(swap_reg, header_reg, obj_reg, rscratch1, count, /*fallthrough*/NULL);
+    }
     // Call the runtime routine for slow case.
     str(obj_reg, Address(lock_reg, BasicObjectLock::obj_offset_in_bytes())); // restore obj
     call_VM_leaf(CAST_FROM_FN_PTR(address, InterpreterRuntime::monitorexit), lock_reg);

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -5936,3 +5936,58 @@ void MacroAssembler::double_move(VMRegPair src, VMRegPair dst, Register tmp) {
       strd(src.first()->as_FloatRegister(), Address(sp, reg2offset_out(dst.first())));
   }
 }
+
+// Attempt to fast-lock an object. Fall-through on success, branch to slow label
+// on failure.
+// Registers:
+//  - obj: the object to be locked
+//  - hdr: the header, already loaded from obj, will be destroyed
+//  - t1, t2, t3: temporary registers, will be destroyed
+void MacroAssembler::fast_lock(Register obj, Register hdr, Register t1, Register t2, Label& slow, bool rt_check_stack) {
+  assert(UseFastLocking, "only used with fast-locking");
+  assert_different_registers(obj, hdr, t1, t2);
+
+  if (rt_check_stack) {
+    // Check if we would have space on lock-stack for the object.
+    ldr(t1, Address(rthread, JavaThread::lock_stack_current_offset()));
+    ldr(t2, Address(rthread, JavaThread::lock_stack_limit_offset()));
+    cmp(t1, t2);
+    br(Assembler::GE, slow);
+  }
+
+  // Load (object->mark() | 1) into hdr
+  orr(hdr, hdr, markWord::unlocked_value);
+  // Clear lock-bits, into t2
+  eor(t2, hdr, markWord::unlocked_value);
+  // Try to swing header from unlocked to locked
+  cmpxchg(/*addr*/ obj, /*expected*/ hdr, /*new*/ t2, Assembler::xword,
+          /*acquire*/ true, /*release*/ true, /*weak*/ false, t1);
+  br(Assembler::NE, slow);
+
+  // After successful lock, push object on lock-stack
+  ldr(t1, Address(rthread, JavaThread::lock_stack_current_offset()));
+  str(obj, Address(t1, 0));
+  add(t1, t1, oopSize);
+  str(t1, Address(rthread, JavaThread::lock_stack_current_offset()));
+}
+
+void MacroAssembler::fast_unlock(Register obj, Register hdr, Register t1, Register t2, Label& slow) {
+  assert(UseFastLocking, "only used with fast-locking");
+  assert_different_registers(obj, hdr, t1, t2);
+
+  // Load the expected old header (lock-bits cleared to indicate 'locked') into hdr
+  andr(hdr, hdr, ~markWord::lock_mask_in_place);
+
+  // Load the new header (unlocked) into t1
+  orr(t1, hdr, markWord::unlocked_value);
+
+  // Try to swing header from locked to unlocked
+  cmpxchg(obj, hdr, t1, Assembler::xword,
+          /*acquire*/ true, /*release*/ true, /*weak*/ false, t2);
+  br(Assembler::NE, slow);
+
+  // After successful unlock, pop object from lock-stack
+  ldr(t1, Address(rthread, JavaThread::lock_stack_current_offset()));
+  sub(t1, t1, oopSize);
+  str(t1, Address(rthread, JavaThread::lock_stack_current_offset()));
+}

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
@@ -1562,6 +1562,9 @@ public:
   // Code for java.lang.Thread::onSpinWait() intrinsic.
   void spin_wait();
 
+  void fast_lock(Register obj, Register hdr, Register t1, Register t2, Label& slow, bool rt_check_stack = true);
+  void fast_unlock(Register obj, Register hdr, Register t1, Register t2, Label& slow);
+
 private:
   // Check the current thread doesn't need a cross modify fence.
   void verify_cross_modify_fence_not_required() PRODUCT_RETURN;

--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -5385,6 +5385,29 @@ class StubGenerator: public StubCodeGenerator {
     return start;
   }
 
+  address generate_check_lock_stack() {
+    __ align(CodeEntryAlignment);
+    StubCodeMark mark(this, "StubRoutines", "check_lock_stack");
+
+    address start = __ pc();
+
+    __ set_last_Java_frame(sp, rfp, lr, rscratch1);
+    __ enter();
+    __ push_call_clobbered_registers();
+
+    __ mov(c_rarg0, r9);
+    __ call_VM_leaf(CAST_FROM_FN_PTR(address, LockStack::ensure_lock_stack_size), 1);
+
+
+    __ pop_call_clobbered_registers();
+    __ leave();
+    __ reset_last_Java_frame(true);
+
+    __ ret(lr);
+
+    return start;
+  }
+
   // r0  = result
   // r1  = str1
   // r2  = cnt1
@@ -8046,6 +8069,9 @@ class StubGenerator: public StubCodeGenerator {
     BarrierSetNMethod* bs_nm = BarrierSet::barrier_set()->barrier_set_nmethod();
     if (bs_nm != NULL) {
       StubRoutines::aarch64::_method_entry_barrier = generate_method_entry_barrier();
+    }
+    if (UseFastLocking) {
+      StubRoutines::aarch64::_check_lock_stack = generate_check_lock_stack();
     }
 #ifdef COMPILER2
     if (UseMultiplyToLenIntrinsic) {

--- a/src/hotspot/cpu/aarch64/stubRoutines_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubRoutines_aarch64.cpp
@@ -57,6 +57,7 @@ address StubRoutines::aarch64::_string_indexof_linear_uu = NULL;
 address StubRoutines::aarch64::_string_indexof_linear_ul = NULL;
 address StubRoutines::aarch64::_large_byte_array_inflate = NULL;
 address StubRoutines::aarch64::_method_entry_barrier = NULL;
+address StubRoutines::aarch64::_check_lock_stack = NULL;
 
 static void empty_spin_wait() { }
 address StubRoutines::aarch64::_spin_wait = CAST_FROM_FN_PTR(address, empty_spin_wait);

--- a/src/hotspot/cpu/aarch64/stubRoutines_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/stubRoutines_aarch64.hpp
@@ -70,6 +70,8 @@ class aarch64 {
 
   static address _method_entry_barrier;
 
+  static address _check_lock_stack;
+
   static address _spin_wait;
 
   static bool _completed;
@@ -178,6 +180,10 @@ class aarch64 {
 
   static address method_entry_barrier() {
     return _method_entry_barrier;
+  }
+
+  static address check_lock_stack() {
+    return _check_lock_stack;
   }
 
   static address spin_wait() {

--- a/src/hotspot/cpu/arm/c1_LIRAssembler_arm.cpp
+++ b/src/hotspot/cpu/arm/c1_LIRAssembler_arm.cpp
@@ -145,7 +145,7 @@ void LIR_Assembler::osr_entry() {
   ValueStack* entry_state = osr_entry->end()->state();
   int number_of_locks = entry_state->locks_size();
 
-  __ build_frame(initial_frame_size_in_bytes(), bang_size_in_bytes());
+  __ build_frame(initial_frame_size_in_bytes(), bang_size_in_bytes(), compilation()->max_monitors());
   Register OSR_buf = osrBufferPointer()->as_pointer_register();
 
   assert(frame::interpreter_frame_monitor_size() == BasicObjectLock::size(), "adjust code below");

--- a/src/hotspot/cpu/arm/c1_MacroAssembler_arm.cpp
+++ b/src/hotspot/cpu/arm/c1_MacroAssembler_arm.cpp
@@ -53,7 +53,7 @@ void C1_MacroAssembler::inline_cache_check(Register receiver, Register iCache) {
   bind(verified);
 }
 
-void C1_MacroAssembler::build_frame(int frame_size_in_bytes, int bang_size_in_bytes) {
+void C1_MacroAssembler::build_frame(int frame_size_in_bytes, int bang_size_in_bytes, int max_monitors) {
   assert(bang_size_in_bytes >= frame_size_in_bytes, "stack bang size incorrect");
   assert((frame_size_in_bytes % StackAlignmentInBytes) == 0, "frame size should be aligned");
 

--- a/src/hotspot/cpu/ppc/c1_LIRAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c1_LIRAssembler_ppc.cpp
@@ -113,7 +113,7 @@ void LIR_Assembler::osr_entry() {
   int number_of_locks = entry_state->locks_size();
 
   // Create a frame for the compiled activation.
-  __ build_frame(initial_frame_size_in_bytes(), bang_size_in_bytes());
+  __ build_frame(initial_frame_size_in_bytes(), bang_size_in_bytes(), compilation()->max_monitors());
 
   // OSR buffer is
   //

--- a/src/hotspot/cpu/ppc/c1_MacroAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c1_MacroAssembler_ppc.cpp
@@ -70,7 +70,7 @@ void C1_MacroAssembler::explicit_null_check(Register base) {
 }
 
 
-void C1_MacroAssembler::build_frame(int frame_size_in_bytes, int bang_size_in_bytes) {
+void C1_MacroAssembler::build_frame(int frame_size_in_bytes, int bang_size_in_bytes, int max_monitors) {
   // Avoid stack bang as first instruction. It may get overwritten by patch_verified_entry.
   const Register return_pc = R20;
   mflr(return_pc);

--- a/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.cpp
@@ -215,7 +215,7 @@ void LIR_Assembler::osr_entry() {
 
   //build frame
   ciMethod* m = compilation()->method();
-  __ build_frame(initial_frame_size_in_bytes(), bang_size_in_bytes());
+  __ build_frame(initial_frame_size_in_bytes(), bang_size_in_bytes(), compilation()->max_monitors());
 
   // OSR buffer is
   //

--- a/src/hotspot/cpu/riscv/c1_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_MacroAssembler_riscv.cpp
@@ -72,39 +72,44 @@ int C1_MacroAssembler::lock_object(Register hdr, Register obj, Register disp_hdr
 
   // Load object header
   ld(hdr, Address(obj, hdr_offset));
-  // and mark it as unlocked
-  ori(hdr, hdr, markWord::unlocked_value);
-  // save unlocked object header into the displaced header location on the stack
-  sd(hdr, Address(disp_hdr, 0));
-  // test if object header is still the same (i.e. unlocked), and if so, store the
-  // displaced header address in the object header - if it is not the same, get the
-  // object header instead
-  la(t1, Address(obj, hdr_offset));
-  cmpxchgptr(hdr, disp_hdr, t1, t0, done, /*fallthough*/NULL);
-  // if the object header was the same, we're done
-  // if the object header was not the same, it is now in the hdr register
-  // => test if it is a stack pointer into the same stack (recursive locking), i.e.:
-  //
-  // 1) (hdr & aligned_mask) == 0
-  // 2) sp <= hdr
-  // 3) hdr <= sp + page_size
-  //
-  // these 3 tests can be done by evaluating the following expression:
-  //
-  // (hdr -sp) & (aligned_mask - page_size)
-  //
-  // assuming both the stack pointer and page_size have their least
-  // significant 2 bits cleared and page_size is a power of 2
-  sub(hdr, hdr, sp);
-  mv(t0, aligned_mask - os::vm_page_size());
-  andr(hdr, hdr, t0);
-  // for recursive locking, the result is zero => save it in the displaced header
-  // location (NULL in the displaced hdr location indicates recursive locking)
-  sd(hdr, Address(disp_hdr, 0));
-  // otherwise we don't care about the result and handle locking via runtime call
-  bnez(hdr, slow_case, /* is_far */ true);
-  // done
-  bind(done);
+
+  if (UseFastLocking) {
+    fast_lock(obj, hdr, t0, t1, slow_case);
+  } else {
+    // and mark it as unlocked
+    ori(hdr, hdr, markWord::unlocked_value);
+    // save unlocked object header into the displaced header location on the stack
+    sd(hdr, Address(disp_hdr, 0));
+    // test if object header is still the same (i.e. unlocked), and if so, store the
+    // displaced header address in the object header - if it is not the same, get the
+    // object header instead
+    la(t1, Address(obj, hdr_offset));
+    cmpxchgptr(hdr, disp_hdr, t1, t0, done, /*fallthough*/NULL);
+    // if the object header was the same, we're done
+    // if the object header was not the same, it is now in the hdr register
+    // => test if it is a stack pointer into the same stack (recursive locking), i.e.:
+    //
+    // 1) (hdr & aligned_mask) == 0
+    // 2) sp <= hdr
+    // 3) hdr <= sp + page_size
+    //
+    // these 3 tests can be done by evaluating the following expression:
+    //
+    // (hdr -sp) & (aligned_mask - page_size)
+    //
+    // assuming both the stack pointer and page_size have their least
+    // significant 2 bits cleared and page_size is a power of 2
+    sub(hdr, hdr, sp);
+    mv(t0, aligned_mask - os::vm_page_size());
+    andr(hdr, hdr, t0);
+    // for recursive locking, the result is zero => save it in the displaced header
+    // location (NULL in the displaced hdr location indicates recursive locking)
+    sd(hdr, Address(disp_hdr, 0));
+    // otherwise we don't care about the result and handle locking via runtime call
+    bnez(hdr, slow_case, /* is_far */ true);
+    // done
+    bind(done);
+  }
   increment(Address(xthread, JavaThread::held_monitor_count_offset()));
   return null_check_offset;
 }
@@ -115,27 +120,35 @@ void C1_MacroAssembler::unlock_object(Register hdr, Register obj, Register disp_
   assert(hdr != obj && hdr != disp_hdr && obj != disp_hdr, "registers must be different");
   Label done;
 
-  // load displaced header
-  ld(hdr, Address(disp_hdr, 0));
-  // if the loaded hdr is NULL we had recursive locking
-  // if we had recursive locking, we are done
-  beqz(hdr, done);
-  // load object
-  ld(obj, Address(disp_hdr, BasicObjectLock::obj_offset_in_bytes()));
-  verify_oop(obj);
-  // test if object header is pointing to the displaced header, and if so, restore
-  // the displaced header in the object - if the object header is not pointing to
-  // the displaced header, get the object header instead
-  // if the object header was not pointing to the displaced header,
-  // we do unlocking via runtime call
-  if (hdr_offset) {
-    la(t0, Address(obj, hdr_offset));
-    cmpxchgptr(disp_hdr, hdr, t0, t1, done, &slow_case);
+  if (UseFastLocking) {
+    // load object
+    ld(obj, Address(disp_hdr, BasicObjectLock::obj_offset_in_bytes()));
+    verify_oop(obj);
+    ld(hdr, Address(obj, oopDesc::mark_offset_in_bytes()));
+    fast_unlock(obj, hdr, t0, t1, slow_case);
   } else {
-    cmpxchgptr(disp_hdr, hdr, obj, t1, done, &slow_case);
+    // load displaced header
+    ld(hdr, Address(disp_hdr, 0));
+    // if the loaded hdr is NULL we had recursive locking
+    // if we had recursive locking, we are done
+    beqz(hdr, done);
+    // load object
+    ld(obj, Address(disp_hdr, BasicObjectLock::obj_offset_in_bytes()));
+    verify_oop(obj);
+    // test if object header is pointing to the displaced header, and if so, restore
+    // the displaced header in the object - if the object header is not pointing to
+    // the displaced header, get the object header instead
+    // if the object header was not pointing to the displaced header,
+    // we do unlocking via runtime call
+    if (hdr_offset) {
+      la(t0, Address(obj, hdr_offset));
+      cmpxchgptr(disp_hdr, hdr, t0, t1, done, &slow_case);
+    } else {
+      cmpxchgptr(disp_hdr, hdr, obj, t1, done, &slow_case);
+    }
+    // done
+    bind(done);
   }
-  // done
-  bind(done);
   decrement(Address(xthread, JavaThread::held_monitor_count_offset()));
 }
 
@@ -305,7 +318,7 @@ void C1_MacroAssembler::inline_cache_check(Register receiver, Register iCache, L
   cmp_klass(receiver, iCache, t0, t2 /* call-clobbered t2 as a tmp */, L);
 }
 
-void C1_MacroAssembler::build_frame(int framesize, int bang_size_in_bytes) {
+void C1_MacroAssembler::build_frame(int framesize, int bang_size_in_bytes, int max_monitors) {
   assert(bang_size_in_bytes >= framesize, "stack bang size incorrect");
   // Make sure there is enough stack space for this method's activation.
   // Note that we do this before creating a frame.

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -4454,3 +4454,58 @@ void MacroAssembler::rt_call(address dest, Register tmp) {
     });
   }
 }
+
+// Attempt to fast-lock an object. Fall-through on success, branch to slow label
+// on failure.
+// Registers:
+//  - obj: the object to be locked
+//  - hdr: the header, already loaded from obj, will be destroyed
+//  - tmp1, tmp2: temporary registers, will be destroyed
+void MacroAssembler::fast_lock(Register obj, Register hdr, Register tmp1, Register tmp2, Label& slow) {
+  assert(UseFastLocking, "only used with fast-locking");
+  assert_different_registers(obj, hdr, tmp1, tmp2);
+
+  // Check if we would have space on lock-stack for the object.
+  ld(tmp1, Address(xthread, JavaThread::lock_stack_current_offset()));
+  ld(tmp2, Address(xthread, JavaThread::lock_stack_limit_offset()));
+  bge(tmp1, tmp2, slow, true);
+
+  // Load (object->mark() | 1) into hdr
+  ori(hdr, hdr, markWord::unlocked_value);
+  // Clear lock-bits, into tmp2
+  xori(tmp2, hdr, markWord::unlocked_value);
+  // Try to swing header from unlocked to locked
+  Label success;
+  cmpxchgptr(hdr, tmp2, obj, tmp1, success, &slow);
+  bind(success);
+
+  // After successful lock, push object on lock-stack
+  // TODO: Can we avoid re-loading the current offset? The CAS above clobbers it.
+  // Maybe we could ensure that we have enough space on the lock stack more cleverly.
+  ld(tmp1, Address(xthread, JavaThread::lock_stack_current_offset()));
+  sd(obj, Address(tmp1, 0));
+  add(tmp1, tmp1, oopSize);
+  sd(tmp1, Address(xthread, JavaThread::lock_stack_current_offset()));
+}
+
+void MacroAssembler::fast_unlock(Register obj, Register hdr, Register tmp1, Register tmp2, Label& slow) {
+  assert(UseFastLocking, "only used with fast-locking");
+  assert_different_registers(obj, hdr, tmp1, tmp2);
+
+  // Load the expected old header (lock-bits cleared to indicate 'locked') into hdr
+  mv(tmp1, ~markWord::lock_mask_in_place);
+  andr(hdr, hdr, tmp1);
+
+  // Load the new header (unlocked) into tmp1
+  ori(tmp1, hdr, markWord::unlocked_value);
+
+  // Try to swing header from locked to unlocked
+  Label success;
+  cmpxchgptr(hdr, tmp1, obj, tmp2, success, &slow);
+  bind(success);
+
+  // After successful unlock, pop object from lock-stack
+  ld(tmp1, Address(xthread, JavaThread::lock_stack_current_offset()));
+  sub(tmp1, tmp1, oopSize);
+  sd(tmp1, Address(xthread, JavaThread::lock_stack_current_offset()));
+}

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -1369,6 +1369,10 @@ private:
 
   void load_reserved(Register addr, enum operand_size size, Assembler::Aqrl acquire);
   void store_conditional(Register addr, Register new_val, enum operand_size size, Assembler::Aqrl release);
+
+public:
+  void fast_lock(Register obj, Register hdr, Register tmp1, Register tmp2, Label& slow);
+  void fast_unlock(Register obj, Register hdr, Register tmp1, Register tmp2, Label& slow);
 };
 
 #ifdef ASSERT

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -2396,36 +2396,46 @@ encode %{
     __ bnez(t0, object_has_monitor);
 
     if (!UseHeavyMonitors) {
-      // Set tmp to be (markWord of object | UNLOCK_VALUE).
-      __ ori(tmp, disp_hdr, markWord::unlocked_value);
+      if (UseFastLocking) {
+        Label slow;
+        __ fast_lock(oop, disp_hdr, tmp, t0, slow);
+        // Indicate success at cont.
+        __ mv(flag, zr);
+        __ j(cont);
+        __ bind(slow);
+        __ mv(flag, 1); // Set non-zero flag to indicate 'failure' -> take slow-path
+      } else {
+        // Set tmp to be (markWord of object | UNLOCK_VALUE).
+        __ ori(tmp, disp_hdr, markWord::unlocked_value);
 
-      // Initialize the box. (Must happen before we update the object mark!)
-      __ sd(tmp, Address(box, BasicLock::displaced_header_offset_in_bytes()));
+        // Initialize the box. (Must happen before we update the object mark!)
+        __ sd(tmp, Address(box, BasicLock::displaced_header_offset_in_bytes()));
 
-      // Compare object markWord with an unlocked value (tmp) and if
-      // equal exchange the stack address of our box with object markWord.
-      // On failure disp_hdr contains the possibly locked markWord.
-      __ cmpxchg(/*memory address*/oop, /*expected value*/tmp, /*new value*/box, Assembler::int64, Assembler::aq,
-                 Assembler::rl, /*result*/disp_hdr);
-      __ mv(flag, zr);
-      __ beq(disp_hdr, tmp, cont); // prepare zero flag and goto cont if we won the cas
+        // Compare object markWord with an unlocked value (tmp) and if
+        // equal exchange the stack address of our box with object markWord.
+        // On failure disp_hdr contains the possibly locked markWord.
+        __ cmpxchg(/*memory address*/oop, /*expected value*/tmp, /*new value*/box, Assembler::int64, Assembler::aq,
+                   Assembler::rl, /*result*/disp_hdr);
+        __ mv(flag, zr);
+        __ beq(disp_hdr, tmp, cont); // prepare zero flag and goto cont if we won the cas
 
-      assert(oopDesc::mark_offset_in_bytes() == 0, "offset of _mark is not 0");
+        assert(oopDesc::mark_offset_in_bytes() == 0, "offset of _mark is not 0");
 
-      // If the compare-and-exchange succeeded, then we found an unlocked
-      // object, will have now locked it will continue at label cont
-      // We did not see an unlocked object so try the fast recursive case.
+        // If the compare-and-exchange succeeded, then we found an unlocked
+        // object, will have now locked it will continue at label cont
+        // We did not see an unlocked object so try the fast recursive case.
 
-      // Check if the owner is self by comparing the value in the
-      // markWord of object (disp_hdr) with the stack pointer.
-      __ sub(disp_hdr, disp_hdr, sp);
-      __ mv(tmp, (intptr_t) (~(os::vm_page_size()-1) | (uintptr_t)markWord::lock_mask_in_place));
-      // If (mark & lock_mask) == 0 and mark - sp < page_size, we are stack-locking and goto cont,
-      // hence we can store 0 as the displaced header in the box, which indicates that it is a
-      // recursive lock.
-      __ andr(tmp/*==0?*/, disp_hdr, tmp);
-      __ sd(tmp/*==0, perhaps*/, Address(box, BasicLock::displaced_header_offset_in_bytes()));
-      __ mv(flag, tmp); // we can use the value of tmp as the result here
+        // Check if the owner is self by comparing the value in the
+        // markWord of object (disp_hdr) with the stack pointer.
+        __ sub(disp_hdr, disp_hdr, sp);
+        __ mv(tmp, (intptr_t) (~(os::vm_page_size()-1) | (uintptr_t)markWord::lock_mask_in_place));
+        // If (mark & lock_mask) == 0 and mark - sp < page_size, we are stack-locking and goto cont,
+        // hence we can store 0 as the displaced header in the box, which indicates that it is a
+        // recursive lock.
+        __ andr(tmp/*==0?*/, disp_hdr, tmp);
+        __ sd(tmp/*==0, perhaps*/, Address(box, BasicLock::displaced_header_offset_in_bytes()));
+        __ mv(flag, tmp); // we can use the value of tmp as the result here
+      }
     } else {
       __ mv(flag, 1); // Set non-zero flag to indicate 'failure' -> take slow-path
     }
@@ -2442,12 +2452,14 @@ encode %{
     __ cmpxchg(/*memory address*/tmp, /*expected value*/zr, /*new value*/xthread, Assembler::int64, Assembler::aq,
              Assembler::rl, /*result*/flag); // cas succeeds if flag == zr(expected)
 
-    // Store a non-null value into the box to avoid looking like a re-entrant
-    // lock. The fast-path monitor unlock code checks for
-    // markWord::monitor_value so use markWord::unused_mark which has the
-    // relevant bit set, and also matches ObjectSynchronizer::slow_enter.
-    __ mv(tmp, (address)markWord::unused_mark().value());
-    __ sd(tmp, Address(box, BasicLock::displaced_header_offset_in_bytes()));
+    if (!UseFastLocking) {
+      // Store a non-null value into the box to avoid looking like a re-entrant
+      // lock. The fast-path monitor unlock code checks for
+      // markWord::monitor_value so use markWord::unused_mark which has the
+      // relevant bit set, and also matches ObjectSynchronizer::slow_enter.
+      __ mv(tmp, (address)markWord::unused_mark().value());
+      __ sd(tmp, Address(box, BasicLock::displaced_header_offset_in_bytes()));
+    }
 
     __ beqz(flag, cont); // CAS success means locking succeeded
 
@@ -2480,7 +2492,7 @@ encode %{
 
     assert_different_registers(oop, box, tmp, disp_hdr, flag);
 
-    if (!UseHeavyMonitors) {
+    if (!UseHeavyMonitors && !UseFastLocking) {
       // Find the lock address and load the displaced header from the stack.
       __ ld(disp_hdr, Address(box, BasicLock::displaced_header_offset_in_bytes()));
 
@@ -2495,13 +2507,24 @@ encode %{
     __ bnez(t0, object_has_monitor);
 
     if (!UseHeavyMonitors) {
-      // Check if it is still a light weight lock, this is true if we
-      // see the stack address of the basicLock in the markWord of the
-      // object.
+      if (UseFastLocking) {
+        Label slow;
+        __ fast_unlock(oop, tmp, box, disp_hdr, slow);
 
-      __ cmpxchg(/*memory address*/oop, /*expected value*/box, /*new value*/disp_hdr, Assembler::int64, Assembler::relaxed,
-                 Assembler::rl, /*result*/tmp);
-      __ xorr(flag, box, tmp); // box == tmp if cas succeeds
+        // Indicate success at cont.
+        __ mv(flag, zr);
+        __ j(cont);
+        __ bind(slow);
+        __ mv(flag, 1); // Set non-zero flag to indicate 'failure' -> take slow path
+      } else {
+        // Check if it is still a light weight lock, this is true if we
+        // see the stack address of the basicLock in the markWord of the
+        // object.
+
+        __ cmpxchg(/*memory address*/oop, /*expected value*/box, /*new value*/disp_hdr, Assembler::int64, Assembler::relaxed,
+                   Assembler::rl, /*result*/tmp);
+        __ xorr(flag, box, tmp); // box == tmp if cas succeeds
+      }
     } else {
       __ mv(flag, 1); // Set non-zero flag to indicate 'failure' -> take slow path
     }
@@ -2513,6 +2536,17 @@ encode %{
     __ bind(object_has_monitor);
     STATIC_ASSERT(markWord::monitor_value <= INT_MAX);
     __ add(tmp, tmp, -(int)markWord::monitor_value); // monitor
+
+    if (UseFastLocking) {
+      Label L;
+      __ ld(disp_hdr, Address(tmp, ObjectMonitor::owner_offset_in_bytes()));
+      __ mv(t0, (unsigned char)(intptr_t)ANONYMOUS_OWNER);
+      __ bne(disp_hdr, t0, L);
+      __ mv(flag, 1); // Indicate failure at cont -- dive into slow-path.
+      __ j(cont);
+      __ bind(L);
+    }
+
     __ ld(disp_hdr, Address(tmp, ObjectMonitor::recursions_offset_in_bytes()));
 
     Label notRecursive;

--- a/src/hotspot/cpu/s390/c1_LIRAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/c1_LIRAssembler_s390.cpp
@@ -112,7 +112,7 @@ void LIR_Assembler::osr_entry() {
   int number_of_locks = entry_state->locks_size();
 
   // Create a frame for the compiled activation.
-  __ build_frame(initial_frame_size_in_bytes(), bang_size_in_bytes());
+  __ build_frame(initial_frame_size_in_bytes(), bang_size_in_bytes(), compilation()->max_monitors());
 
   // OSR buffer is
   //

--- a/src/hotspot/cpu/s390/c1_MacroAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/c1_MacroAssembler_s390.cpp
@@ -69,7 +69,7 @@ void C1_MacroAssembler::explicit_null_check(Register base) {
   ShouldNotCallThis(); // unused
 }
 
-void C1_MacroAssembler::build_frame(int frame_size_in_bytes, int bang_size_in_bytes) {
+void C1_MacroAssembler::build_frame(int frame_size_in_bytes, int bang_size_in_bytes, int max_monitors) {
   assert(bang_size_in_bytes >= frame_size_in_bytes, "stack bang size incorrect");
   generate_stack_overflow_check(bang_size_in_bytes);
   save_return_pc();

--- a/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
@@ -285,7 +285,7 @@ void LIR_Assembler::osr_entry() {
 
   // build frame
   ciMethod* m = compilation()->method();
-  __ build_frame(initial_frame_size_in_bytes(), bang_size_in_bytes());
+  __ build_frame(initial_frame_size_in_bytes(), bang_size_in_bytes(), compilation()->max_monitors());
 
   // OSR buffer is
   //
@@ -3512,8 +3512,9 @@ void LIR_Assembler::emit_lock(LIR_OpLock* op) {
     __ jmp(*op->stub()->entry());
   } else if (op->code() == lir_lock) {
     assert(BasicLock::displaced_header_offset_in_bytes() == 0, "lock_reg must point to the displaced header");
+    Register tmp = UseFastLocking ? op->scratch_opr()->as_register() : noreg;
     // add debug info for NullPointerException only if one is possible
-    int null_check_offset = __ lock_object(hdr, obj, lock, *op->stub()->entry());
+    int null_check_offset = __ lock_object(hdr, obj, lock, tmp, *op->stub()->entry());
     if (op->info() != NULL) {
       add_debug_info_for_null_check(null_check_offset, op->info());
     }

--- a/src/hotspot/cpu/x86/c1_LIRGenerator_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRGenerator_x86.cpp
@@ -319,7 +319,8 @@ void LIRGenerator::do_MonitorEnter(MonitorEnter* x) {
   // this CodeEmitInfo must not have the xhandlers because here the
   // object is already locked (xhandlers expect object to be unlocked)
   CodeEmitInfo* info = state_for(x, x->state(), true);
-  monitor_enter(obj.result(), lock, syncTempOpr(), LIR_OprFact::illegalOpr,
+  LIR_Opr tmp = UseFastLocking ? new_register(T_INT) : LIR_OprFact::illegalOpr;
+  monitor_enter(obj.result(), lock, syncTempOpr(), tmp,
                         x->monitor_no(), info_for_exception, info);
 }
 

--- a/src/hotspot/cpu/x86/c1_MacroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/c1_MacroAssembler_x86.hpp
@@ -50,7 +50,7 @@
   // obj     : must point to the object to lock, contents preserved
   // disp_hdr: must point to the displaced header location, contents preserved
   // returns code offset at which to add null check debug information
-  int lock_object  (Register swap, Register obj, Register disp_hdr, Label& slow_case);
+  int lock_object  (Register swap, Register obj, Register disp_hdr, Register tmp, Label& slow_case);
 
   // unlocking
   // hdr     : contents destroyed

--- a/src/hotspot/cpu/x86/c2_CodeStubs_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_CodeStubs_x86.cpp
@@ -72,4 +72,15 @@ void C2EntryBarrierStub::emit(C2_MacroAssembler& masm) {
   __ jmp(continuation(), false /* maybe_short */);
 }
 
+int C2CheckLockStackStub::max_size() const {
+  return 10;
+}
+
+void C2CheckLockStackStub::emit(C2_MacroAssembler& masm) {
+  __ bind(entry());
+  assert(StubRoutines::x86::check_lock_stack() != NULL, "need runtime call stub");
+  __ call(RuntimeAddress(StubRoutines::x86::check_lock_stack()));
+  __ jmp(continuation(), false /* maybe_short */);
+}
+
 #undef __

--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.hpp
@@ -29,7 +29,7 @@
 
 public:
   // C2 compiled method's prolog code.
-  void verified_entry(int framesize, int stack_bang_size, bool fp_mode_24b, bool is_stub);
+  void verified_entry(int framesize, int stack_bang_size, bool fp_mode_24b, bool is_stub, int max_monitors);
 
   void emit_entry_barrier_stub(C2EntryBarrierStub* stub);
   static int entry_barrier_stub_size();
@@ -39,7 +39,7 @@ public:
   // Code used by cmpFastLock and cmpFastUnlock mach instructions in .ad file.
   // See full description in macroAssembler_x86.cpp.
   void fast_lock(Register obj, Register box, Register tmp,
-                 Register scr, Register cx1, Register cx2,
+                 Register scr, Register cx1, Register cx2, Register thread,
                  RTMLockingCounters* rtm_counters,
                  RTMLockingCounters* stack_rtm_counters,
                  Metadata* method_data,

--- a/src/hotspot/cpu/x86/interp_masm_x86.cpp
+++ b/src/hotspot/cpu/x86/interp_masm_x86.cpp
@@ -1223,59 +1223,71 @@ void InterpreterMacroAssembler::lock_object(Register lock_reg) {
       jcc(Assembler::notZero, slow_case);
     }
 
-    // Load immediate 1 into swap_reg %rax
-    movl(swap_reg, 1);
+    if (UseFastLocking) {
+#ifdef _LP64
+      const Register thread = r15_thread;
+#else
+      const Register thread = lock_reg;
+      get_thread(thread);
+#endif
+      // Load object header, prepare for CAS from unlocked to locked.
+      movptr(swap_reg, Address(obj_reg, oopDesc::mark_offset_in_bytes()));
+      fast_lock_impl(obj_reg, swap_reg, thread, tmp_reg, slow_case);
+    } else {
+      // Load immediate 1 into swap_reg %rax
+      movl(swap_reg, 1);
 
-    // Load (object->mark() | 1) into swap_reg %rax
-    orptr(swap_reg, Address(obj_reg, oopDesc::mark_offset_in_bytes()));
+      // Load (object->mark() | 1) into swap_reg %rax
+      orptr(swap_reg, Address(obj_reg, oopDesc::mark_offset_in_bytes()));
 
-    // Save (object->mark() | 1) into BasicLock's displaced header
-    movptr(Address(lock_reg, mark_offset), swap_reg);
+      // Save (object->mark() | 1) into BasicLock's displaced header
+      movptr(Address(lock_reg, mark_offset), swap_reg);
 
-    assert(lock_offset == 0,
-           "displaced header must be first word in BasicObjectLock");
+      assert(lock_offset == 0,
+             "displaced header must be first word in BasicObjectLock");
 
-    lock();
-    cmpxchgptr(lock_reg, Address(obj_reg, oopDesc::mark_offset_in_bytes()));
-    jcc(Assembler::zero, count_locking);
+      lock();
+      cmpxchgptr(lock_reg, Address(obj_reg, oopDesc::mark_offset_in_bytes()));
+      jcc(Assembler::zero, count_locking);
 
-    const int zero_bits = LP64_ONLY(7) NOT_LP64(3);
+      const int zero_bits = LP64_ONLY(7) NOT_LP64(3);
 
-    // Fast check for recursive lock.
-    //
-    // Can apply the optimization only if this is a stack lock
-    // allocated in this thread. For efficiency, we can focus on
-    // recently allocated stack locks (instead of reading the stack
-    // base and checking whether 'mark' points inside the current
-    // thread stack):
-    //  1) (mark & zero_bits) == 0, and
-    //  2) rsp <= mark < mark + os::pagesize()
-    //
-    // Warning: rsp + os::pagesize can overflow the stack base. We must
-    // neither apply the optimization for an inflated lock allocated
-    // just above the thread stack (this is why condition 1 matters)
-    // nor apply the optimization if the stack lock is inside the stack
-    // of another thread. The latter is avoided even in case of overflow
-    // because we have guard pages at the end of all stacks. Hence, if
-    // we go over the stack base and hit the stack of another thread,
-    // this should not be in a writeable area that could contain a
-    // stack lock allocated by that thread. As a consequence, a stack
-    // lock less than page size away from rsp is guaranteed to be
-    // owned by the current thread.
-    //
-    // These 3 tests can be done by evaluating the following
-    // expression: ((mark - rsp) & (zero_bits - os::vm_page_size())),
-    // assuming both stack pointer and pagesize have their
-    // least significant bits clear.
-    // NOTE: the mark is in swap_reg %rax as the result of cmpxchg
-    subptr(swap_reg, rsp);
-    andptr(swap_reg, zero_bits - os::vm_page_size());
+      // Fast check for recursive lock.
+      //
+      // Can apply the optimization only if this is a stack lock
+      // allocated in this thread. For efficiency, we can focus on
+      // recently allocated stack locks (instead of reading the stack
+      // base and checking whether 'mark' points inside the current
+      // thread stack):
+      //  1) (mark & zero_bits) == 0, and
+      //  2) rsp <= mark < mark + os::pagesize()
+      //
+      // Warning: rsp + os::pagesize can overflow the stack base. We must
+      // neither apply the optimization for an inflated lock allocated
+      // just above the thread stack (this is why condition 1 matters)
+      // nor apply the optimization if the stack lock is inside the stack
+      // of another thread. The latter is avoided even in case of overflow
+      // because we have guard pages at the end of all stacks. Hence, if
+      // we go over the stack base and hit the stack of another thread,
+      // this should not be in a writeable area that could contain a
+      // stack lock allocated by that thread. As a consequence, a stack
+      // lock less than page size away from rsp is guaranteed to be
+      // owned by the current thread.
+      //
+      // These 3 tests can be done by evaluating the following
+      // expression: ((mark - rsp) & (zero_bits - os::vm_page_size())),
+      // assuming both stack pointer and pagesize have their
+      // least significant bits clear.
+      // NOTE: the mark is in swap_reg %rax as the result of cmpxchg
+      subptr(swap_reg, rsp);
+      andptr(swap_reg, zero_bits - os::vm_page_size());
 
-    // Save the test result, for recursive case, the result is zero
-    movptr(Address(lock_reg, mark_offset), swap_reg);
-    jcc(Assembler::notZero, slow_case);
+      // Save the test result, for recursive case, the result is zero
+      movptr(Address(lock_reg, mark_offset), swap_reg);
+      jcc(Assembler::notZero, slow_case);
 
-    bind(count_locking);
+      bind(count_locking);
+    }
     inc_held_monitor_count();
     jmp(done);
 
@@ -1284,7 +1296,7 @@ void InterpreterMacroAssembler::lock_object(Register lock_reg) {
     // Call the runtime routine for slow case
     call_VM(noreg,
             CAST_FROM_FN_PTR(address, InterpreterRuntime::monitorenter),
-            lock_reg);
+            UseFastLocking ? obj_reg : lock_reg);
 
     bind(done);
   }
@@ -1318,9 +1330,11 @@ void InterpreterMacroAssembler::unlock_object(Register lock_reg) {
 
     save_bcp(); // Save in case of exception
 
-    // Convert from BasicObjectLock structure to object and BasicLock
-    // structure Store the BasicLock address into %rax
-    lea(swap_reg, Address(lock_reg, BasicObjectLock::lock_offset_in_bytes()));
+    if (!UseFastLocking) {
+      // Convert from BasicObjectLock structure to object and BasicLock
+      // structure Store the BasicLock address into %rax
+      lea(swap_reg, Address(lock_reg, BasicObjectLock::lock_offset_in_bytes()));
+    }
 
     // Load oop into obj_reg(%c_rarg3)
     movptr(obj_reg, Address(lock_reg, BasicObjectLock::obj_offset_in_bytes()));
@@ -1328,24 +1342,40 @@ void InterpreterMacroAssembler::unlock_object(Register lock_reg) {
     // Free entry
     movptr(Address(lock_reg, BasicObjectLock::obj_offset_in_bytes()), NULL_WORD);
 
-    // Load the old header from BasicLock structure
-    movptr(header_reg, Address(swap_reg,
-                               BasicLock::displaced_header_offset_in_bytes()));
+    if (UseFastLocking) {
+#ifdef _LP64
+      const Register thread = r15_thread;
+#else
+      const Register thread = header_reg;
+      get_thread(thread);
+#endif
+      // Handle unstructured locking.
+      cmpptr(obj_reg, Address(thread, JavaThread::lock_stack_current_offset()));
+      jcc(Assembler::notEqual, slow_case);
+      // Try to swing header from locked to unlock.
+      movptr(swap_reg, Address(obj_reg, oopDesc::mark_offset_in_bytes()));
+      andptr(swap_reg, ~(int32_t)markWord::lock_mask_in_place);
+      fast_unlock_impl(obj_reg, swap_reg, header_reg, slow_case);
+    } else {
+      // Load the old header from BasicLock structure
+      movptr(header_reg, Address(swap_reg,
+                                 BasicLock::displaced_header_offset_in_bytes()));
 
-    // Test for recursion
-    testptr(header_reg, header_reg);
+      // Test for recursion
+      testptr(header_reg, header_reg);
 
-    // zero for recursive case
-    jcc(Assembler::zero, count_locking);
+      // zero for recursive case
+      jcc(Assembler::zero, count_locking);
 
-    // Atomic swap back the old header
-    lock();
-    cmpxchgptr(header_reg, Address(obj_reg, oopDesc::mark_offset_in_bytes()));
+      // Atomic swap back the old header
+      lock();
+      cmpxchgptr(header_reg, Address(obj_reg, oopDesc::mark_offset_in_bytes()));
 
-    // zero for simple unlock of a stack-lock case
-    jcc(Assembler::notZero, slow_case);
+      // zero for simple unlock of a stack-lock case
+      jcc(Assembler::notZero, slow_case);
 
-    bind(count_locking);
+      bind(count_locking);
+    }
     dec_held_monitor_count();
     jmp(done);
 

--- a/src/hotspot/cpu/x86/macroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.hpp
@@ -874,6 +874,7 @@ public:
   void orptr(Address dst, int32_t imm32) { LP64_ONLY(orq(dst, imm32)) NOT_LP64(orl(dst, imm32)); }
 
   void testptr(Register src, int32_t imm32) {  LP64_ONLY(testq(src, imm32)) NOT_LP64(testl(src, imm32)); }
+  void testptr(Address  src, int32_t imm32) {  LP64_ONLY(testq(src, imm32)) NOT_LP64(testl(src, imm32)); }
   void testptr(Register src1, Address src2) { LP64_ONLY(testq(src1, src2)) NOT_LP64(testl(src1, src2)); }
   void testptr(Register src1, Register src2);
 
@@ -2018,6 +2019,8 @@ public:
 
   void check_stack_alignment(Register sp, const char* msg, unsigned bias = 0, Register tmp = noreg);
 
+  void fast_lock_impl(Register obj, Register hdr, Register thread, Register tmp, Label& slow, bool rt_check_stack = true);
+  void fast_unlock_impl(Register obj, Register hdr, Register tmp, Label& slow);
 };
 
 /**

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp
@@ -1677,36 +1677,42 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
     __ movptr(obj_reg, Address(oop_handle_reg, 0));
 
     if (!UseHeavyMonitors) {
-      // Load immediate 1 into swap_reg %rax,
-      __ movptr(swap_reg, 1);
+      if (UseFastLocking) {
+        // Load object header
+        __ movptr(swap_reg, Address(obj_reg, oopDesc::mark_offset_in_bytes()));
+        __ fast_lock_impl(obj_reg, swap_reg, thread, lock_reg, slow_path_lock);
+      } else {
+        // Load immediate 1 into swap_reg %rax,
+        __ movptr(swap_reg, 1);
 
-      // Load (object->mark() | 1) into swap_reg %rax,
-      __ orptr(swap_reg, Address(obj_reg, oopDesc::mark_offset_in_bytes()));
+        // Load (object->mark() | 1) into swap_reg %rax,
+        __ orptr(swap_reg, Address(obj_reg, oopDesc::mark_offset_in_bytes()));
 
-      // Save (object->mark() | 1) into BasicLock's displaced header
-      __ movptr(Address(lock_reg, mark_word_offset), swap_reg);
+        // Save (object->mark() | 1) into BasicLock's displaced header
+        __ movptr(Address(lock_reg, mark_word_offset), swap_reg);
 
-      // src -> dest iff dest == rax, else rax, <- dest
-      // *obj_reg = lock_reg iff *obj_reg == rax, else rax, = *(obj_reg)
-      __ lock();
-      __ cmpxchgptr(lock_reg, Address(obj_reg, oopDesc::mark_offset_in_bytes()));
-      __ jcc(Assembler::equal, count_mon);
+        // src -> dest iff dest == rax, else rax, <- dest
+        // *obj_reg = lock_reg iff *obj_reg == rax, else rax, = *(obj_reg)
+        __ lock();
+        __ cmpxchgptr(lock_reg, Address(obj_reg, oopDesc::mark_offset_in_bytes()));
+        __ jcc(Assembler::equal, count_mon);
 
-      // Test if the oopMark is an obvious stack pointer, i.e.,
-      //  1) (mark & 3) == 0, and
-      //  2) rsp <= mark < mark + os::pagesize()
-      // These 3 tests can be done by evaluating the following
-      // expression: ((mark - rsp) & (3 - os::vm_page_size())),
-      // assuming both stack pointer and pagesize have their
-      // least significant 2 bits clear.
-      // NOTE: the oopMark is in swap_reg %rax, as the result of cmpxchg
+        // Test if the oopMark is an obvious stack pointer, i.e.,
+        //  1) (mark & 3) == 0, and
+        //  2) rsp <= mark < mark + os::pagesize()
+        // These 3 tests can be done by evaluating the following
+        // expression: ((mark - rsp) & (3 - os::vm_page_size())),
+        // assuming both stack pointer and pagesize have their
+        // least significant 2 bits clear.
+        // NOTE: the oopMark is in swap_reg %rax, as the result of cmpxchg
 
-      __ subptr(swap_reg, rsp);
-      __ andptr(swap_reg, 3 - os::vm_page_size());
+        __ subptr(swap_reg, rsp);
+        __ andptr(swap_reg, 3 - os::vm_page_size());
 
-      // Save the test result, for recursive case, the result is zero
-      __ movptr(Address(lock_reg, mark_word_offset), swap_reg);
-      __ jcc(Assembler::notEqual, slow_path_lock);
+        // Save the test result, for recursive case, the result is zero
+        __ movptr(Address(lock_reg, mark_word_offset), swap_reg);
+       __ jcc(Assembler::notEqual, slow_path_lock);
+      }
     } else {
       __ jmp(slow_path_lock);
     }
@@ -1830,7 +1836,7 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
     // Get locked oop from the handle we passed to jni
     __ movptr(obj_reg, Address(oop_handle_reg, 0));
 
-    if (!UseHeavyMonitors) {
+    if (!UseHeavyMonitors && !UseFastLocking) {
       Label not_recur;
       // Simple recursive lock?
       __ cmpptr(Address(rbp, lock_slot_rbp_offset), NULL_WORD);
@@ -1846,18 +1852,24 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
     }
 
     if (!UseHeavyMonitors) {
-      //  get old displaced header
-      __ movptr(rbx, Address(rbp, lock_slot_rbp_offset));
+      if (UseFastLocking) {
+        __ movptr(swap_reg, Address(obj_reg, oopDesc::mark_offset_in_bytes()));
+        __ andptr(swap_reg, ~(int32_t)markWord::lock_mask_in_place);
+        __ fast_unlock_impl(obj_reg, swap_reg, lock_reg, slow_path_unlock);
+      } else {
+        //  get old displaced header
+        __ movptr(rbx, Address(rbp, lock_slot_rbp_offset));
 
-      // get address of the stack lock
-      __ lea(rax, Address(rbp, lock_slot_rbp_offset));
+        // get address of the stack lock
+        __ lea(rax, Address(rbp, lock_slot_rbp_offset));
 
-      // Atomic swap old header if oop still contains the stack lock
-      // src -> dest iff dest == rax, else rax, <- dest
-      // *obj_reg = rbx, iff *obj_reg == rax, else rax, = *(obj_reg)
-      __ lock();
-      __ cmpxchgptr(rbx, Address(obj_reg, oopDesc::mark_offset_in_bytes()));
-      __ jcc(Assembler::notEqual, slow_path_unlock);
+        // Atomic swap old header if oop still contains the stack lock
+        // src -> dest iff dest == rax, else rax, <- dest
+        // *obj_reg = rbx, iff *obj_reg == rax, else rax, = *(obj_reg)
+        __ lock();
+        __ cmpxchgptr(rbx, Address(obj_reg, oopDesc::mark_offset_in_bytes()));
+        __ jcc(Assembler::notEqual, slow_path_unlock);
+      }
       __ dec_held_monitor_count();
     } else {
       __ jmp(slow_path_unlock);

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
@@ -2136,38 +2136,43 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
     __ movptr(obj_reg, Address(oop_handle_reg, 0));
 
     if (!UseHeavyMonitors) {
+      if (UseFastLocking) {
+        // Load object header
+        __ movptr(swap_reg, Address(obj_reg, oopDesc::mark_offset_in_bytes()));
+        __ fast_lock_impl(obj_reg, swap_reg, r15_thread, rscratch1, slow_path_lock);
+      } else {
+        // Load immediate 1 into swap_reg %rax
+        __ movl(swap_reg, 1);
 
-      // Load immediate 1 into swap_reg %rax
-      __ movl(swap_reg, 1);
+        // Load (object->mark() | 1) into swap_reg %rax
+        __ orptr(swap_reg, Address(obj_reg, oopDesc::mark_offset_in_bytes()));
 
-      // Load (object->mark() | 1) into swap_reg %rax
-      __ orptr(swap_reg, Address(obj_reg, oopDesc::mark_offset_in_bytes()));
+        // Save (object->mark() | 1) into BasicLock's displaced header
+        __ movptr(Address(lock_reg, mark_word_offset), swap_reg);
 
-      // Save (object->mark() | 1) into BasicLock's displaced header
-      __ movptr(Address(lock_reg, mark_word_offset), swap_reg);
+        // src -> dest iff dest == rax else rax <- dest
+        __ lock();
+        __ cmpxchgptr(lock_reg, Address(obj_reg, oopDesc::mark_offset_in_bytes()));
+        __ jcc(Assembler::equal, count_mon);
 
-      // src -> dest iff dest == rax else rax <- dest
-      __ lock();
-      __ cmpxchgptr(lock_reg, Address(obj_reg, oopDesc::mark_offset_in_bytes()));
-      __ jcc(Assembler::equal, count_mon);
+        // Hmm should this move to the slow path code area???
 
-      // Hmm should this move to the slow path code area???
+        // Test if the oopMark is an obvious stack pointer, i.e.,
+        //  1) (mark & 3) == 0, and
+        //  2) rsp <= mark < mark + os::pagesize()
+        // These 3 tests can be done by evaluating the following
+        // expression: ((mark - rsp) & (3 - os::vm_page_size())),
+        // assuming both stack pointer and pagesize have their
+        // least significant 2 bits clear.
+        // NOTE: the oopMark is in swap_reg %rax as the result of cmpxchg
 
-      // Test if the oopMark is an obvious stack pointer, i.e.,
-      //  1) (mark & 3) == 0, and
-      //  2) rsp <= mark < mark + os::pagesize()
-      // These 3 tests can be done by evaluating the following
-      // expression: ((mark - rsp) & (3 - os::vm_page_size())),
-      // assuming both stack pointer and pagesize have their
-      // least significant 2 bits clear.
-      // NOTE: the oopMark is in swap_reg %rax as the result of cmpxchg
+        __ subptr(swap_reg, rsp);
+        __ andptr(swap_reg, 3 - os::vm_page_size());
 
-      __ subptr(swap_reg, rsp);
-      __ andptr(swap_reg, 3 - os::vm_page_size());
-
-      // Save the test result, for recursive case, the result is zero
-      __ movptr(Address(lock_reg, mark_word_offset), swap_reg);
-      __ jcc(Assembler::notEqual, slow_path_lock);
+        // Save the test result, for recursive case, the result is zero
+        __ movptr(Address(lock_reg, mark_word_offset), swap_reg);
+        __ jcc(Assembler::notEqual, slow_path_lock);
+      }
     } else {
       __ jmp(slow_path_lock);
     }
@@ -2281,7 +2286,7 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
     // Get locked oop from the handle we passed to jni
     __ movptr(obj_reg, Address(oop_handle_reg, 0));
 
-    if (!UseHeavyMonitors) {
+    if (!UseHeavyMonitors && !UseFastLocking) {
       Label not_recur;
       // Simple recursive lock?
       __ cmpptr(Address(rsp, lock_slot_offset * VMRegImpl::stack_slot_size), NULL_WORD);
@@ -2297,15 +2302,21 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
     }
 
     if (!UseHeavyMonitors) {
-      // get address of the stack lock
-      __ lea(rax, Address(rsp, lock_slot_offset * VMRegImpl::stack_slot_size));
-      //  get old displaced header
-      __ movptr(old_hdr, Address(rax, 0));
+      if (UseFastLocking) {
+        __ movptr(swap_reg, Address(obj_reg, oopDesc::mark_offset_in_bytes()));
+        __ andptr(swap_reg, ~(int32_t)markWord::lock_mask_in_place);
+        __ fast_unlock_impl(obj_reg, swap_reg, lock_reg, slow_path_unlock);
+      } else {
+        // get address of the stack lock
+        __ lea(rax, Address(rsp, lock_slot_offset * VMRegImpl::stack_slot_size));
+        //  get old displaced header
+        __ movptr(old_hdr, Address(rax, 0));
 
-      // Atomic swap old header if oop still contains the stack lock
-      __ lock();
-      __ cmpxchgptr(old_hdr, Address(obj_reg, oopDesc::mark_offset_in_bytes()));
-      __ jcc(Assembler::notEqual, slow_path_unlock);
+        // Atomic swap old header if oop still contains the stack lock
+        __ lock();
+        __ cmpxchgptr(old_hdr, Address(obj_reg, oopDesc::mark_offset_in_bytes()));
+        __ jcc(Assembler::notEqual, slow_path_unlock);
+      }
       __ dec_held_monitor_count();
     } else {
       __ jmp(slow_path_unlock);

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -3026,6 +3026,55 @@ address StubGenerator::generate_method_entry_barrier() {
   return start;
 }
 
+// Call runtime to ensure lock-stack size.
+// Arguments:
+// - c_rarg0: the required _limit pointer
+address StubGenerator::generate_check_lock_stack() {
+  __ align(CodeEntryAlignment);
+  StubCodeMark mark(this, "StubRoutines", "check_lock_stack");
+  address start = __ pc();
+
+  BLOCK_COMMENT("Entry:");
+  __ enter(); // save rbp
+
+  __ pusha();
+
+  // The method may have floats as arguments, and we must spill them before calling
+  // the VM runtime.
+  assert(Argument::n_float_register_parameters_j == 8, "Assumption");
+  const int xmm_size = wordSize * 2;
+  const int xmm_spill_size = xmm_size * Argument::n_float_register_parameters_j;
+  __ subptr(rsp, xmm_spill_size);
+  __ movdqu(Address(rsp, xmm_size * 7), xmm7);
+  __ movdqu(Address(rsp, xmm_size * 6), xmm6);
+  __ movdqu(Address(rsp, xmm_size * 5), xmm5);
+  __ movdqu(Address(rsp, xmm_size * 4), xmm4);
+  __ movdqu(Address(rsp, xmm_size * 3), xmm3);
+  __ movdqu(Address(rsp, xmm_size * 2), xmm2);
+  __ movdqu(Address(rsp, xmm_size * 1), xmm1);
+  __ movdqu(Address(rsp, xmm_size * 0), xmm0);
+
+  __ call_VM_leaf(CAST_FROM_FN_PTR(address, static_cast<void (*)(oop*)>(LockStack::ensure_lock_stack_size)), rax);
+
+  __ movdqu(xmm0, Address(rsp, xmm_size * 0));
+  __ movdqu(xmm1, Address(rsp, xmm_size * 1));
+  __ movdqu(xmm2, Address(rsp, xmm_size * 2));
+  __ movdqu(xmm3, Address(rsp, xmm_size * 3));
+  __ movdqu(xmm4, Address(rsp, xmm_size * 4));
+  __ movdqu(xmm5, Address(rsp, xmm_size * 5));
+  __ movdqu(xmm6, Address(rsp, xmm_size * 6));
+  __ movdqu(xmm7, Address(rsp, xmm_size * 7));
+  __ addptr(rsp, xmm_spill_size);
+
+  __ popa();
+
+  __ leave();
+
+  __ ret(0);
+
+  return start;
+}
+
  /**
  *  Arguments:
  *
@@ -3913,6 +3962,9 @@ void StubGenerator::generate_all() {
   BarrierSetNMethod* bs_nm = BarrierSet::barrier_set()->barrier_set_nmethod();
   if (bs_nm != NULL) {
     StubRoutines::x86::_method_entry_barrier = generate_method_entry_barrier();
+  }
+  if (UseFastLocking) {
+    StubRoutines::x86::_check_lock_stack = generate_check_lock_stack();
   }
 #ifdef COMPILER2
   if (UseMultiplyToLenIntrinsic) {

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.hpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.hpp
@@ -463,6 +463,8 @@ class StubGenerator: public StubCodeGenerator {
 
   address generate_method_entry_barrier();
 
+  address generate_check_lock_stack();
+
   address generate_mulAdd();
 
   address generate_bigIntegerRightShift();

--- a/src/hotspot/cpu/x86/stubRoutines_x86.cpp
+++ b/src/hotspot/cpu/x86/stubRoutines_x86.cpp
@@ -82,6 +82,7 @@ address StubRoutines::x86::_join_2_3_base64 = NULL;
 address StubRoutines::x86::_decoding_table_base64 = NULL;
 #endif
 address StubRoutines::x86::_pshuffle_byte_flip_mask_addr = NULL;
+address StubRoutines::x86::_check_lock_stack = NULL;
 
 uint64_t StubRoutines::x86::_crc_by128_masks[] =
 {

--- a/src/hotspot/cpu/x86/stubRoutines_x86.hpp
+++ b/src/hotspot/cpu/x86/stubRoutines_x86.hpp
@@ -126,6 +126,8 @@ class x86 {
 
   static address _method_entry_barrier;
 
+  static address _check_lock_stack;
+
   // masks and table for CRC32
   static uint64_t _crc_by128_masks[];
   static juint    _crc_table[];
@@ -210,6 +212,8 @@ class x86 {
   static address shuffle_byte_flip_mask_addr() { return _shuffle_byte_flip_mask_addr; }
   static address k256_addr()      { return _k256_adr; }
   static address method_entry_barrier() { return _method_entry_barrier; }
+
+  static address check_lock_stack() { return _check_lock_stack; }
 
   static address vector_short_to_byte_mask() {
     return _vector_short_to_byte_mask;

--- a/src/hotspot/cpu/x86/x86_32.ad
+++ b/src/hotspot/cpu/x86/x86_32.ad
@@ -614,7 +614,8 @@ void MachPrologNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
   int framesize = C->output()->frame_size_in_bytes();
   int bangsize = C->output()->bang_size_in_bytes();
 
-  __ verified_entry(framesize, C->output()->need_stack_bang(bangsize)?bangsize:0, C->in_24_bit_fp_mode(), C->stub_function() != NULL);
+  int max_monitors = C->method() != NULL ? C->max_monitors() : 0;
+  __ verified_entry(framesize, C->output()->need_stack_bang(bangsize)?bangsize:0, C->in_24_bit_fp_mode(), C->stub_function() != NULL, max_monitors);
 
   C->output()->set_frame_complete(cbuf.insts_size());
 
@@ -13802,15 +13803,16 @@ instruct RethrowException()
 
 // inlined locking and unlocking
 
-instruct cmpFastLockRTM(eFlagsReg cr, eRegP object, eBXRegP box, eAXRegI tmp, eDXRegI scr, rRegI cx1, rRegI cx2) %{
+instruct cmpFastLockRTM(eFlagsReg cr, eRegP object, eBXRegP box, eAXRegI tmp, eDXRegI scr, rRegI cx1, rRegI cx2, eRegP thread) %{
   predicate(Compile::current()->use_rtm());
   match(Set cr (FastLock object box));
-  effect(TEMP tmp, TEMP scr, TEMP cx1, TEMP cx2, USE_KILL box);
+  effect(TEMP tmp, TEMP scr, TEMP cx1, TEMP cx2, USE_KILL box, TEMP thread);
   ins_cost(300);
   format %{ "FASTLOCK $object,$box\t! kills $box,$tmp,$scr,$cx1,$cx2" %}
   ins_encode %{
+    __ get_thread($thread$$Register);
     __ fast_lock($object$$Register, $box$$Register, $tmp$$Register,
-                 $scr$$Register, $cx1$$Register, $cx2$$Register,
+                 $scr$$Register, $cx1$$Register, $cx2$$Register, $thread$$Register,
                  _rtm_counters, _stack_rtm_counters,
                  ((Method*)(ra_->C->method()->constant_encoding()))->method_data(),
                  true, ra_->C->profile_rtm());
@@ -13818,15 +13820,16 @@ instruct cmpFastLockRTM(eFlagsReg cr, eRegP object, eBXRegP box, eAXRegI tmp, eD
   ins_pipe(pipe_slow);
 %}
 
-instruct cmpFastLock(eFlagsReg cr, eRegP object, eBXRegP box, eAXRegI tmp, eRegP scr) %{
+instruct cmpFastLock(eFlagsReg cr, eRegP object, eBXRegP box, eAXRegI tmp, eRegP scr, eRegP thread) %{
   predicate(!Compile::current()->use_rtm());
   match(Set cr (FastLock object box));
-  effect(TEMP tmp, TEMP scr, USE_KILL box);
+  effect(TEMP tmp, TEMP scr, USE_KILL box, TEMP thread);
   ins_cost(300);
   format %{ "FASTLOCK $object,$box\t! kills $box,$tmp,$scr" %}
   ins_encode %{
+    __ get_thread($thread$$Register);
     __ fast_lock($object$$Register, $box$$Register, $tmp$$Register,
-                 $scr$$Register, noreg, noreg, NULL, NULL, NULL, false, false);
+                 $scr$$Register, noreg, noreg, $thread$$Register, NULL, NULL, NULL, false, false);
   %}
   ins_pipe(pipe_slow);
 %}

--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -922,7 +922,8 @@ void MachPrologNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
     __ bind(L_skip_barrier);
   }
 
-  __ verified_entry(framesize, C->output()->need_stack_bang(bangsize)?bangsize:0, false, C->stub_function() != NULL);
+  int max_monitors = C->method() != NULL ? C->max_monitors() : 0;
+  __ verified_entry(framesize, C->output()->need_stack_bang(bangsize)?bangsize:0, false, C->stub_function() != NULL, max_monitors);
 
   C->output()->set_frame_complete(cbuf.insts_size());
 
@@ -13339,7 +13340,7 @@ instruct cmpFastLockRTM(rFlagsReg cr, rRegP object, rbx_RegP box, rax_RegI tmp, 
   format %{ "fastlock $object,$box\t! kills $box,$tmp,$scr,$cx1,$cx2" %}
   ins_encode %{
     __ fast_lock($object$$Register, $box$$Register, $tmp$$Register,
-                 $scr$$Register, $cx1$$Register, $cx2$$Register,
+                 $scr$$Register, $cx1$$Register, $cx2$$Register, r15_thread,
                  _rtm_counters, _stack_rtm_counters,
                  ((Method*)(ra_->C->method()->constant_encoding()))->method_data(),
                  true, ra_->C->profile_rtm());
@@ -13355,7 +13356,7 @@ instruct cmpFastLock(rFlagsReg cr, rRegP object, rbx_RegP box, rax_RegI tmp, rRe
   format %{ "fastlock $object,$box\t! kills $box,$tmp,$scr" %}
   ins_encode %{
     __ fast_lock($object$$Register, $box$$Register, $tmp$$Register,
-                 $scr$$Register, $cx1$$Register, noreg, NULL, NULL, NULL, false, false);
+                 $scr$$Register, $cx1$$Register, noreg, r15_thread, NULL, NULL, NULL, false, false);
   %}
   ins_pipe(pipe_slow);
 %}

--- a/src/hotspot/share/c1/c1_Compilation.cpp
+++ b/src/hotspot/share/c1/c1_Compilation.cpp
@@ -384,6 +384,7 @@ int Compilation::compile_java_method() {
 
   if (method()->is_synchronized()) {
     set_has_monitors(true);
+    push_monitor();
   }
 
   {
@@ -571,6 +572,7 @@ Compilation::Compilation(AbstractCompiler* compiler, ciEnv* env, ciMethod* metho
 , _has_method_handle_invokes(false)
 , _has_reserved_stack_access(method->has_reserved_stack_access())
 , _has_monitors(false)
+, _max_monitors(0)
 , _install_code(install_code)
 , _bailout_msg(NULL)
 , _exception_info_list(NULL)

--- a/src/hotspot/share/c1/c1_Compilation.hpp
+++ b/src/hotspot/share/c1/c1_Compilation.hpp
@@ -83,6 +83,7 @@ class Compilation: public StackObj {
   bool               _has_method_handle_invokes;  // True if this method has MethodHandle invokes.
   bool               _has_reserved_stack_access;
   bool               _has_monitors; // Fastpath monitors detection for Continuations
+  int                _max_monitors; // Max number of active monitors, for fast-locking
   bool               _install_code;
   const char*        _bailout_msg;
   ExceptionInfoList* _exception_info_list;
@@ -140,6 +141,7 @@ class Compilation: public StackObj {
   bool has_fpu_code() const                      { return _has_fpu_code; }
   bool has_unsafe_access() const                 { return _has_unsafe_access; }
   bool has_monitors() const                      { return _has_monitors; }
+  int max_monitors() const                       { return _max_monitors; }
   bool has_irreducible_loops() const             { return _has_irreducible_loops; }
   int max_vector_size() const                    { return 0; }
   ciMethod* method() const                       { return _method; }
@@ -172,6 +174,8 @@ class Compilation: public StackObj {
   void set_would_profile(bool f)                 { _would_profile = f; }
   void set_has_access_indexed(bool f)            { _has_access_indexed = f; }
   void set_has_monitors(bool f)                  { _has_monitors = f; }
+  void push_monitor()                            { _max_monitors++; }
+
   // Add a set of exception handlers covering the given PC offset
   void add_exception_handlers_for_pco(int pco, XHandlers* exception_handlers);
   // Statistics gathering

--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -2315,6 +2315,7 @@ void GraphBuilder::monitorenter(Value x, int bci) {
   // save state before locking in case of deoptimization after a NullPointerException
   ValueStack* state_before = copy_state_for_exception_with_bci(bci);
   compilation()->set_has_monitors(true);
+  compilation()->push_monitor();
   append_with_bci(new MonitorEnter(x, state()->lock(x), state_before), bci);
   kill_all();
 }

--- a/src/hotspot/share/c1/c1_LIRAssembler.cpp
+++ b/src/hotspot/share/c1/c1_LIRAssembler.cpp
@@ -771,7 +771,7 @@ void LIR_Assembler::emit_op4(LIR_Op4* op) {
 }
 
 void LIR_Assembler::build_frame() {
-  _masm->build_frame(initial_frame_size_in_bytes(), bang_size_in_bytes());
+  _masm->build_frame(initial_frame_size_in_bytes(), bang_size_in_bytes(), compilation()->max_monitors());
 }
 
 

--- a/src/hotspot/share/c1/c1_MacroAssembler.hpp
+++ b/src/hotspot/share/c1/c1_MacroAssembler.hpp
@@ -39,7 +39,7 @@ class C1_MacroAssembler: public MacroAssembler {
   void explicit_null_check(Register base);
 
   void inline_cache_check(Register receiver, Register iCache);
-  void build_frame(int frame_size_in_bytes, int bang_size_in_bytes);
+  void build_frame(int frame_size_in_bytes, int bang_size_in_bytes, int max_monitors);
   void remove_frame(int frame_size_in_bytes);
 
   void verified_entry(bool breakAtEntry);

--- a/src/hotspot/share/c1/c1_Runtime1.cpp
+++ b/src/hotspot/share/c1/c1_Runtime1.cpp
@@ -758,8 +758,8 @@ JRT_BLOCK_ENTRY(void, Runtime1::monitorenter(JavaThread* current, oopDesc* obj, 
   if (UseHeavyMonitors) {
     lock->set_obj(obj);
   }
-  assert(obj == lock->obj(), "must match");
-  SharedRuntime::monitor_enter_helper(obj, lock->lock(), current);
+  assert(UseFastLocking || obj == lock->obj(), "must match");
+  SharedRuntime::monitor_enter_helper(obj, UseFastLocking ? NULL : lock->lock(), current);
 JRT_END
 
 

--- a/src/hotspot/share/oops/oop.cpp
+++ b/src/hotspot/share/oops/oop.cpp
@@ -114,7 +114,7 @@ bool oopDesc::is_oop(oop obj, bool ignore_mark_word) {
   // at a safepoint, it must not be zero.
   // Outside of a safepoint, the header could be changing (for example,
   // another thread could be inflating a lock on this object).
-  if (ignore_mark_word) {
+  if (ignore_mark_word || UseFastLocking) {
     return true;
   }
   if (obj->mark().value() != 0) {

--- a/src/hotspot/share/opto/c2_CodeStubs.hpp
+++ b/src/hotspot/share/opto/c2_CodeStubs.hpp
@@ -86,4 +86,12 @@ public:
   void emit(C2_MacroAssembler& masm);
 };
 
+class C2CheckLockStackStub : public C2CodeStub {
+public:
+  C2CheckLockStackStub() : C2CodeStub() {}
+
+  int max_size() const;
+  void emit(C2_MacroAssembler& masm);
+};
+
 #endif // SHARE_OPTO_C2_CODESTUBS_HPP

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -1012,6 +1012,7 @@ void Compile::Init(bool aliasing) {
 
   set_do_vector_loop(false);
   set_has_monitors(false);
+  reset_max_monitors();
 
   if (AllowVectorizeOnDemand) {
     if (has_method() && (_directive->VectorizeOption || _directive->VectorizeDebugOption)) {

--- a/src/hotspot/share/opto/compile.hpp
+++ b/src/hotspot/share/opto/compile.hpp
@@ -340,6 +340,7 @@ class Compile : public Phase {
   // JSR 292
   bool                  _has_method_handle_invokes; // True if this method has MethodHandle invokes.
   bool                  _has_monitors;          // Metadata transfered to nmethod to enable Continuations lock-detection fastpath
+  uint                  _max_monitors;          // Keep track of maximum number of active monitors in this compilation
   RTMState              _rtm_state;             // State of Restricted Transactional Memory usage
   int                   _loop_opts_cnt;         // loop opts round
   bool                  _clinit_barrier_on_entry; // True if clinit barrier is needed on nmethod entry
@@ -633,6 +634,10 @@ class Compile : public Phase {
   void          set_clinit_barrier_on_entry(bool z) { _clinit_barrier_on_entry = z; }
   bool              has_monitors() const         { return _has_monitors; }
   void          set_has_monitors(bool v)         { _has_monitors = v; }
+
+  void          push_monitor() { _max_monitors++; }
+  void          reset_max_monitors() { _max_monitors = 0; }
+  uint          max_monitors() { return _max_monitors; }
 
   // check the CompilerOracle for special behaviours for this compile
   bool          method_has_option(enum CompileCommand option) {

--- a/src/hotspot/share/opto/locknode.cpp
+++ b/src/hotspot/share/opto/locknode.cpp
@@ -180,6 +180,7 @@ void Parse::do_monitor_enter() {
   kill_dead_locals();
 
   C->set_has_monitors(true);
+  C->push_monitor();
 
   // Null check; get casted pointer.
   Node* obj = null_check(peek());

--- a/src/hotspot/share/opto/parse1.cpp
+++ b/src/hotspot/share/opto/parse1.cpp
@@ -423,6 +423,7 @@ Parse::Parse(JVMState* caller, ciMethod* parse_method, float expected_uses)
 
   if (parse_method->is_synchronized()) {
     C->set_has_monitors(true);
+    C->push_monitor();
   }
 
   _tf = TypeFunc::make(method());

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1988,6 +1988,9 @@ const int ObjectAlignmentInBytes = 8;
                                                                             \
   product(size_t, HeapObjectStatsSamplingInterval, 500, DIAGNOSTIC,         \
              "Heap object statistics sampling interval (ms)")               \
+                                                                            \
+  product(bool, UseFastLocking, false, EXPERIMENTAL,                        \
+                "Use fast-locking instead of stack-locking")                \
 
 // end of RUNTIME_FLAGS
 

--- a/src/hotspot/share/runtime/javaThread.cpp
+++ b/src/hotspot/share/runtime/javaThread.cpp
@@ -70,6 +70,7 @@
 #include "runtime/javaCalls.hpp"
 #include "runtime/javaThread.inline.hpp"
 #include "runtime/jniHandles.inline.hpp"
+#include "runtime/lockStack.inline.hpp"
 #include "runtime/mutexLocker.hpp"
 #include "runtime/orderAccess.hpp"
 #include "runtime/osThread.hpp"
@@ -487,8 +488,9 @@ JavaThread::JavaThread() :
 
   _class_to_be_initialized(nullptr),
 
-  _SleepEvent(ParkEvent::Allocate(this))
-{
+  _SleepEvent(ParkEvent::Allocate(this)),
+
+  _lock_stack() {
   set_jni_functions(jni_functions());
 
 #if INCLUDE_JVMCI
@@ -985,6 +987,7 @@ JavaThread* JavaThread::active() {
 }
 
 bool JavaThread::is_lock_owned(address adr) const {
+  assert(!UseFastLocking, "should not be called with fast-locking");
   if (Thread::is_lock_owned(adr)) return true;
 
   for (MonitorChunk* chunk = monitor_chunks(); chunk != NULL; chunk = chunk->next()) {
@@ -1377,6 +1380,10 @@ void JavaThread::oops_do_no_frames(OopClosure* f, CodeBlobClosure* cf) {
     f->do_oop((oop*)entry->cont_addr());
     f->do_oop((oop*)entry->chunk_addr());
     entry = entry->parent();
+  }
+
+  if (!UseHeavyMonitors && UseFastLocking) {
+    lock_stack().oops_do(f);
   }
 }
 

--- a/src/hotspot/share/runtime/javaThread.hpp
+++ b/src/hotspot/share/runtime/javaThread.hpp
@@ -34,6 +34,7 @@
 #include "runtime/globals.hpp"
 #include "runtime/handshake.hpp"
 #include "runtime/javaFrameAnchor.hpp"
+#include "runtime/lockStack.hpp"
 #include "runtime/park.hpp"
 #include "runtime/safepointMechanism.hpp"
 #include "runtime/stackWatermarkSet.hpp"
@@ -1143,6 +1144,16 @@ public:
   // java.lang.Thread interruption support
   void interrupt();
   bool is_interrupted(bool clear_interrupted);
+
+private:
+  LockStack _lock_stack;
+
+public:
+  LockStack& lock_stack() { return _lock_stack; }
+
+  static ByteSize lock_stack_current_offset()    { return byte_offset_of(JavaThread, _lock_stack) + LockStack::current_offset(); }
+  static ByteSize lock_stack_limit_offset()    { return byte_offset_of(JavaThread, _lock_stack) + LockStack::limit_offset(); }
+
 
   static OopStorage* thread_oop_storage();
 

--- a/src/hotspot/share/runtime/lockStack.cpp
+++ b/src/hotspot/share/runtime/lockStack.cpp
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "precompiled.hpp"
+#include "memory/allocation.hpp"
+#include "runtime/lockStack.hpp"
+#include "runtime/safepoint.hpp"
+#include "runtime/thread.hpp"
+#include "utilities/copy.hpp"
+#include "utilities/ostream.hpp"
+
+LockStack::LockStack() :
+  _base(UseFastLocking && !UseHeavyMonitors ? NEW_C_HEAP_ARRAY(oop, INITIAL_CAPACITY, mtSynchronizer) : NULL),
+  _limit(_base + INITIAL_CAPACITY),
+  _current(_base) {
+}
+
+LockStack::~LockStack() {
+  if (UseFastLocking && !UseHeavyMonitors) {
+    FREE_C_HEAP_ARRAY(oop, _base);
+  }
+}
+
+#ifndef PRODUCT
+void LockStack::validate(const char* msg) const {
+  assert(UseFastLocking && !UseHeavyMonitors, "never use lock-stack when fast-locking is disabled");
+  for (oop* loc1 = _base; loc1 < _current - 1; loc1++) {
+    for (oop* loc2 = loc1 + 1; loc2 < _current; loc2++) {
+      assert(*loc1 != *loc2, "entries must be unique: %s", msg);
+    }
+  }
+}
+#endif
+
+void LockStack::grow(size_t min_capacity) {
+  // Grow stack.
+  assert(_limit > _base, "invariant");
+  size_t capacity = _limit - _base;
+  size_t index = _current - _base;
+  size_t new_capacity = MAX2(min_capacity, capacity * 2);
+  oop* new_stack = NEW_C_HEAP_ARRAY(oop, new_capacity, mtSynchronizer);
+  for (size_t i = 0; i < index; i++) {
+    *(new_stack + i) = *(_base + i);
+  }
+  FREE_C_HEAP_ARRAY(oop, _base);
+  _base = new_stack;
+  _limit = _base + new_capacity;
+  _current = _base + index;
+  assert(_current < _limit, "must fit after growing");
+  assert((_limit - _base) >= (ptrdiff_t) min_capacity, "must grow enough");
+}
+
+void LockStack::ensure_lock_stack_size(oop* required_limit) {
+  JavaThread* jt = JavaThread::current();
+  LockStack& lock_stack = jt->lock_stack();
+  lock_stack.grow(required_limit - lock_stack._base);
+}

--- a/src/hotspot/share/runtime/lockStack.hpp
+++ b/src/hotspot/share/runtime/lockStack.hpp
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef SHARE_RUNTIME_LOCKSTACK_HPP
+#define SHARE_RUNTIME_LOCKSTACK_HPP
+
+#include "oops/oopsHierarchy.hpp"
+#include "utilities/globalDefinitions.hpp"
+#include "utilities/sizes.hpp"
+
+class Thread;
+class OopClosure;
+
+class LockStack {
+  friend class VMStructs;
+private:
+  static const size_t INITIAL_CAPACITY = 1;
+  oop* _base;
+  oop* _limit;
+  oop* _current;
+
+  void grow(size_t min_capacity);
+
+  void validate(const char* msg) const PRODUCT_RETURN;
+public:
+  static ByteSize current_offset()    { return byte_offset_of(LockStack, _current); }
+  static ByteSize base_offset()       { return byte_offset_of(LockStack, _base); }
+  static ByteSize limit_offset()      { return byte_offset_of(LockStack, _limit); }
+
+  static void ensure_lock_stack_size(oop* _required_limit);
+
+  LockStack();
+  ~LockStack();
+
+  inline void push(oop o);
+  inline oop pop();
+  inline void remove(oop o);
+
+  inline bool contains(oop o) const;
+
+  // GC support
+  inline void oops_do(OopClosure* cl);
+
+};
+
+#endif // SHARE_RUNTIME_LOCKSTACK_HPP

--- a/src/hotspot/share/runtime/lockStack.inline.hpp
+++ b/src/hotspot/share/runtime/lockStack.inline.hpp
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef SHARE_RUNTIME_LOCKSTACK_INLINE_HPP
+#define SHARE_RUNTIME_LOCKSTACK_INLINE_HPP
+
+#include "memory/iterator.hpp"
+#include "runtime/lockStack.hpp"
+
+inline void LockStack::push(oop o) {
+  validate("pre-push");
+  assert(oopDesc::is_oop(o), "must be");
+  assert(!contains(o), "entries must be unique");
+  if (_current >= _limit) {
+    grow((_limit - _base) + 1);
+  }
+  *_current = o;
+  _current++;
+  validate("post-push");
+}
+
+inline oop LockStack::pop() {
+  validate("pre-pop");
+  oop* new_loc = _current - 1;
+  assert(new_loc < _current, "underflow, probably unbalanced push/pop");
+  _current = new_loc;
+  oop o = *_current;
+  assert(!contains(o), "entries must be unique");
+  validate("post-pop");
+  return o;
+}
+
+inline void LockStack::remove(oop o) {
+  validate("pre-remove");
+  assert(contains(o), "entry must be present");
+  for (oop* loc = _base; loc < _current; loc++) {
+    if (*loc == o) {
+      oop* last = _current - 1;
+      for (; loc < last; loc++) {
+        *loc = *(loc + 1);
+      }
+      _current--;
+      break;
+    }
+  }
+  assert(!contains(o), "entries must be unique: " PTR_FORMAT, p2i(o));
+  validate("post-remove");
+}
+
+inline bool LockStack::contains(oop o) const {
+  validate("pre-contains");
+  bool found = false;
+  size_t i = 0;
+  size_t found_i = 0;
+  for (oop* loc = _current - 1; loc >= _base; loc--) {
+    if (*loc == o) {
+      return true;
+    }
+  }
+  validate("post-contains");
+  return false;
+}
+
+inline void LockStack::oops_do(OopClosure* cl) {
+  validate("pre-oops-do");
+  for (oop* loc = _base; loc < _current; loc++) {
+    cl->do_oop(loc);
+  }
+  validate("post-oops-do");
+}
+
+#endif // SHARE_RUNTIME_LOCKSTACK_INLINE_HPP

--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -40,6 +40,7 @@
 #include "runtime/handshake.hpp"
 #include "runtime/interfaceSupport.inline.hpp"
 #include "runtime/javaThread.hpp"
+#include "runtime/lockStack.inline.hpp"
 #include "runtime/mutexLocker.hpp"
 #include "runtime/objectMonitor.hpp"
 #include "runtime/objectMonitor.inline.hpp"
@@ -312,7 +313,8 @@ bool ObjectSynchronizer::quick_notify(oopDesc* obj, JavaThread* current, bool al
   if (obj == NULL) return false;  // slow-path for invalid obj
   const markWord mark = obj->mark();
 
-  if (mark.has_locker() && current->is_lock_owned((address)mark.locker())) {
+  if ((mark.is_fast_locked() && current->lock_stack().contains(oop(obj))) ||
+      (mark.has_locker() && current->is_lock_owned((address)mark.locker()))) {
     // Degenerate notify
     // stack-locked by caller so by definition the implied waitset is empty.
     return true;
@@ -395,7 +397,9 @@ bool ObjectSynchronizer::quick_enter(oop obj, JavaThread* current,
     // stack-locking in the object's header, the second check is for
     // recursive stack-locking in the displaced header in the BasicLock,
     // and last are the inflated Java Monitor (ObjectMonitor) checks.
-    lock->set_displaced_header(markWord::unused_mark());
+    if (!UseFastLocking) {
+      lock->set_displaced_header(markWord::unused_mark());
+    }
 
     if (owner == NULL && m->try_set_owner_from(NULL, current) == NULL) {
       assert(m->_recursions == 0, "invariant");
@@ -484,30 +488,54 @@ void ObjectSynchronizer::enter(Handle obj, BasicLock* lock, JavaThread* current)
   current->inc_held_monitor_count();
 
   if (!useHeavyMonitors()) {
-    markWord mark = obj->mark();
-    if (mark.is_neutral()) {
-      // Anticipate successful CAS -- the ST of the displaced mark must
-      // be visible <= the ST performed by the CAS.
-      lock->set_displaced_header(mark);
-      if (mark == obj()->cas_set_mark(markWord::from_pointer(lock), mark)) {
+    if (UseFastLocking) {
+      LockStack& lock_stack = current->lock_stack();
+
+      markWord header = obj()->mark_acquire();
+      while (true) {
+        if (header.is_neutral()) {
+          assert(!lock_stack.contains(obj()), "thread must not already hold the lock");
+          // Try to swing into 'fast-locked' state without inflating.
+          markWord locked_header = header.set_fast_locked();
+          markWord witness = obj()->cas_set_mark(locked_header, header);
+          if (witness == header) {
+            // Successfully fast-locked, push object to lock-stack and return.
+            lock_stack.push(obj());
+            return;
+          }
+          // Otherwise retry.
+          header = witness;
+        } else {
+          // Fall-through to inflate-enter.
+          break;
+        }
+      }
+    } else {
+      markWord mark = obj->mark();
+      if (mark.is_neutral()) {
+        // Anticipate successful CAS -- the ST of the displaced mark must
+        // be visible <= the ST performed by the CAS.
+        lock->set_displaced_header(mark);
+        if (mark == obj()->cas_set_mark(markWord::from_pointer(lock), mark)) {
+          return;
+        }
+        // Fall through to inflate() ...
+      } else if (mark.has_locker() &&
+                 current->is_lock_owned((address) mark.locker())) {
+        assert(lock != mark.locker(), "must not re-lock the same lock");
+        assert(lock != (BasicLock*) obj->mark().value(), "don't relock with same BasicLock");
+        lock->set_displaced_header(markWord::from_pointer(NULL));
         return;
       }
-      // Fall through to inflate() ...
-    } else if (mark.has_locker() &&
-               current->is_lock_owned((address)mark.locker())) {
-      assert(lock != mark.locker(), "must not re-lock the same lock");
-      assert(lock != (BasicLock*)obj->mark().value(), "don't relock with same BasicLock");
-      lock->set_displaced_header(markWord::from_pointer(NULL));
-      return;
-    }
 
-    // The object header will never be displaced to this lock,
-    // so it does not matter what the value is, except that it
-    // must be non-zero to avoid looking like a re-entrant lock,
-    // and must not look locked either.
-    lock->set_displaced_header(markWord::unused_mark());
+      // The object header will never be displaced to this lock,
+      // so it does not matter what the value is, except that it
+      // must be non-zero to avoid looking like a re-entrant lock,
+      // and must not look locked either.
+      lock->set_displaced_header(markWord::unused_mark());
+    }
   } else if (VerifyHeavyMonitors) {
-    guarantee(!obj->mark().has_locker(), "must not be stack-locked");
+    guarantee(!obj->mark().has_locker() && !obj->mark().is_fast_locked(), "must not be stack-locked");
   }
 
   // An async deflation can race after the inflate() call and before
@@ -526,43 +554,61 @@ void ObjectSynchronizer::exit(oop object, BasicLock* lock, JavaThread* current) 
 
   if (!useHeavyMonitors()) {
     markWord mark = object->mark();
-
-    markWord dhw = lock->displaced_header();
-    if (dhw.value() == 0) {
-      // If the displaced header is NULL, then this exit matches up with
-      // a recursive enter. No real work to do here except for diagnostics.
-#ifndef PRODUCT
-      if (mark != markWord::INFLATING()) {
-        // Only do diagnostics if we are not racing an inflation. Simply
-        // exiting a recursive enter of a Java Monitor that is being
-        // inflated is safe; see the has_monitor() comment below.
-        assert(!mark.is_neutral(), "invariant");
-        assert(!mark.has_locker() ||
-        current->is_lock_owned((address)mark.locker()), "invariant");
-        if (mark.has_monitor()) {
-          // The BasicLock's displaced_header is marked as a recursive
-          // enter and we have an inflated Java Monitor (ObjectMonitor).
-          // This is a special case where the Java Monitor was inflated
-          // after this thread entered the stack-lock recursively. When a
-          // Java Monitor is inflated, we cannot safely walk the Java
-          // Monitor owner's stack and update the BasicLocks because a
-          // Java Monitor can be asynchronously inflated by a thread that
-          // does not own the Java Monitor.
-          ObjectMonitor* m = mark.monitor();
-          assert(m->object()->mark() == mark, "invariant");
-          assert(m->is_entered(current), "invariant");
+    if (UseFastLocking) {
+      if (mark.is_fast_locked()) {
+        markWord unlocked_header = mark.set_unlocked();
+        markWord witness = object->cas_set_mark(unlocked_header, mark);
+        if (witness != mark) {
+          // Another thread beat us, it can only have installed an anonymously locked monitor at this point.
+          // Fetch that monitor, set owner correctly to this thread, and exit it (allowing waiting threads to enter).
+          assert(witness.has_monitor(), "must have monitor");
+          ObjectMonitor* monitor = witness.monitor();
+          assert(monitor->is_owner_anonymous(), "must be anonymous owner");
+          monitor->set_owner_from_anonymous(current);
+          monitor->exit(current);
         }
-      }
-#endif
-      return;
-    }
-
-    if (mark == markWord::from_pointer(lock)) {
-      // If the object is stack-locked by the current thread, try to
-      // swing the displaced header from the BasicLock back to the mark.
-      assert(dhw.is_neutral(), "invariant");
-      if (object->cas_set_mark(dhw, mark) == mark) {
+        LockStack& lock_stack = current->lock_stack();
+        lock_stack.remove(object);
         return;
+      }
+    } else {
+      markWord dhw = lock->displaced_header();
+      if (dhw.value() == 0) {
+        // If the displaced header is NULL, then this exit matches up with
+        // a recursive enter. No real work to do here except for diagnostics.
+#ifndef PRODUCT
+        if (mark != markWord::INFLATING()) {
+          // Only do diagnostics if we are not racing an inflation. Simply
+          // exiting a recursive enter of a Java Monitor that is being
+          // inflated is safe; see the has_monitor() comment below.
+          assert(!mark.is_neutral(), "invariant");
+          assert(!mark.has_locker() ||
+                 current->is_lock_owned((address)mark.locker()), "invariant");
+          if (mark.has_monitor()) {
+            // The BasicLock's displaced_header is marked as a recursive
+            // enter and we have an inflated Java Monitor (ObjectMonitor).
+            // This is a special case where the Java Monitor was inflated
+            // after this thread entered the stack-lock recursively. When a
+            // Java Monitor is inflated, we cannot safely walk the Java
+            // Monitor owner's stack and update the BasicLocks because a
+            // Java Monitor can be asynchronously inflated by a thread that
+            // does not own the Java Monitor.
+            ObjectMonitor* m = mark.monitor();
+            assert(m->object()->mark() == mark, "invariant");
+            assert(m->is_entered(current), "invariant");
+          }
+        }
+#endif
+        return;
+      }
+
+      if (mark == markWord::from_pointer(lock)) {
+        // If the object is stack-locked by the current thread, try to
+        // swing the displaced header from the BasicLock back to the mark.
+        assert(dhw.is_neutral(), "invariant");
+        if (object->cas_set_mark(dhw, mark) == mark) {
+          return;
+        }
       }
     }
   } else if (VerifyHeavyMonitors) {
@@ -573,6 +619,13 @@ void ObjectSynchronizer::exit(oop object, BasicLock* lock, JavaThread* current) 
   // The ObjectMonitor* can't be async deflated until ownership is
   // dropped inside exit() and the ObjectMonitor* must be !is_busy().
   ObjectMonitor* monitor = inflate(current, object, inflate_cause_vm_internal);
+  if (UseFastLocking && monitor->is_owner_anonymous()) {
+    // It must be us. Pop lock object from lock stack.
+    LockStack& lock_stack = current->lock_stack();
+    oop popped = lock_stack.pop();
+    assert(popped == object, "must be owned by this thread");
+    monitor->set_owner_from_anonymous(current);
+  }
   monitor->exit(current);
 }
 
@@ -699,7 +752,8 @@ void ObjectSynchronizer::notify(Handle obj, TRAPS) {
   JavaThread* current = THREAD;
 
   markWord mark = obj->mark();
-  if (mark.has_locker() && current->is_lock_owned((address)mark.locker())) {
+  if ((mark.is_fast_locked() && current->lock_stack().contains(obj())) ||
+      (mark.has_locker() && current->is_lock_owned((address)mark.locker()))) {
     // Not inflated so there can't be any waiters to notify.
     return;
   }
@@ -714,7 +768,8 @@ void ObjectSynchronizer::notifyall(Handle obj, TRAPS) {
   JavaThread* current = THREAD;
 
   markWord mark = obj->mark();
-  if (mark.has_locker() && current->is_lock_owned((address)mark.locker())) {
+  if ((mark.is_fast_locked() && current->lock_stack().contains(obj())) ||
+      (mark.has_locker() && current->is_lock_owned((address)mark.locker()))) {
     // Not inflated so there can't be any waiters to notify.
     return;
   }
@@ -742,7 +797,7 @@ static SharedGlobals GVars;
 
 markWord ObjectSynchronizer::read_stable_mark(oop obj) {
   markWord mark = obj->mark_acquire();
-  if (!mark.is_being_inflated()) {
+  if (!mark.is_being_inflated() || UseFastLocking) {
     return mark;       // normal fast-path return
   }
 
@@ -924,6 +979,11 @@ static inline intptr_t get_next_hash(Thread* current, oop obj) {
   return value;
 }
 
+static bool is_lock_owned(Thread* thread, oop obj) {
+  assert(UseFastLocking, "only call this with fast-locking enabled");
+  return thread->is_Java_thread() ? reinterpret_cast<JavaThread*>(thread)->lock_stack().contains(obj) : false;
+}
+
 intptr_t ObjectSynchronizer::FastHashCode(Thread* current, oop obj) {
 
   while (true) {
@@ -978,7 +1038,14 @@ intptr_t ObjectSynchronizer::FastHashCode(Thread* current, oop obj) {
       }
       // Fall thru so we only have one place that installs the hash in
       // the ObjectMonitor.
-    } else if (current->is_lock_owned((address)mark.locker())) {
+    } else if (mark.is_fast_locked() && is_lock_owned(current, obj)) {
+      // This is a fast lock owned by the calling thread so use the
+      // markWord from the object.
+      hash = mark.hash();
+      if (hash != 0) {                  // if it has a hash, just return it
+        return hash;
+      }
+    } else if (mark.has_locker() && current->is_lock_owned((address)mark.locker())) {
       // This is a stack lock owned by the calling thread so fetch the
       // displaced markWord from the BasicLock on the stack.
       temp = mark.displaced_mark_helper();
@@ -1047,6 +1114,12 @@ bool ObjectSynchronizer::current_thread_holds_lock(JavaThread* current,
   if (mark.has_locker()) {
     return current->is_lock_owned((address)mark.locker());
   }
+
+  // Fast-locking case.
+  if (mark.is_fast_locked()) {
+    return current->lock_stack().contains(h_obj());
+  }
+
   // Contended case, header points to ObjectMonitor (tagged pointer)
   if (mark.has_monitor()) {
     // The first stage of async deflation does not affect any field
@@ -1061,33 +1134,25 @@ bool ObjectSynchronizer::current_thread_holds_lock(JavaThread* current,
 
 JavaThread* ObjectSynchronizer::get_lock_owner(ThreadsList * t_list, Handle h_obj) {
   oop obj = h_obj();
-  address owner = NULL;
-
   markWord mark = read_stable_mark(obj);
 
   // Uncontended case, header points to stack
   if (mark.has_locker()) {
-    owner = (address) mark.locker();
+    return Threads::owning_thread_from_monitor_owner(t_list, (address) mark.locker());
+  }
+
+  if (mark.is_fast_locked()) {
+    return Threads::owning_thread_from_object(t_list, h_obj());
   }
 
   // Contended case, header points to ObjectMonitor (tagged pointer)
-  else if (mark.has_monitor()) {
+  if (mark.has_monitor()) {
     // The first stage of async deflation does not affect any field
     // used by this comparison so the ObjectMonitor* is usable here.
     ObjectMonitor* monitor = mark.monitor();
     assert(monitor != NULL, "monitor should be non-null");
-    owner = (address) monitor->owner();
+    return Threads::owning_thread_from_monitor(t_list, monitor);
   }
-
-  if (owner != NULL) {
-    // owning_thread_from_monitor_owner() may also return NULL here
-    return Threads::owning_thread_from_monitor_owner(t_list, owner);
-  }
-
-  // Unlocked case, header in place
-  // Cannot have assertion since this object may have been
-  // locked by another thread when reaching here.
-  // assert(mark.is_neutral(), "sanity check");
 
   return NULL;
 }
@@ -1286,6 +1351,11 @@ ObjectMonitor* ObjectSynchronizer::inflate(Thread* current, oop object,
       ObjectMonitor* inf = mark.monitor();
       markWord dmw = inf->header();
       assert(dmw.is_neutral(), "invariant: header=" INTPTR_FORMAT, dmw.value());
+      if (UseFastLocking && inf->is_owner_anonymous() && is_lock_owned(current, object)) {
+        inf->set_owner_from_anonymous(current);
+        assert(current->is_Java_thread(), "must be Java thread");
+        reinterpret_cast<JavaThread*>(current)->lock_stack().remove(object);
+      }
       return inf;
     }
 
@@ -1295,7 +1365,10 @@ ObjectMonitor* ObjectSynchronizer::inflate(Thread* current, oop object,
     // The INFLATING value is transient.
     // Currently, we spin/yield/park and poll the markword, waiting for inflation to finish.
     // We could always eliminate polling by parking the thread on some auxiliary list.
-    if (mark == markWord::INFLATING()) {
+    // NOTE: We need to check UseFastLocking here, because with fast-locking, the header
+    // may legitimately be zero: cleared lock-bits and all upper header bits zero.
+    // With fast-locking, the INFLATING protocol is not used.
+    if (mark == markWord::INFLATING() && !UseFastLocking) {
       read_stable_mark(object);
       continue;
     }
@@ -1311,8 +1384,51 @@ ObjectMonitor* ObjectSynchronizer::inflate(Thread* current, oop object,
     // the odds of inflation contention.
 
     LogStreamHandle(Trace, monitorinflation) lsh;
+    if (mark.is_fast_locked()) {
+      assert(UseFastLocking, "can only happen with fast-locking");
+      ObjectMonitor* monitor = new ObjectMonitor(object);
+      monitor->set_header(mark.set_unlocked());
+      bool own = is_lock_owned(current, object);
+      if (own) {
+        // Owned by us.
+        monitor->set_owner_from(NULL, current);
+      } else {
+        // Owned by somebody else.
+        monitor->set_owner_anonymous();
+      }
+      markWord monitor_mark = markWord::encode(monitor);
+      markWord witness = object->cas_set_mark(monitor_mark, mark);
+      if (witness == mark) {
+        // Success! Return inflated monitor.
+        if (own) {
+          assert(current->is_Java_thread(), "must be: checked in is_lock_owned()");
+          reinterpret_cast<JavaThread*>(current)->lock_stack().remove(object);
+        }
+        // Once the ObjectMonitor is configured and object is associated
+        // with the ObjectMonitor, it is safe to allow async deflation:
+        _in_use_list.add(monitor);
+
+        // Hopefully the performance counters are allocated on distinct
+        // cache lines to avoid false sharing on MP systems ...
+        OM_PERFDATA_OP(Inflations, inc());
+        if (log_is_enabled(Trace, monitorinflation)) {
+          ResourceMark rm(current);
+          lsh.print_cr("inflate(locked): object=" INTPTR_FORMAT ", mark="
+                       INTPTR_FORMAT ", type='%s'", p2i(object),
+                       object->mark().value(), object->klass()->external_name());
+        }
+        if (event.should_commit()) {
+          post_monitor_inflate_event(&event, object, cause);
+        }
+        return monitor;
+      } else {
+        delete monitor;
+        continue;
+      }
+    }
 
     if (mark.has_locker()) {
+      assert(!UseFastLocking, "can not happen with fast-locking");
       ObjectMonitor* m = new ObjectMonitor(object);
       // Optimistically prepare the ObjectMonitor - anticipate successful CAS
       // We do this before the CAS in order to minimize the length of time

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -533,6 +533,7 @@ void Thread::print_owned_locks_on(outputStream* st) const {
 // should be revisited, and they should be removed if possible.
 
 bool Thread::is_lock_owned(address adr) const {
+  assert(!UseFastLocking, "should not be called with fast-locking");
   return is_in_full_stack(adr);
 }
 

--- a/src/hotspot/share/runtime/threads.hpp
+++ b/src/hotspot/share/runtime/threads.hpp
@@ -135,6 +135,7 @@ class Threads: AllStatic {
   static JavaThread *owning_thread_from_monitor_owner(ThreadsList * t_list,
                                                       address owner);
 
+  static JavaThread* owning_thread_from_object(ThreadsList* t_list, oop obj);
   static JavaThread* owning_thread_from_monitor(ThreadsList* t_list, ObjectMonitor* owner);
 
   // Number of threads on the active threads list

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -704,6 +704,9 @@
   nonstatic_field(ThreadShadow,                _exception_line,                               int)                                   \
   nonstatic_field(Thread,                      _tlab,                                         ThreadLocalAllocBuffer)                \
   nonstatic_field(Thread,                      _allocated_bytes,                              jlong)                                 \
+  nonstatic_field(JavaThread,                  _lock_stack,                                   LockStack)                             \
+  nonstatic_field(LockStack,                   _current,                                      oop*)                                  \
+  nonstatic_field(LockStack,                   _base,                                         oop*)                                  \
   nonstatic_field(NamedThread,                 _name,                                         char*)                                 \
   nonstatic_field(NamedThread,                 _processed_thread,                             Thread*)                               \
   nonstatic_field(JavaThread,                  _threadObj,                                    OopHandle)                             \
@@ -1317,6 +1320,7 @@
                                                                           \
   declare_toplevel_type(ThreadsSMRSupport)                                \
   declare_toplevel_type(ThreadsList)                                      \
+  declare_toplevel_type(LockStack)                                        \
                                                                           \
   /***************/                                                       \
   /* Interpreter */                                                       \

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/JavaThread.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/JavaThread.java
@@ -44,6 +44,8 @@ public class JavaThread extends Thread {
   private static final boolean DEBUG = System.getProperty("sun.jvm.hotspot.runtime.JavaThread.DEBUG") != null;
 
   private static long          threadObjFieldOffset;
+  private static long          lockStackCurrentOffset;
+  private static long          lockStackBaseOffset;
   private static AddressField  anchorField;
   private static AddressField  lastJavaSPField;
   private static AddressField  lastJavaPCField;
@@ -53,6 +55,7 @@ public class JavaThread extends Thread {
   private static CIntegerField stackSizeField;
   private static CIntegerField terminatedField;
   private static AddressField activeHandlesField;
+  private static long oopPtrSize;
 
   private static JavaThreadPDAccess access;
 
@@ -85,6 +88,7 @@ public class JavaThread extends Thread {
   private static synchronized void initialize(TypeDataBase db) {
     Type type = db.lookupType("JavaThread");
     Type anchorType = db.lookupType("JavaFrameAnchor");
+    Type typeLockStack = db.lookupType("LockStack");
 
     threadObjFieldOffset = type.getField("_threadObj").getOffset();
 
@@ -97,6 +101,10 @@ public class JavaThread extends Thread {
     stackSizeField    = type.getCIntegerField("_stack_size");
     terminatedField   = type.getCIntegerField("_terminated");
     activeHandlesField = type.getAddressField("_active_handles");
+
+    lockStackCurrentOffset = type.getField("_lock_stack").getOffset() + typeLockStack.getField("_current").getOffset();
+    lockStackBaseOffset = type.getField("_lock_stack").getOffset() + typeLockStack.getField("_base").getOffset();
+    oopPtrSize = VM.getVM().getAddressSize();
 
     UNINITIALIZED     = db.lookupIntConstant("_thread_uninitialized").intValue();
     NEW               = db.lookupIntConstant("_thread_new").intValue();
@@ -392,6 +400,19 @@ public class JavaThread extends Thread {
     // Be robust
     if (sp == null) return false;
     return stackBase.greaterThan(a) && sp.lessThanOrEqual(a);
+  }
+
+  public boolean isLockOwned(OopHandle obj) {
+    Address current = addr.getAddressAt(lockStackCurrentOffset);
+    Address base = addr.getAddressAt(lockStackBaseOffset);
+    while (base.lessThan(current)) {
+        Address oop = base.getAddressAt(0);
+        if (oop.equals(obj)) {
+            return true;
+        }
+        base = base.addOffsetTo(oopPtrSize);
+    }
+    return false;
   }
 
   public boolean isLockOwned(Address a) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/JavaVFrame.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/JavaVFrame.java
@@ -82,6 +82,7 @@ public abstract class JavaVFrame extends VFrame {
     if (mark.hasMonitor() &&
         ( // we have marked ourself as pending on this monitor
           mark.monitor().equals(thread.getCurrentPendingMonitor()) ||
+          mark.monitor().isOwnedAnonymous() ||
           // we are not the owner of this monitor
           !mark.monitor().isEntered(thread)
         )) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/ObjectMonitor.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/ObjectMonitor.java
@@ -79,6 +79,10 @@ public class ObjectMonitor extends VMObject {
     return false;
   }
 
+  public boolean isOwnedAnonymous() {
+    return addr.getAddressAt(ownerFieldOffset).asLongValue() == 1;
+  }
+
   public Address owner() { return addr.getAddressAt(ownerFieldOffset); }
   // FIXME
   //  void      set_owner(void* owner);


### PR DESCRIPTION
This cherry-picks https://github.com/openjdk/jdk/pull/10907 before it lands in mainline JDK. It will:
- Greatly simply access to the header in the face of racy stack-locking
- Enable some optimizations in various places, most importantly accessing Klass* and i-hash
- Enable full SA support
- Enable full ZGC support
- Enable adding a runtime flag to turn on/off Lilliput

However, this PR implements none of the above. It is a straight port of the upstream change, and fast-locking is *not yet* enabled with Lilliput. This is going to happen in a follow-up PR.

Testing and performance impact, see upstream PR.

Ok to push to Lilliput?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8300440](https://bugs.openjdk.org/browse/JDK-8300440): [Lilliput] Implement alternative fast-locking scheme


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput pull/62/head:pull/62` \
`$ git checkout pull/62`

Update a local copy of the PR: \
`$ git checkout pull/62` \
`$ git pull https://git.openjdk.org/lilliput pull/62/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 62`

View PR using the GUI difftool: \
`$ git pr show -t 62`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput/pull/62.diff">https://git.openjdk.org/lilliput/pull/62.diff</a>

</details>
