### PR TITLE
8300888: [Lilliput] Remaining missing parts in the SA

### DIFF
--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -2611,6 +2611,7 @@
   declare_constant(markWord::lock_shift)                                  \
   declare_constant(markWord::age_shift)                                   \
   declare_constant(markWord::hash_shift)                                  \
+  LP64_ONLY(declare_constant(markWord::klass_shift))                      \
                                                                           \
   declare_constant(markWord::lock_mask)                                   \
   declare_constant(markWord::lock_mask_in_place)                          \

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/DebuggerBase.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/DebuggerBase.java
@@ -24,6 +24,8 @@
 
 package sun.jvm.hotspot.debugger;
 
+import sun.jvm.hotspot.oops.Mark;
+
 /** <P> DebuggerBase is a recommended base class for debugger
     implementations. It can use a PageCache to cache data from the
     target process. Note that this class would not be suitable if the
@@ -394,7 +396,11 @@ public abstract class DebuggerBase implements Debugger {
 
   protected long readCompKlassAddressValue(long address)
     throws UnmappedAddressException, UnalignedAddressException {
-    long value = readCInteger(address, getKlassPtrSize(), true);
+    // On 64 bit systems, the compressed Klass* is currently read from the mark
+    // word. We need to load the whole mark, and shift the upper parts.
+    long value = readCInteger(address, getJLongSize(), true);
+    value = value >>> Mark.getKlassShift();
+
     // Todo: Lilliput: this is a hack. The real problem is the assumption that size
     //  of a narrow Klass pointer can be expressed in number of bytes (getKlassPtrSize).
     //  That assumption is present in a number of files here. Better would be

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/DebuggerBase.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/DebuggerBase.java
@@ -398,7 +398,7 @@ public abstract class DebuggerBase implements Debugger {
     throws UnmappedAddressException, UnalignedAddressException {
     // On 64 bit systems, the compressed Klass* is currently read from the mark
     // word. We need to load the whole mark, and shift the upper parts.
-    long value = readCInteger(address, getJLongSize(), true);
+    long value = readCInteger(address, machDesc.getAddressSize(), true);
     value = value >>> Mark.getKlassShift();
 
     // Todo: Lilliput: this is a hack. The real problem is the assumption that size

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/Array.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/Array.java
@@ -61,32 +61,15 @@ public class Array extends Oop {
     if (headerSize != 0) {
       return headerSize;
     }
-    if (VM.getVM().isCompressedKlassPointersEnabled()) {
-      headerSize = typeSize;
-    } else {
-      headerSize = VM.getVM().alignUp(typeSize + VM.getVM().getIntSize(),
-                                      VM.getVM().getHeapWordSize());
-    }
+    headerSize = lengthOffsetInBytes() + VM.getVM().getIntSize();
     return headerSize;
   }
 
-  private static long headerSize(BasicType type) {
-    if (Universe.elementTypeShouldBeAligned(type)) {
-       return alignObjectSize(headerSizeInBytes())/VM.getVM().getHeapWordSize();
-    } else {
-      return headerSizeInBytes()/VM.getVM().getHeapWordSize();
-    }
-  }
-
-  private long lengthOffsetInBytes() {
+  private static long lengthOffsetInBytes() {
     if (lengthOffsetInBytes != 0) {
       return lengthOffsetInBytes;
     }
-    if (VM.getVM().isCompressedKlassPointersEnabled()) {
-      lengthOffsetInBytes = typeSize - VM.getVM().getIntSize();
-    } else {
-      lengthOffsetInBytes = typeSize;
-    }
+    lengthOffsetInBytes = typeSize;
     return lengthOffsetInBytes;
   }
 
@@ -108,7 +91,13 @@ public class Array extends Oop {
   }
 
   public static long baseOffsetInBytes(BasicType type) {
-    return headerSize(type) * VM.getVM().getHeapWordSize();
+    long typeSizeInBytes = headerSizeInBytes();
+    if (Universe.elementTypeShouldBeAligned(type)) {
+      VM vm = VM.getVM();
+      return vm.alignUp(typeSizeInBytes, vm.getVM().getHeapWordSize());
+    } else {
+      return typeSizeInBytes;
+    }
   }
 
   public boolean isArray()             { return true; }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/Mark.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/Mark.java
@@ -54,6 +54,9 @@ public class Mark extends VMObject {
     lockShift           = db.lookupLongConstant("markWord::lock_shift").longValue();
     ageShift            = db.lookupLongConstant("markWord::age_shift").longValue();
     hashShift           = db.lookupLongConstant("markWord::hash_shift").longValue();
+    if (VM.getVM().isLP64()) {
+      klassShift          = db.lookupLongConstant("markWord::klass_shift").longValue();
+    }
     lockMask            = db.lookupLongConstant("markWord::lock_mask").longValue();
     lockMaskInPlace     = db.lookupLongConstant("markWord::lock_mask_in_place").longValue();
     ageMask             = db.lookupLongConstant("markWord::age_mask").longValue();
@@ -82,6 +85,7 @@ public class Mark extends VMObject {
   private static long lockShift;
   private static long ageShift;
   private static long hashShift;
+  private static long klassShift;
 
   private static long lockMask;
   private static long lockMaskInPlace;
@@ -106,6 +110,10 @@ public class Mark extends VMObject {
   private static long cmsShift;
   private static long cmsMask;
   private static long sizeShift;
+
+  public static long getKlassShift() {
+    return klassShift;
+  }
 
   public Mark(Address addr) {
     super(addr);
@@ -184,6 +192,11 @@ public class Mark extends VMObject {
 
   public boolean hasNoHash() {
     return hash() == noHash;
+  }
+
+  public Klass getKlass() {
+    assert(!hasMonitor());
+    return (Klass)Metadata.instantiateWrapperFor(addr.getCompKlassAddressAt(0));
   }
 
   // Debugging

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/RobustOopDeterminator.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/RobustOopDeterminator.java
@@ -26,6 +26,7 @@ package sun.jvm.hotspot.utilities;
 
 import sun.jvm.hotspot.debugger.*;
 import sun.jvm.hotspot.oops.Metadata;
+import sun.jvm.hotspot.oops.Oop;
 import sun.jvm.hotspot.runtime.*;
 import sun.jvm.hotspot.types.*;
 
@@ -37,26 +38,6 @@ import sun.jvm.hotspot.types.*;
     states than the ObjectHeap code. */
 
 public class RobustOopDeterminator {
-  private static AddressField klassField;
-
-  static {
-    VM.registerVMInitializedObserver(new Observer() {
-        public void update(Observable o, Object data) {
-          initialize(VM.getVM().getTypeDataBase());
-        }
-      });
-  }
-
-  private static void initialize(TypeDataBase db) {
-    Type type = db.lookupType("oopDesc");
-
-    if (VM.getVM().isCompressedKlassPointersEnabled()) {
-      klassField = type.getAddressField("_metadata._compressed_klass");
-    } else {
-      klassField = type.getAddressField("_metadata._klass");
-    }
-  }
-
   public static boolean oopLooksValid(OopHandle oop) {
     if (oop == null) {
       return false;
@@ -66,11 +47,7 @@ public class RobustOopDeterminator {
     }
     try {
       // Try to instantiate the Klass
-      if (VM.getVM().isCompressedKlassPointersEnabled()) {
-        Metadata.instantiateWrapperFor(oop.getCompKlassAddressAt(klassField.getOffset()));
-      } else {
-        Metadata.instantiateWrapperFor(klassField.getValue(oop));
-      }
+      Oop.getKlassForOopHandle(oop);
       return true;
     } catch (AddressException | WrongTypeException e) {
       return false;

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -123,40 +123,6 @@ serviceability/sa/TestJmapCoreMetaspace.java 8294316,8267433 macosx-x64
 
 serviceability/attach/ConcAttachTest.java 8290043 linux-all
 
-# Missing Lilliput support to load Klass*
-serviceability/sa/CDSJMapClstats.java 1234567 generic-all
-serviceability/sa/ClhsdbCDSCore.java 1234567 generic-all
-serviceability/sa/ClhsdbCDSJstackPrintAll.java 1234567 generic-all
-serviceability/sa/ClhsdbDumpheap.java 1234567 generic-all
-serviceability/sa/ClhsdbFindPC.java#no-xcomp-core
-serviceability/sa/ClhsdbFindPC.java#no-xcomp-process
-serviceability/sa/ClhsdbFindPC.java#xcomp-core
-serviceability/sa/ClhsdbFindPC.java#xcomp-process
-serviceability/sa/ClhsdbInspect.java 1234567 generic-all
-serviceability/sa/ClhsdbJdis.java 1234567 generic-all
-serviceability/sa/ClhsdbJhisto.java 1234567 generic-all
-serviceability/sa/ClhsdbJstack.java#id0 1234567 generic-all
-serviceability/sa/ClhsdbJstack.java#id1 1234567 generic-all
-serviceability/sa/ClhsdbPrintAs.java 1234567 generic-all
-serviceability/sa/ClhsdbPstack.java#core 1234567 generic-all
-serviceability/sa/ClhsdbPstack.java#process 1234567 generic-all
-serviceability/sa/ClhsdbSource.java 1234567 generic-all
-serviceability/sa/ClhsdbThread.java 1234567 generic-all
-serviceability/sa/ClhsdbThreadContext.java 1234567 generic-all
-serviceability/sa/ClhsdbWhere.java 1234567 generic-all
-serviceability/sa/DeadlockDetectionTest.java 1234567 generic-all
-serviceability/sa/JhsdbThreadInfoTest.java 1234567 generic-all
-serviceability/sa/TestClhsdbJstackLock.java 1234567 generic-all
-serviceability/sa/TestHeapDumpForInvokeDynamic.java 1234567 generic-all
-serviceability/sa/TestJhsdbJstackLineNumbers.java 1234567 generic-all
-serviceability/sa/TestJhsdbJstackLock.java 1234567 generic-all
-serviceability/sa/TestJhsdbJstackMixed.java 1234567 generic-all
-serviceability/sa/TestObjectMonitorIterate.java 1234567 generic-all
-serviceability/sa/TestSysProps.java 1234567 generic-all
-serviceability/sa/jmap-hprof/JMapHProfLargeHeapTest.java 1234567 generic-all
-serviceability/sa/sadebugd/DebugdConnectTest.java 1234567 generic-all
-serviceability/sa/sadebugd/DisableRegistryTest.java 1234567 generic-all
-
 #############################################################################
 
 # :hotspot_misc


### PR DESCRIPTION
With fast-locking, it is now possible to provide a safe implementation of load-Klass* (following the same principle as in the runtime: load mark, check for monitor, possibly load real mark from monitor, decode Klass* from mark). This change also fixes array layout calculation and un-blocks a number of SA tests that did not work before.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8300888](https://bugs.openjdk.org/browse/JDK-8300888): [Lilliput] Remaining missing parts in the SA


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput pull/67/head:pull/67` \
`$ git checkout pull/67`

Update a local copy of the PR: \
`$ git checkout pull/67` \
`$ git pull https://git.openjdk.org/lilliput pull/67/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 67`

View PR using the GUI difftool: \
`$ git pr show -t 67`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput/pull/67.diff">https://git.openjdk.org/lilliput/pull/67.diff</a>

</details>
