### PR TITLE
8301545: [Lilliput] Fix aarch64 interpreter load_nklass()

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -4039,7 +4039,7 @@ void MacroAssembler::load_nklass(Register dst, Register src) {
   // Check if we can take the (common) fast path, if obj is unlocked.
   ldr(dst, Address(src, oopDesc::mark_offset_in_bytes()));
   tst(dst, markWord::monitor_value);
-  br(Assembler::NE, fast);
+  br(Assembler::EQ, fast);
 
   // Fetch displaced header
   ldr(dst, Address(dst, OM_OFFSET_NO_MONITOR_VALUE_TAG(header)));


### PR DESCRIPTION
In #66 I made a mistake in a last-minute change and GHA hasn't caught it: I got a condition wrong. Let's fix it.

Testing:
 - [x] tier1
 - [x] tier2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8301545](https://bugs.openjdk.org/browse/JDK-8301545): [Lilliput] Fix aarch64 interpreter load_nklass()


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput pull/68/head:pull/68` \
`$ git checkout pull/68`

Update a local copy of the PR: \
`$ git checkout pull/68` \
`$ git pull https://git.openjdk.org/lilliput pull/68/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 68`

View PR using the GUI difftool: \
`$ git pr show -t 68`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput/pull/68.diff">https://git.openjdk.org/lilliput/pull/68.diff</a>

</details>
