### PR TITLE
8301514: [Lilliput] Enable fast-locking with ZGC

### DIFF
--- a/src/hotspot/share/gc/z/zArguments.cpp
+++ b/src/hotspot/share/gc/z/zArguments.cpp
@@ -106,9 +106,6 @@ void ZArguments::initialize() {
     FLAG_SET_DEFAULT(ZVerifyRoots, true);
     FLAG_SET_DEFAULT(ZVerifyObjects, true);
   }
-
-  // Cannot currently support stack-locking with Lilliput and ZGC.
-  FLAG_SET_DEFAULT(UseHeavyMonitors, true);
 }
 
 size_t ZArguments::heap_virtual_to_physical_ratio() {


### PR DESCRIPTION
Previously, we disabled stack-locking in ZGC because it couldn't easily deal with racy header. Now that we have fast-locking (in place of stack-locking), we can re-enable it.

Testing:
 - [x] tier1
 - [x] tier2
 - [x] hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8301514](https://bugs.openjdk.org/browse/JDK-8301514): [Lilliput] Enable fast-locking with ZGC


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput pull/69/head:pull/69` \
`$ git checkout pull/69`

Update a local copy of the PR: \
`$ git checkout pull/69` \
`$ git pull https://git.openjdk.org/lilliput pull/69/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 69`

View PR using the GUI difftool: \
`$ git pr show -t 69`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput/pull/69.diff">https://git.openjdk.org/lilliput/pull/69.diff</a>

</details>
