### PR TITLE
JDK-8301786: [Lilliput] Failing CompressedClassPointerEncoding.java

### DIFF
--- a/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointerEncoding.java
+++ b/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointerEncoding.java
@@ -39,6 +39,9 @@
 //  and we exercise the ability of Metaspace to allocate Klass structures with the correct alignment, compatible to
 //  encoding.
 
+
+///// x64 ///////////////////////////////////////////////////////////////
+
 /*
  * @test id=x64-area-beyond-encoding-range-use-xor
  * @requires os.arch=="amd64" | os.arch=="x86_64"
@@ -46,155 +49,250 @@
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @run driver CompressedClassPointerEncoding
+ * @run driver CompressedClassPointerEncoding x64-area-beyond-encoding-range-use-xor
+ */
+
+/*
+ * @test id=x64-area-partly-within-encoding-range-use-add
+ * @requires os.arch=="amd64" | os.arch=="x86_64"
+ * @requires vm.flagless
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ * @run driver CompressedClassPointerEncoding x64-area-partly-within-encoding-range-use-add
+ */
+
+/*
+ * @test id=x64-area-within-encoding-range-use-zero
+ * @requires os.arch=="amd64" | os.arch=="x86_64"
+ * @requires vm.flagless
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ * @run driver CompressedClassPointerEncoding x64-area-within-encoding-range-use-zero
+ */
+
+/*
+ * @test id=x64-area-far-out-no-low-bits-use-xor
+ * @requires os.arch=="amd64" | os.arch=="x86_64"
+ * @requires vm.flagless
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ * @run driver CompressedClassPointerEncoding x64-area-far-out-no-low-bits-use-xor
+ */
+
+/*
+ * @test id=x64-area-far-out-with-low-bits-use-add
+ * @requires os.arch=="amd64" | os.arch=="x86_64"
+ * @requires vm.flagless
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ * @run driver CompressedClassPointerEncoding x64-area-far-out-with-low-bits-use-add
+ */
+
+///// aarch64 ///////////////////////////////////////////////////////////////
+
+/*
+ * @test id=aarch64-xor
+ * @requires os.arch=="aarch64"
+ * @requires vm.flagless
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ * @run driver CompressedClassPointerEncoding aarch64-xor
+ */
+
+/*
+ * @test id=aarch64-movk-1
+ * @requires os.arch=="aarch64"
+ * @requires vm.flagless
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ * @run driver CompressedClassPointerEncoding aarch64-movk-1
+ */
+
+/*
+ * @test id=aarch64-movk-2
+ * @requires os.arch=="aarch64"
+ * @requires vm.flagless
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ * @run driver CompressedClassPointerEncoding aarch64-movk-2
+ */
+
+/*
+ * @test id=aarch64-movk-3
+ * @requires os.arch=="aarch64"
+ * @requires vm.flagless
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ * @run driver CompressedClassPointerEncoding aarch64-movk-3
  */
 
 import jdk.test.lib.Platform;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
+import jtreg.SkippedException;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.regex.Pattern;
 
 public class CompressedClassPointerEncoding {
-
-    // Replace:
-    // $1 with force base address
-    // $2 with compressed class space size
-    final static String[] vmOptionsTemplate = new String[] {
-      "-XX:CompressedClassSpaceBaseAddress=$1",
-      "-XX:CompressedClassSpaceSize=$2",
-      "-Xshare:off",                         // Disable CDS
-      "-Xlog:metaspace*",                    // for analysis
-      "-XX:+PrintMetaspaceStatisticsAtExit", // for analysis
-      "-version"
-    };
-
-    // Replace:
-    // $1 with expected ccs base address (extended hex printed)
-    // $2 with expected encoding base (extended hex printed)
-    // $3 with expected encoding shift
-    // $4 with expected encoding range
-    // $5 with expected encoding mode
-    final String[] expectedOutputTemplate = new String[] {
-            ".*Sucessfully forced class space address to $1.*",
-            ".*CDS archive(s) not mapped.*",
-            ".*Narrow klass base: $2, Narrow klass shift: $3, Narrow klass range: $4, Encoding mode $5.*"
-    };
 
     final static long M = 1024 * 1024;
     final static long G = 1024 * M;
 
-    final static long expectedShift = 9;
-    final static long expectedEncodingRange = 2 * G;
-    final static long defaultCCSSize = 32 * M;
+    final static int narrowKlassBitSize = 22;
+    final static int narrowKlassShift = 9;
+    final static long narrowKlassValueSpan = (long)1 << narrowKlassBitSize;
+    final static long encodingRangeSpan = narrowKlassValueSpan << narrowKlassShift;
 
-    enum EPlatform {
-        // Add more where needed
-        // (Note: this would be useful in Platform.java)
-        linux_aarch64,
-        linux_x64,
-        unknown
-    };
+    final static long defaultCCSSize = 128 * M;
+    final static long ccsGranularity = 16 * M; // root chunk size
 
-    static EPlatform getCurrentPlatform() {
-        if (Platform.isAArch64() && Platform.isLinux()) {
-            return EPlatform.linux_aarch64;
-        } else if (Platform.isX64() && Platform.isLinux()) {
-            return EPlatform.linux_x64;
-        }
-        return EPlatform.unknown;
-    }
+
 
     static class TestDetails {
-        public final EPlatform platform;
         public final String name;
-        public final long[] baseAdressesToTry;
+        public final long ccsBaseAddress;
         public final long compressedClassSpaceSize;
         public final long expectedEncodingBase;
         public final String expectedEncodingMode;
+        // The test relies on -XX:CompressedClassSpaceBaseAddress to force the CCS base address to a certain value.
+        // That can fail due to ASLR. This switch, if true, tolerates those failures. Lets keep it to false for now. The
+        // danger of setting it true is that we may not notice if all tests start to fail due to other reasons.
+        public final boolean tolerateCCSMappingError;
 
-        public TestDetails(EPlatform platform, String name, long[] baseAdressesToTry,
-                           long compressedClassSpaceSize, long expectedEncodingBase, String expectedEncodingMode) {
-            this.platform = platform;
+        public TestDetails(String name, long ccsBaseAddress,
+                           long expectedEncodingBase, String expectedEncodingMode, boolean tolerateCCSMappingError) {
             this.name = name;
-            this.baseAdressesToTry = baseAdressesToTry;
-            this.compressedClassSpaceSize = compressedClassSpaceSize;
+            this.ccsBaseAddress = ccsBaseAddress;
+            this.compressedClassSpaceSize = defaultCCSSize;
             this.expectedEncodingBase = expectedEncodingBase;
             this.expectedEncodingMode = expectedEncodingMode;
-        }
-
-        // Simplified, common version: one base address (which we assume always works) and 32G ccs size
-        public TestDetails(EPlatform platform, String name, long baseAdress,
-                           long expectedEncodingBase, String expectedEncodingMode) {
-            this(platform, name, new long[]{ baseAdress }, defaultCCSSize,
-                 expectedEncodingBase, expectedEncodingMode);
+            this.tolerateCCSMappingError = tolerateCCSMappingError;
         }
     };
 
-    static TestDetails[] testDetails = new TestDetails[] {
+    static void runTestWithName(String name) throws IOException {
+
+        // How this works:
+        // 1) we enforce a CCS base address with -XX:CompressedClassSpaceBaseAddress. This bypasses the automatic
+        //    CCS placement we do in Metaspace/CDS initialization; CCS begins at that address.
+        // 2) We set CCS size to 128M.
+        // 3) We expect the zero-based encoding range to be [0...8G)
+        // 4) Depending on how CCS base address looks like, we expect different encoding mechanisms from the platforms.
+        //    These are somewhat platform dependent.
+        //    a) If CCS range fits completely into the zero-based encoding range, we expect zero-based encoding to be used
+        //    b) If CCs range lies partly or completely outside the zero-based encoding range, zero-base encoding cannot work.
+        //    c) for (b), depending on the platform and how the CCS base address looks like, different mechanisms
+        //       should be chosen to decode the Klass*. Typically, if CCS base address does not intersect with
+        //       the narrow Klass pointer bit range 0..24, CCS base address and narrow Klass pointer can be appended
+        //       (e.g. xor), otherwise we would expect some form of shift+add
+
+        String expectedMode;
+        long ccsBaseAddress;
+        long expectedEncodingRangeStart;
+        boolean tolerateMappingFailure = false;
+        switch (name) {
 
             //////////////////////////////////////////////////////////////////////////
             ////// x64 ///////////////////////////////////////////////////////////////
 
-            // CCS base beyond encoding range (base=2G). Base does does not intersect the uncompressed klass pointer
-            // bits. Encoding cannot be zero, and we should use xor+shift mode.
-            new TestDetails(EPlatform.linux_x64,
-                    "x64-area-beyond-encoding-range-use-xor",
-                    2 * G,
-                    2 * G,
-                    "xor"),
-
-            // CCS partly contained in encoding range. We cannot use zero based encoding. We cannot use xor either,
-            // since the first part of the ccs intersects the encoding range. Encoding hould use add+shift.
-            /*
-            new TestDetails(EPlatform.linux_x64,
-                    "x64-area-partly-within-encoding-range-use-add",
-                    0x7fc00000,
-                    2 * G,
-                    "add"),
-            */
-
-            // CCS (just) fully contained in encoding range (base=2G-ccs size). Expect zero-based encoding.
-            new TestDetails(EPlatform.linux_x64,
-                    "x64-area-within-encoding-range-use-zero",
-                    0x7e000000, // 2G - 32M (ccs size)
-                    0,
-                    "zero"),
-
-            // CCS located far beyond the zero-based limit. Base does not intersect with narrow Klass pointer bits.
-            // We should use xor.
-            new TestDetails(EPlatform.linux_x64,
-                    "x64-area-far-out-no-low-bits-use-xor",
-                    0x800000000L, // 32G
-                    0x800000000L,
-                    "xor"),
-
-            // CCS located far beyond the zero-based limit. Base address intersects with narrow Klass pointer bits.
-            // We should use add.
-            /*
-            new TestDetails(EPlatform.linux_x64,
-                    "x64-area-far-out-with-low-bits-use-add",
-                    0x800800000L, // 32G + 8M (4M is minimum ccs alignment)
-                    0x800800000L,
-                    "xor"),
-            */
+            case "x64-area-beyond-encoding-range-use-xor":
+                // CCS base starts just (beyond) zero-based encoding range.
+                // - Encoding cannot be zero-based
+                // - We should be able to use xor mode since CCS base address does not intersect with max left-shifted narrow Klass pointer
+                ccsBaseAddress = encodingRangeSpan;
+                expectedEncodingRangeStart = ccsBaseAddress;
+                expectedMode = "xor";
+                break;
+            case "x64-area-partly-within-encoding-range-use-add":
+                // CCS partly contained within zero-based encoding range, but last part (a single granule) outside.
+                // - Encoding cannot be zero-based
+                // - We cannot use xor since CCS base address intersects with max left-shifted narrow Klass pointer
+                ccsBaseAddress = encodingRangeSpan - defaultCCSSize + ccsGranularity;
+                expectedEncodingRangeStart = ccsBaseAddress;
+                expectedMode = "add";
+                break;
+            case "x64-area-within-encoding-range-use-zero":
+                // CCS fully contained within zero-based encoding range
+                // - Encoding can be zero-based
+                ccsBaseAddress = encodingRangeSpan - defaultCCSSize;
+                expectedEncodingRangeStart = 0;
+                expectedMode = "zero";
+                break;
+            case "x64-area-far-out-no-low-bits-use-xor":
+                // CCS located far beyond zero-based encoding range, at a nicely aligned base.
+                // - Encoding cannot be zero-based
+                // - We should be able to use xor mode since CCS base address does not intersect with
+                //   max left-shifted narrow Klass pointer
+                ccsBaseAddress = encodingRangeSpan * 4; // 32G
+                expectedEncodingRangeStart = ccsBaseAddress;
+                expectedMode = "xor";
+                break;
+            case "x64-area-far-out-with-low-bits-use-add":
+                // CCS located far beyond zero-based encoding range, but address is unfit for xor mode.
+                // - Encoding cannot be zero-based
+                // - We cannot use xor since CCS base address has lower bits set that intersect with
+                //   max left-shifted narrow Klass pointer
+                ccsBaseAddress = (encodingRangeSpan * 4) + ccsGranularity; // 32G + a bit
+                expectedEncodingRangeStart = ccsBaseAddress;
+                expectedMode = "add";
+                break;
 
             //////////////////////////////////////////////////////////////////////////
             ////// aarch64 ///////////////////////////////////////////////////////////
 
+            case "aarch64-xor":
+                // CCS with a base which is a valid immediate, does not intersect the uncompressed klass pointer bits,
+                // should use xor+shift
+                ccsBaseAddress = 0x1000000000L;
+                expectedEncodingRangeStart = ccsBaseAddress;
+                expectedMode = "xor";
+                break;
 
-            // CCS with a base which is a valid immediate, does not intersect the uncompressed klass pointer bits,
-            // should use xor+shift
-            new TestDetails(EPlatform.linux_aarch64,
-                    "aarch64-area-beyond-encoding-range-base-valid-immediate-use-xor",
-                    0x800000000L, // 32G
-                    800000000L,
-                    "xor")
+            // Attempt to test movk:
+            // Addresses that would need movk mode are quite high for lilliput (9 bit shift), with the lowest
+            // needing 40bits. Therefore the following tests may fail because CCS cannot be mapped. This depends on
+            // how the kernel was compiled (39, 42 or 48 bit virtual addresses).
+            // Therefore we tolerate mapping failures for the following tests.
+            case "aarch64-movk-1":
+                ccsBaseAddress = 0x00000a0000000000L;
+                expectedEncodingRangeStart = ccsBaseAddress;
+                expectedMode = "movk";
+                tolerateMappingFailure = true;
+                break;
 
-            // ... add more
+            case "aarch64-movk-2":
+                ccsBaseAddress = 0x120000000000L;
+                expectedEncodingRangeStart = ccsBaseAddress;
+                expectedMode = "movk";
+                tolerateMappingFailure = true;
+                break;
 
-    };
+            case "aarch64-movk-3":
+                ccsBaseAddress = 0x160000000000L;
+                expectedEncodingRangeStart = ccsBaseAddress;
+                expectedMode = "movk";
+                tolerateMappingFailure = true;
+                break;
+
+            default:
+                throw new RuntimeException("Bad test name: " + name);
+        }
+
+        TestDetails details = new TestDetails(name, ccsBaseAddress, expectedEncodingRangeStart, expectedMode, tolerateMappingFailure);
+        runTest(details);
+    }
+
+    ;
 
     // Helper function. Given a string, replace $1 ... $n with
     // replacement_strings[0] ... replacement_strings[n]
@@ -224,8 +322,19 @@ public class CompressedClassPointerEncoding {
         System.err.println("Running Test: " + details.name);
         System.err.println(details);
 
-        long ccsBaseAddress = details.baseAdressesToTry[0];
-        String ccsBaseAddressAsHex = String.format("0x%016x", ccsBaseAddress);
+        // Replace:
+        // $1 with force base address
+        // $2 with compressed class space size
+        String[] vmOptionsTemplate = new String[] {
+                "-XX:CompressedClassSpaceBaseAddress=$1",
+                "-XX:CompressedClassSpaceSize=$2",
+                "-Xshare:off",                         // Disable CDS
+                "-Xlog:metaspace*",                    // for analysis
+                "-XX:+PrintMetaspaceStatisticsAtExit", // for analysis
+                "-version"
+        };
+
+        String ccsBaseAddressAsHex = String.format("0x%016x", details.ccsBaseAddress);
 
         // VM Options: replace:
         // $1 with force base address
@@ -242,19 +351,57 @@ public class CompressedClassPointerEncoding {
         output.reportDiagnosticSummary();
         System.err.println("----------------------------------------------------");
 
-        output.shouldHaveExitValue(0);
-
-    }
-
-    static void runTestsForPlatform(EPlatform platform) throws IOException {
-        for (TestDetails details : testDetails) {
-            if (details.platform == platform) {
-                runTest(details);
+        if (details.tolerateCCSMappingError) {
+            String template = "CompressedClassSpaceBaseAddress=$1 given, but reserving class space failed";
+            String pat = replacePlaceholdersInString(template, ccsBaseAddressAsHex);
+            if (output.getStdout().contains(pat)) {
+                throw new SkippedException("Skipping test: failed to force CCS to base address " + ccsBaseAddressAsHex);
             }
         }
+
+        // Replace:
+        // $1 with expected ccs base address (extended hex printed)
+        // $2 with expected encoding base (extended hex printed)
+        // $3 with expected encoding shift
+        // $4 with expected encoding range
+        // $5 with expected encoding mode
+        String[] expectedOutputTemplate = new String[] {
+                "Successfully forced class space address to $1",
+                "CDS archive(s) not mapped",
+                "CompressedClassSpaceSize: 128.00 MB",
+                "KlassAlignmentInBytes: 512",
+                "KlassEncodingMetaspaceMax: 2.00 GB",
+                "Narrow klass base: $2, Narrow klass shift: $3, Narrow klass range: $4, Encoding mode $5"
+        };
+
+        String expectedOutput[] = replacePlaceholdersInArray(expectedOutputTemplate,
+                ccsBaseAddressAsHex, // $1
+                String.format("0x%016x", details.expectedEncodingBase), // $2
+                Long.toString(narrowKlassShift), // $3
+                String.format("0x%x", encodingRangeSpan), // $4
+                details.expectedEncodingMode  // $5
+        );
+
+        String[] lines = output.asLines().toArray(new String[0]);
+        int found = 0;
+        int lineno = 0;
+        while (lineno < lines.length && found < expectedOutput.length) {
+            String pat = expectedOutput[found];
+            String line = lines[lineno];
+            if (line.contains(pat)) {
+                System.out.println("Found: " + pat + " at line " + lineno);
+                found ++;
+            }
+            lineno++;
+        }
+        if (found < expectedOutput.length) {
+            throw new RuntimeException("Not all expected pattern found. First missing: " + expectedOutput[found]);
+        }
+
+        output.shouldHaveExitValue(0);
     }
 
     public static void main(String[] args) throws Exception {
-        runTestsForPlatform(getCurrentPlatform());
+        runTestWithName(args[0]);
     }
 }


### PR DESCRIPTION
This fixes and expands runtime/CompressedOops/CompressedClassPointerEncoding.java.

Test had been broken by integration of [JDK-8294677](https://bugs.openjdk.org/browse/JDK-8294677), but to my embarrassment, I found that the test had never actually been finished, some vital checks were missing.

I fixed all that, clarified comments, and also changed the test to have multiple sub tests. I manually tested on x64 and aarch64.

On aarch64, I tried to test both `xor` and `movk` encoding modes but was unable to test latter - the lowest valid encoding base that would trigger `movk` mode is `0xa00_00000000`, and the kernel on my Raspi box is compiled for max. 39 bits for virtual user space addresses. That makes mapping at higher addresses fail. See comment in test.

There is more work to be done for aarch64: runtime/CompressedOops/CompressedClassPointerEncoding.java asserts. I opened https://bugs.openjdk.org/browse/JDK-8301880 to track that.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8301786](https://bugs.openjdk.org/browse/JDK-8301786): [Lilliput] Failing CompressedClassPointerEncoding.java


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - Committer) ⚠️ Review applies to [be6b5575](https://git.openjdk.org/lilliput/pull/72/files/be6b5575233494d2b2122fb14d621276409ef4e7)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput pull/72/head:pull/72` \
`$ git checkout pull/72`

Update a local copy of the PR: \
`$ git checkout pull/72` \
`$ git pull https://git.openjdk.org/lilliput pull/72/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 72`

View PR using the GUI difftool: \
`$ git pr show -t 72`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput/pull/72.diff">https://git.openjdk.org/lilliput/pull/72.diff</a>

</details>
