### PR TITLE
8302209: [Lilliput] Optimize fix-anon monitor owner path

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -3928,12 +3928,13 @@ encode %{
     __ add(tmp, tmp, -(int)markWord::monitor_value); // monitor
 
     if (UseFastLocking) {
-      // If the owner is anonymous, we need to fix it -- in the slow-path.
-      __ ldr(disp_hdr, Address(tmp, ObjectMonitor::owner_offset_in_bytes()));
+      // If the owner is anonymous, we need to fix it -- in an outline stub.
+      Register tmp2 = disp_hdr;
+      __ ldr(tmp2, Address(tmp, ObjectMonitor::owner_offset_in_bytes()));
       // We cannot use tbnz here, the target might be too far away and cannot
       // be encoded.
-      __ tst(disp_hdr, (uint64_t)(intptr_t) ANONYMOUS_OWNER);
-      C2FixAnonOMOwnerStub* stub = new (Compile::current()->comp_arena()) C2FixAnonOMOwnerStub(tmp, disp_hdr);
+      __ tst(tmp2, (uint64_t)(intptr_t) ANONYMOUS_OWNER);
+      C2HandleAnonOMOwnerStub* stub = new (Compile::current()->comp_arena()) C2HandleAnonOMOwnerStub(tmp, rthread, tmp2);
       Compile::current()->output()->add_stub(stub);
       __ br(Assembler::NE, stub->entry());
       __ bind(stub->continuation());

--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -3930,11 +3930,13 @@ encode %{
     if (UseFastLocking) {
       // If the owner is anonymous, we need to fix it -- in the slow-path.
       __ ldr(disp_hdr, Address(tmp, ObjectMonitor::owner_offset_in_bytes()));
-      // We cannot use tbnz here: tbnz would leave the condition flags untouched,
-      // but we want to carry-over the NE condition to the exit at the cont label,
-      // in order to take the slow-path.
+      // We cannot use tbnz here, the target might be too far away and cannot
+      // be encoded.
       __ tst(disp_hdr, (uint64_t)(intptr_t) ANONYMOUS_OWNER);
-      __ br(Assembler::NE, no_count);
+      C2FixAnonOMOwnerStub* stub = new (Compile::current()->comp_arena()) C2FixAnonOMOwnerStub(tmp, disp_hdr);
+      Compile::current()->output()->add_stub(stub);
+      __ br(Assembler::NE, stub->entry());
+      __ bind(stub->continuation());
     }
 
     __ ldr(disp_hdr, Address(tmp, ObjectMonitor::recursions_offset_in_bytes()));

--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -3934,7 +3934,7 @@ encode %{
       // We cannot use tbnz here, the target might be too far away and cannot
       // be encoded.
       __ tst(tmp2, (uint64_t)(intptr_t) ANONYMOUS_OWNER);
-      C2HandleAnonOMOwnerStub* stub = new (Compile::current()->comp_arena()) C2HandleAnonOMOwnerStub(tmp, rthread, tmp2);
+      C2HandleAnonOMOwnerStub* stub = new (Compile::current()->comp_arena()) C2HandleAnonOMOwnerStub(tmp, tmp2);
       Compile::current()->output()->add_stub(stub);
       __ br(Assembler::NE, stub->entry());
       __ bind(stub->continuation());

--- a/src/hotspot/cpu/aarch64/c2_CodeStubs_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c2_CodeStubs_aarch64.cpp
@@ -75,22 +75,24 @@ void C2CheckLockStackStub::emit(C2_MacroAssembler& masm) {
   __ b(continuation());
 }
 
-int C2FixAnonOMOwnerStub::max_size() const {
+int C2HandleAnonOMOwnerStub::max_size() const {
   return 20;
 }
 
-void C2FixAnonOMOwnerStub::emit(C2_MacroAssembler& masm) {
+void C2HandleAnonOMOwnerStub::emit(C2_MacroAssembler& masm) {
   __ bind(entry());
   Register mon = monitor();
+  Register thr = thread();
   Register t = tmp();
+  assert(t != noreg, "need tmp register");
 
   // Fix owner to be the current thread.
-  __ str(rthread, Address(mon, ObjectMonitor::owner_offset_in_bytes()));
+  __ str(thr, Address(mon, ObjectMonitor::owner_offset_in_bytes()));
 
   // Pop owner object from lock-stack.
-  __ ldr(t, Address(rthread, JavaThread::lock_stack_current_offset()));
+  __ ldr(t, Address(thr, JavaThread::lock_stack_current_offset()));
   __ sub(t, t, oopSize);
-  __ str(t, Address(rthread, JavaThread::lock_stack_current_offset()));
+  __ str(t, Address(thr, JavaThread::lock_stack_current_offset()));
 
   __ b(continuation());
 }

--- a/src/hotspot/cpu/aarch64/c2_CodeStubs_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c2_CodeStubs_aarch64.cpp
@@ -75,6 +75,26 @@ void C2CheckLockStackStub::emit(C2_MacroAssembler& masm) {
   __ b(continuation());
 }
 
+int C2FixAnonOMOwnerStub::max_size() const {
+  return 20;
+}
+
+void C2FixAnonOMOwnerStub::emit(C2_MacroAssembler& masm) {
+  __ bind(entry());
+  Register mon = monitor();
+  Register t = tmp();
+
+  // Fix owner to be the current thread.
+  __ str(rthread, Address(mon, ObjectMonitor::owner_offset_in_bytes()));
+
+  // Pop owner object from lock-stack.
+  __ ldr(t, Address(rthread, JavaThread::lock_stack_current_offset()));
+  __ sub(t, t, oopSize);
+  __ str(t, Address(rthread, JavaThread::lock_stack_current_offset()));
+
+  __ b(continuation());
+}
+
 int C2LoadNKlassStub::max_size() const {
   return 8;
 }

--- a/src/hotspot/cpu/aarch64/c2_CodeStubs_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c2_CodeStubs_aarch64.cpp
@@ -82,17 +82,16 @@ int C2HandleAnonOMOwnerStub::max_size() const {
 void C2HandleAnonOMOwnerStub::emit(C2_MacroAssembler& masm) {
   __ bind(entry());
   Register mon = monitor();
-  Register thr = thread();
   Register t = tmp();
   assert(t != noreg, "need tmp register");
 
   // Fix owner to be the current thread.
-  __ str(thr, Address(mon, ObjectMonitor::owner_offset_in_bytes()));
+  __ str(rthread, Address(mon, ObjectMonitor::owner_offset_in_bytes()));
 
   // Pop owner object from lock-stack.
-  __ ldr(t, Address(thr, JavaThread::lock_stack_current_offset()));
+  __ ldr(t, Address(rthread, JavaThread::lock_stack_current_offset()));
   __ sub(t, t, oopSize);
-  __ str(t, Address(thr, JavaThread::lock_stack_current_offset()));
+  __ str(t, Address(rthread, JavaThread::lock_stack_current_offset()));
 
   __ b(continuation());
 }

--- a/src/hotspot/cpu/x86/c2_CodeStubs_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_CodeStubs_x86.cpp
@@ -92,9 +92,8 @@ int C2HandleAnonOMOwnerStub::max_size() const {
 void C2HandleAnonOMOwnerStub::emit(C2_MacroAssembler& masm) {
   __ bind(entry());
   Register mon = monitor();
-  Register thr = thread();
-  __ movptr(Address(mon, OM_OFFSET_NO_MONITOR_VALUE_TAG(owner)), thr);
-  __ subptr(Address(thr, JavaThread::lock_stack_current_offset()), oopSize);
+  __ movptr(Address(mon, OM_OFFSET_NO_MONITOR_VALUE_TAG(owner)), r15_thread);
+  __ subptr(Address(r15_thread, JavaThread::lock_stack_current_offset()), oopSize);
   __ jmp(continuation());
 }
 

--- a/src/hotspot/cpu/x86/c2_CodeStubs_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_CodeStubs_x86.cpp
@@ -85,6 +85,18 @@ void C2CheckLockStackStub::emit(C2_MacroAssembler& masm) {
 }
 
 #ifdef _LP64
+int C2FixAnonOMOwnerStub::max_size() const {
+  return 17;
+}
+
+void C2FixAnonOMOwnerStub::emit(C2_MacroAssembler& masm) {
+  __ bind(entry());
+  Register mon = monitor();
+  __ movptr(Address(mon, OM_OFFSET_NO_MONITOR_VALUE_TAG(owner)), r15_thread);
+  __ subptr(Address(r15_thread, JavaThread::lock_stack_current_offset()), oopSize);
+  __ jmp(continuation());
+}
+
 int C2LoadNKlassStub::max_size() const {
   return 10;
 }

--- a/src/hotspot/cpu/x86/c2_CodeStubs_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_CodeStubs_x86.cpp
@@ -85,15 +85,16 @@ void C2CheckLockStackStub::emit(C2_MacroAssembler& masm) {
 }
 
 #ifdef _LP64
-int C2FixAnonOMOwnerStub::max_size() const {
+int C2HandleAnonOMOwnerStub::max_size() const {
   return 17;
 }
 
-void C2FixAnonOMOwnerStub::emit(C2_MacroAssembler& masm) {
+void C2HandleAnonOMOwnerStub::emit(C2_MacroAssembler& masm) {
   __ bind(entry());
   Register mon = monitor();
-  __ movptr(Address(mon, OM_OFFSET_NO_MONITOR_VALUE_TAG(owner)), r15_thread);
-  __ subptr(Address(r15_thread, JavaThread::lock_stack_current_offset()), oopSize);
+  Register thr = thread();
+  __ movptr(Address(mon, OM_OFFSET_NO_MONITOR_VALUE_TAG(owner)), thr);
+  __ subptr(Address(thr, JavaThread::lock_stack_current_offset()), oopSize);
   __ jmp(continuation());
 }
 

--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
@@ -813,10 +813,16 @@ void C2_MacroAssembler::fast_unlock(Register objReg, Register boxReg, Register t
     if (UseFastLocking) {
       // If the owner is ANONYMOUS, we need to fix it.
       testb(Address(tmpReg, OM_OFFSET_NO_MONITOR_VALUE_TAG(owner)), (int32_t) (intptr_t) ANONYMOUS_OWNER);
-      C2HandleAnonOMOwnerStub* stub = new (Compile::current()->comp_arena()) C2HandleAnonOMOwnerStub(tmpReg, thread);
+#ifdef _LP64
+      C2HandleAnonOMOwnerStub* stub = new (Compile::current()->comp_arena()) C2HandleAnonOMOwnerStub(tmpReg);
       Compile::current()->output()->add_stub(stub);
       jcc(Assembler::notEqual, stub->entry());
       bind(stub->continuation());
+#else
+      // We can't easily implement this optimization on 32 bit because we don't have a thread register.
+      // Call the slow-path instead.
+      jcc(Assembler::notEqual, NO_COUNT);
+#endif
     }
   }
 

--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
@@ -811,9 +811,16 @@ void C2_MacroAssembler::fast_unlock(Register objReg, Register boxReg, Register t
 #endif
     jccb(Assembler::zero, Stacked);
     if (UseFastLocking) {
-      // If the owner is ANONYMOUS, we need to fix it - in the slow-path.
+      // If the owner is ANONYMOUS, we need to fix it.
       testptr(Address(tmpReg, OM_OFFSET_NO_MONITOR_VALUE_TAG(owner)), (int32_t) (intptr_t) ANONYMOUS_OWNER);
+#ifdef _LP64
+      C2FixAnonOMOwnerStub* stub = new (Compile::current()->comp_arena()) C2FixAnonOMOwnerStub(tmpReg);
+      Compile::current()->output()->add_stub(stub);
+      jcc(Assembler::notEqual, stub->entry());
+      bind(stub->continuation());
+#else
       jcc(Assembler::notEqual, NO_COUNT);
+#endif
     }
   }
 

--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
@@ -813,14 +813,10 @@ void C2_MacroAssembler::fast_unlock(Register objReg, Register boxReg, Register t
     if (UseFastLocking) {
       // If the owner is ANONYMOUS, we need to fix it.
       testb(Address(tmpReg, OM_OFFSET_NO_MONITOR_VALUE_TAG(owner)), (int32_t) (intptr_t) ANONYMOUS_OWNER);
-#ifdef _LP64
-      C2FixAnonOMOwnerStub* stub = new (Compile::current()->comp_arena()) C2FixAnonOMOwnerStub(tmpReg);
+      C2HandleAnonOMOwnerStub* stub = new (Compile::current()->comp_arena()) C2HandleAnonOMOwnerStub(tmpReg, thread);
       Compile::current()->output()->add_stub(stub);
       jcc(Assembler::notEqual, stub->entry());
       bind(stub->continuation());
-#else
-      jcc(Assembler::notEqual, NO_COUNT);
-#endif
     }
   }
 

--- a/src/hotspot/share/opto/c2_CodeStubs.hpp
+++ b/src/hotspot/share/opto/c2_CodeStubs.hpp
@@ -98,13 +98,11 @@ public:
 class C2HandleAnonOMOwnerStub : public C2CodeStub {
 private:
   Register _monitor;
-  Register _thread;
   Register _tmp;
 public:
-  C2HandleAnonOMOwnerStub(Register monitor, Register thread, Register tmp = noreg) : C2CodeStub(),
-    _monitor(monitor), _thread(thread), _tmp(tmp) {}
+  C2HandleAnonOMOwnerStub(Register monitor, Register tmp = noreg) : C2CodeStub(),
+    _monitor(monitor), _tmp(tmp) {}
   Register monitor() { return _monitor; }
-  Register thread()  { return _thread; }
   Register tmp()     { return _tmp; }
   int max_size() const;
   void emit(C2_MacroAssembler& masm);

--- a/src/hotspot/share/opto/c2_CodeStubs.hpp
+++ b/src/hotspot/share/opto/c2_CodeStubs.hpp
@@ -95,6 +95,19 @@ public:
 };
 
 #ifdef _LP64
+class C2FixAnonOMOwnerStub : public C2CodeStub {
+private:
+  Register _monitor;
+  Register _tmp;
+public:
+  C2FixAnonOMOwnerStub(Register monitor, Register tmp = noreg) : C2CodeStub(),
+    _monitor(monitor), _tmp(tmp) {}
+  Register monitor() { return _monitor; }
+  Register tmp() { return _tmp; }
+  int max_size() const;
+  void emit(C2_MacroAssembler& masm);
+};
+
 class C2LoadNKlassStub : public C2CodeStub {
 private:
   Register _dst;

--- a/src/hotspot/share/opto/c2_CodeStubs.hpp
+++ b/src/hotspot/share/opto/c2_CodeStubs.hpp
@@ -95,15 +95,17 @@ public:
 };
 
 #ifdef _LP64
-class C2FixAnonOMOwnerStub : public C2CodeStub {
+class C2HandleAnonOMOwnerStub : public C2CodeStub {
 private:
   Register _monitor;
+  Register _thread;
   Register _tmp;
 public:
-  C2FixAnonOMOwnerStub(Register monitor, Register tmp = noreg) : C2CodeStub(),
-    _monitor(monitor), _tmp(tmp) {}
+  C2HandleAnonOMOwnerStub(Register monitor, Register thread, Register tmp = noreg) : C2CodeStub(),
+    _monitor(monitor), _thread(thread), _tmp(tmp) {}
   Register monitor() { return _monitor; }
-  Register tmp() { return _tmp; }
+  Register thread()  { return _thread; }
+  Register tmp()     { return _tmp; }
   int max_size() const;
   void emit(C2_MacroAssembler& masm);
 };


### PR DESCRIPTION
When trying to exit a monitor, we need to check if the current owner is anonymous, and if so, fix it before exiting the monitor. So far, we have been doing this by calling into the slow-path and handle it in the runtime. However, it is fairly easy to do in the fast-path and avoid calling into the runtime altogether. I also included those changes in [upstream fast-locking PR](https://github.com/openjdk/jdk/pull/10907).

Testing:
 - [x] tier1 (x86_64, aarch64)
 - [x] tier2 (x86_64, aarch64)
 - [ ] jcstress -t sync -m quick

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8302209](https://bugs.openjdk.org/browse/JDK-8302209): [Lilliput] Optimize fix-anon monitor owner path


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - Committer) ⚠️ Review applies to [808ae7e3](https://git.openjdk.org/lilliput/pull/74/files/808ae7e3ba994ef8b105f03c85f73b2feeb08603)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput pull/74/head:pull/74` \
`$ git checkout pull/74`

Update a local copy of the PR: \
`$ git checkout pull/74` \
`$ git pull https://git.openjdk.org/lilliput pull/74/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 74`

View PR using the GUI difftool: \
`$ git pr show -t 74`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput/pull/74.diff">https://git.openjdk.org/lilliput/pull/74.diff</a>

</details>
