### PR TITLE
8303769: [Lilliput] Fix interpreter asymmetric fast-locking

### DIFF
--- a/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
@@ -872,9 +872,10 @@ void InterpreterMacroAssembler::unlock_object(Register lock_reg)
 
       // Check for non-symmetric locking. This is allowed by the spec and the interpreter
       // must handle it.
-      ldr(header_reg, Address(rthread, JavaThread::lock_stack_current_offset()));
-      ldr(header_reg, Address(header_reg, -oopSize));
-      cmpoop(header_reg, obj_reg);
+      Register tmp = header_reg;
+      ldr(tmp, Address(rthread, JavaThread::lock_stack_current_offset()));
+      ldr(tmp, Address(tmp, -oopSize));
+      cmpoop(tmp, obj_reg);
       br(Assembler::NE, slow_case);
 
       ldr(header_reg, Address(obj_reg, oopDesc::mark_offset_in_bytes()));

--- a/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
@@ -873,6 +873,7 @@ void InterpreterMacroAssembler::unlock_object(Register lock_reg)
       // Check for non-symmetric locking. This is allowed by the spec and the interpreter
       // must handle it.
       ldr(header_reg, Address(rthread, JavaThread::lock_stack_current_offset()));
+      ldr(header_reg, Address(header_reg, -oopSize));
       cmpoop(header_reg, obj_reg);
       br(Assembler::NE, slow_case);
 

--- a/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
+++ b/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
@@ -897,8 +897,10 @@ void InterpreterMacroAssembler::unlock_object(Register lock_reg)
 
       // Check for non-symmetric locking. This is allowed by the spec and the interpreter
       // must handle it.
-      ld(header_reg, Address(xthread, JavaThread::lock_stack_current_offset()));
-      bne(header_reg, obj_reg, slow_case);
+      Register tmp = header_reg;
+      ld(tmp, Address(xthread, JavaThread::lock_stack_current_offset()));
+      ld(tmp, Address(tmp, -oopSize));
+      bne(tmp, obj_reg, slow_case);
 
       ld(header_reg, Address(obj_reg, oopDesc::mark_offset_in_bytes()));
       fast_unlock(obj_reg, header_reg, swap_reg, t0, slow_case);

--- a/src/hotspot/cpu/x86/interp_masm_x86.cpp
+++ b/src/hotspot/cpu/x86/interp_masm_x86.cpp
@@ -1350,7 +1350,8 @@ void InterpreterMacroAssembler::unlock_object(Register lock_reg) {
       get_thread(thread);
 #endif
       // Handle unstructured locking.
-      cmpptr(obj_reg, Address(thread, JavaThread::lock_stack_current_offset()));
+      movptr(swap_reg, Address(thread, JavaThread::lock_stack_current_offset()));
+      cmpptr(obj_reg, Address(swap_reg, -oopSize));
       jcc(Assembler::notEqual, slow_case);
       // Try to swing header from locked to unlock.
       movptr(swap_reg, Address(obj_reg, oopDesc::mark_offset_in_bytes()));

--- a/src/hotspot/cpu/x86/interp_masm_x86.cpp
+++ b/src/hotspot/cpu/x86/interp_masm_x86.cpp
@@ -1350,8 +1350,9 @@ void InterpreterMacroAssembler::unlock_object(Register lock_reg) {
       get_thread(thread);
 #endif
       // Handle unstructured locking.
-      movptr(swap_reg, Address(thread, JavaThread::lock_stack_current_offset()));
-      cmpptr(obj_reg, Address(swap_reg, -oopSize));
+      Register tmp = swap_reg;
+      movptr(tmp, Address(thread, JavaThread::lock_stack_current_offset()));
+      cmpptr(obj_reg, Address(tmp, -oopSize));
       jcc(Assembler::notEqual, slow_case);
       // Try to swing header from locked to unlock.
       movptr(swap_reg, Address(obj_reg, oopDesc::mark_offset_in_bytes()));


### PR DESCRIPTION
Currently we get the asymmetric locking check in the interpreters wrong:

ldr(header_reg, Address(rthread, JavaThread::lock_stack_current_offset()));
cmpoop(header_reg, obj_reg);
br(Assembler::NE, slow_case);

The intention is to load the top of the lock-stack, and compare it to the unlocked object, and, if not equal, branch to the slow-path to handle it. However, what it really does is, it loads the *address* of the top of lock-stack, and compares that to the unlocked object. This can never succeed, and therefore we always call the slow-path. Additionally, the address is not the address of the topmost object, it is the address of the next free slot. What we really want to load is the element at -1 oop from that address. This is not incorrect, but it's unnecessarily slow.'

I've already pushed that fix to the upstream fast-locking PR https://github.com/openjdk/jdk/pull/10907

Testing:
 - [x] tier1 (x86_64, x86_32, aarch64)
 - [ ] tier2 (x86_64, x86_32, aarch64)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8303769](https://bugs.openjdk.org/browse/JDK-8303769): [Lilliput] Fix interpreter asymmetric fast-locking


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput pull/76/head:pull/76` \
`$ git checkout pull/76`

Update a local copy of the PR: \
`$ git checkout pull/76` \
`$ git pull https://git.openjdk.org/lilliput pull/76/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 76`

View PR using the GUI difftool: \
`$ git pr show -t 76`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput/pull/76.diff">https://git.openjdk.org/lilliput/pull/76.diff</a>

</details>
