### PR TITLE
8303813: [Lilliput] (AArch64) Use tbz instead of tst and br in load_klass()

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -4254,8 +4254,7 @@ void MacroAssembler::load_method_holder(Register holder, Register method) {
 }
 
 // Loads the obj's Klass* into dst.
-// src and dst must be distinct registers
-// Preserves all registers (incl src, rscratch1 and rscratch2), but clobbers condition flags
+// Preserves all registers (incl src, rscratch1 and rscratch2).
 void MacroAssembler::load_nklass(Register dst, Register src) {
   assert(UseCompressedClassPointers, "expects UseCompressedClassPointers");
 

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -4263,8 +4263,7 @@ void MacroAssembler::load_nklass(Register dst, Register src) {
 
   // Check if we can take the (common) fast path, if obj is unlocked.
   ldr(dst, Address(src, oopDesc::mark_offset_in_bytes()));
-  tst(dst, markWord::monitor_value);
-  br(Assembler::EQ, fast);
+  tbz(dst, exact_log2(markWord::monitor_value), fast);
 
   // Fetch displaced header
   ldr(dst, Address(dst, OM_OFFSET_NO_MONITOR_VALUE_TAG(header)));


### PR DESCRIPTION
In the implementation of load_klass(), we have a test-and-branch idiom:

```
tst(dst, markWord::monitor_value);
br(Assembler::EQ, fast);

```
We can make this better:

`tbz(dst, exact_log2(markWord::monitor_value), fast);
`
This is not only smaller and perhaps a little faster, it also has the advantage that it doesn't touch the condition flags. This is relevant in at least one place: in verify_oop() the condition flag is alive across the load_klass() call and one jtreg test (runtime/CheckUnhandledOops/TestVerifyOops.java) is failing because of that.

Testing:
 - [x] tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8303813](https://bugs.openjdk.org/browse/JDK-8303813): [Lilliput] (AArch64) Use tbz instead of tst and br in load_klass()


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - no project role) ⚠️ Review applies to [0e6a576e](https://git.openjdk.org/lilliput/pull/78/files/0e6a576e579f069bbc8995061978f5763a8fa18e)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - Committer) ⚠️ Review applies to [0e6a576e](https://git.openjdk.org/lilliput/pull/78/files/0e6a576e579f069bbc8995061978f5763a8fa18e)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput pull/78/head:pull/78` \
`$ git checkout pull/78`

Update a local copy of the PR: \
`$ git checkout pull/78` \
`$ git pull https://git.openjdk.org/lilliput pull/78/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 78`

View PR using the GUI difftool: \
`$ git pr show -t 78`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput/pull/78.diff">https://git.openjdk.org/lilliput/pull/78.diff</a>

</details>
