### PR TITLE
8303816: [Lilliput] Use realloc instead of malloc+copy when growing the lock-stack

### DIFF
--- a/src/hotspot/share/runtime/lockStack.cpp
+++ b/src/hotspot/share/runtime/lockStack.cpp
@@ -59,12 +59,7 @@ void LockStack::grow(size_t min_capacity) {
   size_t capacity = _limit - _base;
   size_t index = _current - _base;
   size_t new_capacity = MAX2(min_capacity, capacity * 2);
-  oop* new_stack = NEW_C_HEAP_ARRAY(oop, new_capacity, mtSynchronizer);
-  for (size_t i = 0; i < index; i++) {
-    *(new_stack + i) = *(_base + i);
-  }
-  FREE_C_HEAP_ARRAY(oop, _base);
-  _base = new_stack;
+  _base = REALLOC_C_HEAP_ARRAY(oop, _base, new_capacity, mtSynchronizer);
   _limit = _base + new_capacity;
   _current = _base + index;
   assert(_current < _limit, "must fit after growing");


### PR DESCRIPTION
We currently grow the fast-locking lock-stack by allocating a larger stack and copying over all elements. This can be done simpler and more efficient by using realloc instead of malloc+copy.

I also applied the same change to the upstream fast-locking PR: https://github.com/openjdk/jdk/pull/10907

Testing:
 - [x] tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8303816](https://bugs.openjdk.org/browse/JDK-8303816): [Lilliput] Use realloc instead of malloc+copy when growing the lock-stack


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput pull/79/head:pull/79` \
`$ git checkout pull/79`

Update a local copy of the PR: \
`$ git checkout pull/79` \
`$ git pull https://git.openjdk.org/lilliput pull/79/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 79`

View PR using the GUI difftool: \
`$ git pr show -t 79`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput/pull/79.diff">https://git.openjdk.org/lilliput/pull/79.diff</a>

</details>
