### PR TITLE
Inline initial LockStack stack

### DIFF
--- a/src/hotspot/share/runtime/lockStack.hpp
+++ b/src/hotspot/share/runtime/lockStack.hpp
@@ -35,10 +35,11 @@ class OopClosure;
 class LockStack {
   friend class VMStructs;
 private:
-  static const size_t INITIAL_CAPACITY = 1;
+  static const size_t INITIAL_CAPACITY = 2;
   oop* _base;
   oop* _limit;
   oop* _current;
+  oop _initial[INITIAL_CAPACITY];
 
   void grow(size_t min_capacity);
 


### PR DESCRIPTION
Inlines the initial lock stack. This gives us:
- Much higher chance of cache hits when accessing lockstack slots via lockstack header.
- postponed malloc call
- we use actually less memory (not that it matters much) per thread since malloc overhead is at least 48 bytes per allocation, probably more.

Also increases size of initial stack to two slots, and uses realloc instead of malloc+free when growing stack.