### PR TITLE
8304341: [Lilliput] Use fixed-size lock-stack

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -1784,18 +1784,6 @@ void MachPrologNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
 
   __ build_frame(framesize);
 
-  int max_monitors = C->method() != NULL ? C->max_monitors() : 0;
-  if (UseFastLocking && max_monitors > 0) {
-    C2CheckLockStackStub* stub = new (C->comp_arena()) C2CheckLockStackStub();
-    C->output()->add_stub(stub);
-    __ ldr(r9, Address(rthread, JavaThread::lock_stack_current_offset()));
-    __ ldr(r10, Address(rthread, JavaThread::lock_stack_limit_offset()));
-    __ add(r9, r9, max_monitors * oopSize);
-    __ cmp(r9, r10);
-    __ br(Assembler::GE, stub->entry());
-    __ bind(stub->continuation());
-  }
-
   if (C->stub_function() == NULL) {
     BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
     if (BarrierSet::barrier_set()->barrier_set_nmethod() != NULL) {
@@ -3801,11 +3789,14 @@ encode %{
 
     if (!UseHeavyMonitors) {
       if (UseFastLocking) {
-        __ fast_lock(oop, disp_hdr, tmp, rscratch1, no_count, false);
+        Label slow;
+        __ fast_lock(oop, disp_hdr, tmp, rscratch1, slow);
 
-        // Indicate success at cont.
+        // Indicate success on completion.
         __ cmp(oop, oop);
         __ b(count);
+        __ bind(slow);
+        __ b(no_count);
       } else {
         // Set tmp to be (markWord of object | UNLOCK_VALUE).
         __ orr(tmp, disp_hdr, markWord::unlocked_value);

--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -3793,9 +3793,10 @@ encode %{
         __ fast_lock(oop, disp_hdr, tmp, rscratch1, slow);
 
         // Indicate success on completion.
-        __ cmp(oop, oop);
+        __ cmp(oop, oop); // Force ZF=1 to indicate success.
         __ b(count);
         __ bind(slow);
+        __ tst(oop, oop); // Force ZF=0 to indicate failure and take slow-path. We know that oop != null.
         __ b(no_count);
       } else {
         // Set tmp to be (markWord of object | UNLOCK_VALUE).

--- a/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
@@ -243,7 +243,7 @@ void LIR_Assembler::osr_entry() {
 
   // build frame
   ciMethod* m = compilation()->method();
-  __ build_frame(initial_frame_size_in_bytes(), bang_size_in_bytes(), compilation()->max_monitors());
+  __ build_frame(initial_frame_size_in_bytes(), bang_size_in_bytes());
 
   // OSR buffer is
   //

--- a/src/hotspot/cpu/aarch64/c1_MacroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_MacroAssembler_aarch64.cpp
@@ -84,7 +84,7 @@ int C1_MacroAssembler::lock_object(Register hdr, Register obj, Register disp_hdr
   // Load object header
   ldr(hdr, Address(obj, hdr_offset));
   if (UseFastLocking) {
-    fast_lock(obj, hdr, rscratch1, rscratch2, slow_case, false);
+    fast_lock(obj, hdr, rscratch1, rscratch2, slow_case);
   } else {
     // and mark it as unlocked
     orr(hdr, hdr, markWord::unlocked_value);
@@ -330,24 +330,12 @@ void C1_MacroAssembler::inline_cache_check(Register receiver, Register iCache) {
 }
 
 
-void C1_MacroAssembler::build_frame(int framesize, int bang_size_in_bytes, int max_monitors) {
+void C1_MacroAssembler::build_frame(int framesize, int bang_size_in_bytes) {
   assert(bang_size_in_bytes >= framesize, "stack bang size incorrect");
   // Make sure there is enough stack space for this method's activation.
   // Note that we do this before creating a frame.
   generate_stack_overflow_check(bang_size_in_bytes);
   MacroAssembler::build_frame(framesize);
-
-  if (UseFastLocking && max_monitors > 0) {
-    Label ok;
-    ldr(r9, Address(rthread, JavaThread::lock_stack_current_offset()));
-    ldr(r10, Address(rthread, JavaThread::lock_stack_limit_offset()));
-    add(r9, r9, max_monitors * oopSize);
-    cmp(r9, r10);
-    br(Assembler::LT, ok);
-    assert(StubRoutines::aarch64::check_lock_stack() != NULL, "need runtime call stub");
-    far_call(StubRoutines::aarch64::check_lock_stack());
-    bind(ok);
-  }
 
   // Insert nmethod entry barrier into frame.
   BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();

--- a/src/hotspot/cpu/aarch64/c2_CodeStubs_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c2_CodeStubs_aarch64.cpp
@@ -64,17 +64,6 @@ void C2EntryBarrierStub::emit(C2_MacroAssembler& masm) {
   __ emit_int32(0);   // nmethod guard value
 }
 
-int C2CheckLockStackStub::max_size() const {
-  return 20;
-}
-
-void C2CheckLockStackStub::emit(C2_MacroAssembler& masm) {
-  __ bind(entry());
-  assert(StubRoutines::aarch64::check_lock_stack() != NULL, "need runtime call stub");
-  __ far_call(StubRoutines::aarch64::check_lock_stack());
-  __ b(continuation());
-}
-
 int C2HandleAnonOMOwnerStub::max_size() const {
   return 20;
 }
@@ -89,9 +78,9 @@ void C2HandleAnonOMOwnerStub::emit(C2_MacroAssembler& masm) {
   __ str(rthread, Address(mon, ObjectMonitor::owner_offset_in_bytes()));
 
   // Pop owner object from lock-stack.
-  __ ldr(t, Address(rthread, JavaThread::lock_stack_current_offset()));
-  __ sub(t, t, oopSize);
-  __ str(t, Address(rthread, JavaThread::lock_stack_current_offset()));
+  __ ldrw(t, Address(rthread, JavaThread::lock_stack_offset_offset()));
+  __ subw(t, t, oopSize);
+  __ strw(t, Address(rthread, JavaThread::lock_stack_offset_offset()));
 
   __ b(continuation());
 }

--- a/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
@@ -873,8 +873,9 @@ void InterpreterMacroAssembler::unlock_object(Register lock_reg)
       // Check for non-symmetric locking. This is allowed by the spec and the interpreter
       // must handle it.
       Register tmp = header_reg;
-      ldr(tmp, Address(rthread, JavaThread::lock_stack_current_offset()));
-      ldr(tmp, Address(tmp, -oopSize));
+      ldrw(tmp, Address(rthread, JavaThread::lock_stack_offset_offset()));
+      subw(tmp, tmp, oopSize);
+      ldr(tmp, Address(rthread, tmp));
       cmpoop(tmp, obj_reg);
       br(Assembler::NE, slow_case);
 

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -6194,17 +6194,14 @@ void MacroAssembler::double_move(VMRegPair src, VMRegPair dst, Register tmp) {
 //  - obj: the object to be locked
 //  - hdr: the header, already loaded from obj, will be destroyed
 //  - t1, t2, t3: temporary registers, will be destroyed
-void MacroAssembler::fast_lock(Register obj, Register hdr, Register t1, Register t2, Label& slow, bool rt_check_stack) {
+void MacroAssembler::fast_lock(Register obj, Register hdr, Register t1, Register t2, Label& slow) {
   assert(UseFastLocking, "only used with fast-locking");
   assert_different_registers(obj, hdr, t1, t2);
 
-  if (rt_check_stack) {
-    // Check if we would have space on lock-stack for the object.
-    ldr(t1, Address(rthread, JavaThread::lock_stack_current_offset()));
-    ldr(t2, Address(rthread, JavaThread::lock_stack_limit_offset()));
-    cmp(t1, t2);
-    br(Assembler::GE, slow);
-  }
+  // Check if we would have space on lock-stack for the object.
+  ldrw(t1, Address(rthread, JavaThread::lock_stack_offset_offset()));
+  cmpw(t1, (unsigned)LockStack::end_offset());
+  br(Assembler::GE, slow);
 
   // Load (object->mark() | 1) into hdr
   orr(hdr, hdr, markWord::unlocked_value);
@@ -6216,10 +6213,10 @@ void MacroAssembler::fast_lock(Register obj, Register hdr, Register t1, Register
   br(Assembler::NE, slow);
 
   // After successful lock, push object on lock-stack
-  ldr(t1, Address(rthread, JavaThread::lock_stack_current_offset()));
-  str(obj, Address(t1, 0));
-  add(t1, t1, oopSize);
-  str(t1, Address(rthread, JavaThread::lock_stack_current_offset()));
+  ldrw(t1, Address(rthread, JavaThread::lock_stack_offset_offset()));
+  str(obj, Address(rthread, t1));
+  addw(t1, t1, oopSize);
+  strw(t1, Address(rthread, JavaThread::lock_stack_offset_offset()));
 }
 
 void MacroAssembler::fast_unlock(Register obj, Register hdr, Register t1, Register t2, Label& slow) {
@@ -6238,7 +6235,7 @@ void MacroAssembler::fast_unlock(Register obj, Register hdr, Register t1, Regist
   br(Assembler::NE, slow);
 
   // After successful unlock, pop object from lock-stack
-  ldr(t1, Address(rthread, JavaThread::lock_stack_current_offset()));
-  sub(t1, t1, oopSize);
-  str(t1, Address(rthread, JavaThread::lock_stack_current_offset()));
+  ldrw(t1, Address(rthread, JavaThread::lock_stack_offset_offset()));
+  subw(t1, t1, oopSize);
+  strw(t1, Address(rthread, JavaThread::lock_stack_offset_offset()));
 }

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
@@ -1582,7 +1582,7 @@ public:
   // Code for java.lang.Thread::onSpinWait() intrinsic.
   void spin_wait();
 
-  void fast_lock(Register obj, Register hdr, Register t1, Register t2, Label& slow, bool rt_check_stack = true);
+  void fast_lock(Register obj, Register hdr, Register t1, Register t2, Label& slow);
   void fast_unlock(Register obj, Register hdr, Register t1, Register t2, Label& slow);
 
 private:

--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -5357,29 +5357,6 @@ class StubGenerator: public StubCodeGenerator {
     return start;
   }
 
-  address generate_check_lock_stack() {
-    __ align(CodeEntryAlignment);
-    StubCodeMark mark(this, "StubRoutines", "check_lock_stack");
-
-    address start = __ pc();
-
-    __ set_last_Java_frame(sp, rfp, lr, rscratch1);
-    __ enter();
-    __ push_call_clobbered_registers();
-
-    __ mov(c_rarg0, r9);
-    __ call_VM_leaf(CAST_FROM_FN_PTR(address, LockStack::ensure_lock_stack_size), 1);
-
-
-    __ pop_call_clobbered_registers();
-    __ leave();
-    __ reset_last_Java_frame(true);
-
-    __ ret(lr);
-
-    return start;
-  }
-
   // r0  = result
   // r1  = str1
   // r2  = cnt1
@@ -8011,9 +7988,6 @@ class StubGenerator: public StubCodeGenerator {
     BarrierSetNMethod* bs_nm = BarrierSet::barrier_set()->barrier_set_nmethod();
     if (bs_nm != NULL) {
       StubRoutines::aarch64::_method_entry_barrier = generate_method_entry_barrier();
-    }
-    if (UseFastLocking) {
-      StubRoutines::aarch64::_check_lock_stack = generate_check_lock_stack();
     }
 #ifdef COMPILER2
     if (UseMultiplyToLenIntrinsic) {

--- a/src/hotspot/cpu/aarch64/stubRoutines_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubRoutines_aarch64.cpp
@@ -57,7 +57,6 @@ address StubRoutines::aarch64::_string_indexof_linear_uu = NULL;
 address StubRoutines::aarch64::_string_indexof_linear_ul = NULL;
 address StubRoutines::aarch64::_large_byte_array_inflate = NULL;
 address StubRoutines::aarch64::_method_entry_barrier = NULL;
-address StubRoutines::aarch64::_check_lock_stack = NULL;
 
 static void empty_spin_wait() { }
 address StubRoutines::aarch64::_spin_wait = CAST_FROM_FN_PTR(address, empty_spin_wait);

--- a/src/hotspot/cpu/aarch64/stubRoutines_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/stubRoutines_aarch64.hpp
@@ -70,8 +70,6 @@ class aarch64 {
 
   static address _method_entry_barrier;
 
-  static address _check_lock_stack;
-
   static address _spin_wait;
 
   static bool _completed;
@@ -180,10 +178,6 @@ class aarch64 {
 
   static address method_entry_barrier() {
     return _method_entry_barrier;
-  }
-
-  static address check_lock_stack() {
-    return _check_lock_stack;
   }
 
   static address spin_wait() {

--- a/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
@@ -285,7 +285,7 @@ void LIR_Assembler::osr_entry() {
 
   // build frame
   ciMethod* m = compilation()->method();
-  __ build_frame(initial_frame_size_in_bytes(), bang_size_in_bytes(), compilation()->max_monitors());
+  __ build_frame(initial_frame_size_in_bytes(), bang_size_in_bytes());
 
   // OSR buffer is
   //

--- a/src/hotspot/cpu/x86/c1_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_MacroAssembler_x86.cpp
@@ -69,7 +69,7 @@ int C1_MacroAssembler::lock_object(Register hdr, Register obj, Register disp_hdr
     const Register thread = disp_hdr;
     get_thread(thread);
 #endif
-    fast_lock_impl(obj, hdr, thread, tmp, slow_case, LP64_ONLY(false) NOT_LP64(true));
+    fast_lock_impl(obj, hdr, thread, tmp, slow_case);
   } else {
     Label done;
     orptr(hdr, markWord::unlocked_value);
@@ -322,7 +322,7 @@ void C1_MacroAssembler::inline_cache_check(Register receiver, Register iCache) {
 }
 
 
-void C1_MacroAssembler::build_frame(int frame_size_in_bytes, int bang_size_in_bytes, int max_monitors) {
+void C1_MacroAssembler::build_frame(int frame_size_in_bytes, int bang_size_in_bytes) {
   assert(bang_size_in_bytes >= frame_size_in_bytes, "stack bang size incorrect");
   // Make sure there is enough stack space for this method's activation.
   // Note that we do this before doing an enter(). This matches the
@@ -342,19 +342,6 @@ void C1_MacroAssembler::build_frame(int frame_size_in_bytes, int bang_size_in_by
   }
 #endif // !_LP64 && COMPILER2
   decrement(rsp, frame_size_in_bytes); // does not emit code for frame_size == 0
-
-#ifdef _LP64
-  if (UseFastLocking && max_monitors > 0) {
-    Label ok;
-    movptr(rax, Address(r15_thread, JavaThread::lock_stack_current_offset()));
-    addptr(rax, max_monitors * wordSize);
-    cmpptr(rax, Address(r15_thread, JavaThread::lock_stack_limit_offset()));
-    jcc(Assembler::less, ok);
-    assert(StubRoutines::x86::check_lock_stack() != NULL, "need runtime call stub");
-    call(RuntimeAddress(StubRoutines::x86::check_lock_stack()));
-    bind(ok);
-  }
-#endif
 
   BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
   // C1 code is not hot enough to micro optimize the nmethod entry barrier with an out-of-line stub

--- a/src/hotspot/cpu/x86/c2_CodeStubs_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_CodeStubs_x86.cpp
@@ -73,17 +73,6 @@ void C2EntryBarrierStub::emit(C2_MacroAssembler& masm) {
   __ jmp(continuation(), false /* maybe_short */);
 }
 
-int C2CheckLockStackStub::max_size() const {
-  return 10;
-}
-
-void C2CheckLockStackStub::emit(C2_MacroAssembler& masm) {
-  __ bind(entry());
-  assert(StubRoutines::x86::check_lock_stack() != NULL, "need runtime call stub");
-  __ call(RuntimeAddress(StubRoutines::x86::check_lock_stack()));
-  __ jmp(continuation(), false /* maybe_short */);
-}
-
 #ifdef _LP64
 int C2HandleAnonOMOwnerStub::max_size() const {
   return 17;
@@ -93,7 +82,7 @@ void C2HandleAnonOMOwnerStub::emit(C2_MacroAssembler& masm) {
   __ bind(entry());
   Register mon = monitor();
   __ movptr(Address(mon, OM_OFFSET_NO_MONITOR_VALUE_TAG(owner)), r15_thread);
-  __ subptr(Address(r15_thread, JavaThread::lock_stack_current_offset()), oopSize);
+  __ subl(Address(r15_thread, JavaThread::lock_stack_offset_offset()), oopSize);
   __ jmp(continuation());
 }
 

--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
@@ -45,7 +45,7 @@
 #endif
 
 // C2 compiled method's prolog code.
-void C2_MacroAssembler::verified_entry(int framesize, int stack_bang_size, bool fp_mode_24b, bool is_stub, int max_monitors) {
+void C2_MacroAssembler::verified_entry(int framesize, int stack_bang_size, bool fp_mode_24b, bool is_stub) {
 
   // WARNING: Initial instruction MUST be 5 bytes or longer so that
   // NativeJump::patch_verified_entry will be able to patch out the entry
@@ -124,20 +124,6 @@ void C2_MacroAssembler::verified_entry(int framesize, int stack_bang_size, bool 
     jcc(Assembler::equal, L);
     STOP("Stack is not properly aligned!");
     bind(L);
-  }
-#endif
-
-#ifdef _LP64
-  if (UseFastLocking && max_monitors > 0) {
-    C2CheckLockStackStub* stub = new (Compile::current()->comp_arena()) C2CheckLockStackStub();
-    Compile::current()->output()->add_stub(stub);
-    assert(!is_stub, "only methods have monitors");
-    Register thread = r15_thread;
-    movptr(rax, Address(thread, JavaThread::lock_stack_current_offset()));
-    addptr(rax, max_monitors * oopSize);
-    cmpptr(rax, Address(thread, JavaThread::lock_stack_limit_offset()));
-    jcc(Assembler::greaterEqual, stub->entry());
-    bind(stub->continuation());
   }
 #endif
 
@@ -617,21 +603,12 @@ void C2_MacroAssembler::fast_lock(Register objReg, Register boxReg, Register tmp
 
   if (!UseHeavyMonitors) {
     if (UseFastLocking) {
-#ifdef _LP64
-      fast_lock_impl(objReg, tmpReg, thread, scrReg, NO_COUNT, false);
-      jmp(COUNT);
-#else
-      // We can not emit the lock-stack-check in verified_entry() because we don't have enough
-      // registers (for thread ptr). Therefore we have to emit the lock-stack-check in
-      // fast_lock_impl(). However, that check can take a slow-path with ZF=1, therefore
-      // we need to handle it specially and force ZF=0 before taking the actual slow-path.
       Label slow;
       fast_lock_impl(objReg, tmpReg, thread, scrReg, slow);
       jmp(COUNT);
       bind(slow);
       testptr(objReg, objReg); // ZF=0 to indicate failure
       jmp(NO_COUNT);
-#endif
     } else {
       // Attempt stack-locking ...
       orptr (tmpReg, markWord::unlocked_value);

--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.hpp
@@ -29,7 +29,7 @@
 
 public:
   // C2 compiled method's prolog code.
-  void verified_entry(int framesize, int stack_bang_size, bool fp_mode_24b, bool is_stub, int max_monitors);
+  void verified_entry(int framesize, int stack_bang_size, bool fp_mode_24b, bool is_stub);
 
   Assembler::AvxVectorLen vector_length_encoding(int vlen_in_bytes);
 

--- a/src/hotspot/cpu/x86/interp_masm_x86.cpp
+++ b/src/hotspot/cpu/x86/interp_masm_x86.cpp
@@ -1351,8 +1351,8 @@ void InterpreterMacroAssembler::unlock_object(Register lock_reg) {
 #endif
       // Handle unstructured locking.
       Register tmp = swap_reg;
-      movptr(tmp, Address(thread, JavaThread::lock_stack_current_offset()));
-      cmpptr(obj_reg, Address(tmp, -oopSize));
+      movl(tmp, Address(thread, JavaThread::lock_stack_offset_offset()));
+      cmpptr(obj_reg, Address(thread, tmp, Address::times_1, -oopSize));
       jcc(Assembler::notEqual, slow_case);
       // Try to swing header from locked to unlock.
       movptr(swap_reg, Address(obj_reg, oopDesc::mark_offset_in_bytes()));

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -9859,26 +9859,13 @@ void MacroAssembler::check_stack_alignment(Register sp, const char* msg, unsigne
   bind(L_stack_ok);
 }
 
-void MacroAssembler::fast_lock_impl(Register obj, Register hdr, Register thread, Register tmp, Label& slow, bool rt_check_stack) {
+void MacroAssembler::fast_lock_impl(Register obj, Register hdr, Register thread, Register tmp, Label& slow) {
   assert(hdr == rax, "header must be in rax for cmpxchg");
   assert_different_registers(obj, hdr, thread, tmp);
 
   // First we need to check if the lock-stack has room for pushing the object reference.
-  if (rt_check_stack) {
-    movptr(tmp, Address(thread, JavaThread::lock_stack_current_offset()));
-    cmpptr(tmp, Address(thread, JavaThread::lock_stack_limit_offset()));
-    jcc(Assembler::greaterEqual, slow);
-  }
-#ifdef ASSERT
-  else {
-    Label ok;
-    movptr(tmp, Address(thread, JavaThread::lock_stack_current_offset()));
-    cmpptr(tmp, Address(thread, JavaThread::lock_stack_limit_offset()));
-    jcc(Assembler::less, ok);
-    stop("Not enough room in lock stack; should have been checked in the method prologue");
-    bind(ok);
-  }
-#endif
+  cmpl(Address(thread, JavaThread::lock_stack_offset_offset()), LockStack::end_offset());
+  jcc(Assembler::greaterEqual, slow);
 
   // Now we attempt to take the fast-lock.
   // Clear lowest two header bits (locked state).
@@ -9891,10 +9878,10 @@ void MacroAssembler::fast_lock_impl(Register obj, Register hdr, Register thread,
   jcc(Assembler::notEqual, slow);
 
   // If successful, push object to lock-stack.
-  movptr(tmp, Address(thread, JavaThread::lock_stack_current_offset()));
-  movptr(Address(tmp, 0), obj);
-  increment(tmp, oopSize);
-  movptr(Address(thread, JavaThread::lock_stack_current_offset()), tmp);
+  movl(tmp, Address(thread, JavaThread::lock_stack_offset_offset()));
+  movptr(Address(thread, tmp, Address::times_1), obj);
+  incrementl(tmp, oopSize);
+  movl(Address(thread, JavaThread::lock_stack_offset_offset()), tmp);
 }
 
 void MacroAssembler::fast_unlock_impl(Register obj, Register hdr, Register tmp, Label& slow) {
@@ -9914,5 +9901,5 @@ void MacroAssembler::fast_unlock_impl(Register obj, Register hdr, Register tmp, 
   const Register thread = rax;
   get_thread(rax);
 #endif
-  subptr(Address(thread, JavaThread::lock_stack_current_offset()), oopSize);
+  subl(Address(thread, JavaThread::lock_stack_offset_offset()), oopSize);
 }

--- a/src/hotspot/cpu/x86/macroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.hpp
@@ -2028,7 +2028,7 @@ public:
 
   void check_stack_alignment(Register sp, const char* msg, unsigned bias = 0, Register tmp = noreg);
 
-  void fast_lock_impl(Register obj, Register hdr, Register thread, Register tmp, Label& slow, bool rt_check_stack = true);
+  void fast_lock_impl(Register obj, Register hdr, Register thread, Register tmp, Label& slow);
   void fast_unlock_impl(Register obj, Register hdr, Register tmp, Label& slow);
 };
 

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -3183,55 +3183,6 @@ address StubGenerator::generate_method_entry_barrier() {
   return start;
 }
 
-// Call runtime to ensure lock-stack size.
-// Arguments:
-// - c_rarg0: the required _limit pointer
-address StubGenerator::generate_check_lock_stack() {
-  __ align(CodeEntryAlignment);
-  StubCodeMark mark(this, "StubRoutines", "check_lock_stack");
-  address start = __ pc();
-
-  BLOCK_COMMENT("Entry:");
-  __ enter(); // save rbp
-
-  __ pusha();
-
-  // The method may have floats as arguments, and we must spill them before calling
-  // the VM runtime.
-  assert(Argument::n_float_register_parameters_j == 8, "Assumption");
-  const int xmm_size = wordSize * 2;
-  const int xmm_spill_size = xmm_size * Argument::n_float_register_parameters_j;
-  __ subptr(rsp, xmm_spill_size);
-  __ movdqu(Address(rsp, xmm_size * 7), xmm7);
-  __ movdqu(Address(rsp, xmm_size * 6), xmm6);
-  __ movdqu(Address(rsp, xmm_size * 5), xmm5);
-  __ movdqu(Address(rsp, xmm_size * 4), xmm4);
-  __ movdqu(Address(rsp, xmm_size * 3), xmm3);
-  __ movdqu(Address(rsp, xmm_size * 2), xmm2);
-  __ movdqu(Address(rsp, xmm_size * 1), xmm1);
-  __ movdqu(Address(rsp, xmm_size * 0), xmm0);
-
-  __ call_VM_leaf(CAST_FROM_FN_PTR(address, static_cast<void (*)(oop*)>(LockStack::ensure_lock_stack_size)), rax);
-
-  __ movdqu(xmm0, Address(rsp, xmm_size * 0));
-  __ movdqu(xmm1, Address(rsp, xmm_size * 1));
-  __ movdqu(xmm2, Address(rsp, xmm_size * 2));
-  __ movdqu(xmm3, Address(rsp, xmm_size * 3));
-  __ movdqu(xmm4, Address(rsp, xmm_size * 4));
-  __ movdqu(xmm5, Address(rsp, xmm_size * 5));
-  __ movdqu(xmm6, Address(rsp, xmm_size * 6));
-  __ movdqu(xmm7, Address(rsp, xmm_size * 7));
-  __ addptr(rsp, xmm_spill_size);
-
-  __ popa();
-
-  __ leave();
-
-  __ ret(0);
-
-  return start;
-}
-
  /**
  *  Arguments:
  *
@@ -4068,9 +4019,6 @@ void StubGenerator::generate_all() {
   BarrierSetNMethod* bs_nm = BarrierSet::barrier_set()->barrier_set_nmethod();
   if (bs_nm != NULL) {
     StubRoutines::x86::_method_entry_barrier = generate_method_entry_barrier();
-  }
-  if (UseFastLocking) {
-    StubRoutines::x86::_check_lock_stack = generate_check_lock_stack();
   }
 #ifdef COMPILER2
   if (UseMultiplyToLenIntrinsic) {

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.hpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.hpp
@@ -465,8 +465,6 @@ class StubGenerator: public StubCodeGenerator {
 
   address generate_method_entry_barrier();
 
-  address generate_check_lock_stack();
-
   address generate_mulAdd();
 
   address generate_bigIntegerRightShift();

--- a/src/hotspot/cpu/x86/stubRoutines_x86.cpp
+++ b/src/hotspot/cpu/x86/stubRoutines_x86.cpp
@@ -84,7 +84,6 @@ address StubRoutines::x86::_join_2_3_base64 = NULL;
 address StubRoutines::x86::_decoding_table_base64 = NULL;
 #endif
 address StubRoutines::x86::_pshuffle_byte_flip_mask_addr = NULL;
-address StubRoutines::x86::_check_lock_stack = NULL;
 
 uint64_t StubRoutines::x86::_crc_by128_masks[] =
 {

--- a/src/hotspot/cpu/x86/stubRoutines_x86.hpp
+++ b/src/hotspot/cpu/x86/stubRoutines_x86.hpp
@@ -126,8 +126,6 @@ class x86 {
 
   static address _method_entry_barrier;
 
-  static address _check_lock_stack;
-
   // masks and table for CRC32
   static uint64_t _crc_by128_masks[];
   static juint    _crc_table[];
@@ -216,8 +214,6 @@ class x86 {
   static address shuffle_byte_flip_mask_addr() { return _shuffle_byte_flip_mask_addr; }
   static address k256_addr()      { return _k256_adr; }
   static address method_entry_barrier() { return _method_entry_barrier; }
-
-  static address check_lock_stack() { return _check_lock_stack; }
 
   static address vector_short_to_byte_mask() {
     return _vector_short_to_byte_mask;

--- a/src/hotspot/cpu/x86/x86_32.ad
+++ b/src/hotspot/cpu/x86/x86_32.ad
@@ -614,8 +614,7 @@ void MachPrologNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
   int framesize = C->output()->frame_size_in_bytes();
   int bangsize = C->output()->bang_size_in_bytes();
 
-  int max_monitors = C->method() != NULL ? C->max_monitors() : 0;
-  __ verified_entry(framesize, C->output()->need_stack_bang(bangsize)?bangsize:0, C->in_24_bit_fp_mode(), C->stub_function() != NULL, max_monitors);
+  __ verified_entry(framesize, C->output()->need_stack_bang(bangsize)?bangsize:0, C->in_24_bit_fp_mode(), C->stub_function() != NULL);
 
   C->output()->set_frame_complete(cbuf.insts_size());
 

--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -922,8 +922,7 @@ void MachPrologNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
     __ bind(L_skip_barrier);
   }
 
-  int max_monitors = C->method() != NULL ? C->max_monitors() : 0;
-  __ verified_entry(framesize, C->output()->need_stack_bang(bangsize)?bangsize:0, false, C->stub_function() != NULL, max_monitors);
+  __ verified_entry(framesize, C->output()->need_stack_bang(bangsize)?bangsize:0, false, C->stub_function() != NULL);
 
   C->output()->set_frame_complete(cbuf.insts_size());
 

--- a/src/hotspot/share/c1/c1_Compilation.cpp
+++ b/src/hotspot/share/c1/c1_Compilation.cpp
@@ -384,7 +384,6 @@ int Compilation::compile_java_method() {
 
   if (method()->is_synchronized()) {
     set_has_monitors(true);
-    push_monitor();
   }
 
   {
@@ -572,7 +571,6 @@ Compilation::Compilation(AbstractCompiler* compiler, ciEnv* env, ciMethod* metho
 , _has_method_handle_invokes(false)
 , _has_reserved_stack_access(method->has_reserved_stack_access())
 , _has_monitors(false)
-, _max_monitors(0)
 , _install_code(install_code)
 , _bailout_msg(NULL)
 , _exception_info_list(NULL)

--- a/src/hotspot/share/c1/c1_Compilation.hpp
+++ b/src/hotspot/share/c1/c1_Compilation.hpp
@@ -83,7 +83,6 @@ class Compilation: public StackObj {
   bool               _has_method_handle_invokes;  // True if this method has MethodHandle invokes.
   bool               _has_reserved_stack_access;
   bool               _has_monitors; // Fastpath monitors detection for Continuations
-  int                _max_monitors; // Max number of active monitors, for fast-locking
   bool               _install_code;
   const char*        _bailout_msg;
   ExceptionInfoList* _exception_info_list;
@@ -141,7 +140,6 @@ class Compilation: public StackObj {
   bool has_fpu_code() const                      { return _has_fpu_code; }
   bool has_unsafe_access() const                 { return _has_unsafe_access; }
   bool has_monitors() const                      { return _has_monitors; }
-  int max_monitors() const                       { return _max_monitors; }
   bool has_irreducible_loops() const             { return _has_irreducible_loops; }
   int max_vector_size() const                    { return 0; }
   ciMethod* method() const                       { return _method; }
@@ -174,8 +172,6 @@ class Compilation: public StackObj {
   void set_would_profile(bool f)                 { _would_profile = f; }
   void set_has_access_indexed(bool f)            { _has_access_indexed = f; }
   void set_has_monitors(bool f)                  { _has_monitors = f; }
-  void push_monitor()                            { _max_monitors++; }
-
   // Add a set of exception handlers covering the given PC offset
   void add_exception_handlers_for_pco(int pco, XHandlers* exception_handlers);
   // Statistics gathering

--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -2315,7 +2315,6 @@ void GraphBuilder::monitorenter(Value x, int bci) {
   // save state before locking in case of deoptimization after a NullPointerException
   ValueStack* state_before = copy_state_for_exception_with_bci(bci);
   compilation()->set_has_monitors(true);
-  compilation()->push_monitor();
   append_with_bci(new MonitorEnter(x, state()->lock(x), state_before), bci);
   kill_all();
 }

--- a/src/hotspot/share/c1/c1_LIRAssembler.cpp
+++ b/src/hotspot/share/c1/c1_LIRAssembler.cpp
@@ -771,7 +771,7 @@ void LIR_Assembler::emit_op4(LIR_Op4* op) {
 }
 
 void LIR_Assembler::build_frame() {
-  _masm->build_frame(initial_frame_size_in_bytes(), bang_size_in_bytes(), compilation()->max_monitors());
+  _masm->build_frame(initial_frame_size_in_bytes(), bang_size_in_bytes());
 }
 
 

--- a/src/hotspot/share/c1/c1_MacroAssembler.hpp
+++ b/src/hotspot/share/c1/c1_MacroAssembler.hpp
@@ -39,7 +39,7 @@ class C1_MacroAssembler: public MacroAssembler {
   void explicit_null_check(Register base);
 
   void inline_cache_check(Register receiver, Register iCache);
-  void build_frame(int frame_size_in_bytes, int bang_size_in_bytes, int max_monitors);
+  void build_frame(int frame_size_in_bytes, int bang_size_in_bytes);
   void remove_frame(int frame_size_in_bytes);
 
   void verified_entry(bool breakAtEntry);

--- a/src/hotspot/share/opto/c2_CodeStubs.hpp
+++ b/src/hotspot/share/opto/c2_CodeStubs.hpp
@@ -86,14 +86,6 @@ public:
   void emit(C2_MacroAssembler& masm);
 };
 
-class C2CheckLockStackStub : public C2CodeStub {
-public:
-  C2CheckLockStackStub() : C2CodeStub() {}
-
-  int max_size() const;
-  void emit(C2_MacroAssembler& masm);
-};
-
 #ifdef _LP64
 class C2HandleAnonOMOwnerStub : public C2CodeStub {
 private:

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -1021,7 +1021,6 @@ void Compile::Init(bool aliasing) {
 
   set_do_vector_loop(false);
   set_has_monitors(false);
-  reset_max_monitors();
 
   if (AllowVectorizeOnDemand) {
     if (has_method() && (_directive->VectorizeOption || _directive->VectorizeDebugOption)) {

--- a/src/hotspot/share/opto/compile.hpp
+++ b/src/hotspot/share/opto/compile.hpp
@@ -337,7 +337,6 @@ class Compile : public Phase {
   // JSR 292
   bool                  _has_method_handle_invokes; // True if this method has MethodHandle invokes.
   bool                  _has_monitors;          // Metadata transfered to nmethod to enable Continuations lock-detection fastpath
-  uint                  _max_monitors;          // Keep track of maximum number of active monitors in this compilation
   RTMState              _rtm_state;             // State of Restricted Transactional Memory usage
   int                   _loop_opts_cnt;         // loop opts round
   bool                  _clinit_barrier_on_entry; // True if clinit barrier is needed on nmethod entry
@@ -631,10 +630,6 @@ class Compile : public Phase {
   void          set_clinit_barrier_on_entry(bool z) { _clinit_barrier_on_entry = z; }
   bool              has_monitors() const         { return _has_monitors; }
   void          set_has_monitors(bool v)         { _has_monitors = v; }
-
-  void          push_monitor() { _max_monitors++; }
-  void          reset_max_monitors() { _max_monitors = 0; }
-  uint          max_monitors() { return _max_monitors; }
 
   // check the CompilerOracle for special behaviours for this compile
   bool          method_has_option(enum CompileCommand option) {

--- a/src/hotspot/share/opto/locknode.cpp
+++ b/src/hotspot/share/opto/locknode.cpp
@@ -180,7 +180,6 @@ void Parse::do_monitor_enter() {
   kill_dead_locals();
 
   C->set_has_monitors(true);
-  C->push_monitor();
 
   // Null check; get casted pointer.
   Node* obj = null_check(peek());

--- a/src/hotspot/share/opto/parse1.cpp
+++ b/src/hotspot/share/opto/parse1.cpp
@@ -423,7 +423,6 @@ Parse::Parse(JVMState* caller, ciMethod* parse_method, float expected_uses)
 
   if (parse_method->is_synchronized()) {
     C->set_has_monitors(true);
-    C->push_monitor();
   }
 
   _tf = TypeFunc::make(method());

--- a/src/hotspot/share/runtime/javaThread.hpp
+++ b/src/hotspot/share/runtime/javaThread.hpp
@@ -1147,8 +1147,8 @@ private:
 public:
   LockStack& lock_stack() { return _lock_stack; }
 
-  static ByteSize lock_stack_current_offset()    { return byte_offset_of(JavaThread, _lock_stack) + LockStack::current_offset(); }
-  static ByteSize lock_stack_limit_offset()    { return byte_offset_of(JavaThread, _lock_stack) + LockStack::limit_offset(); }
+  static ByteSize lock_stack_offset_offset()    { return byte_offset_of(JavaThread, _lock_stack) + LockStack::offset_offset(); }
+  static ByteSize lock_stack_base_offset()      { return byte_offset_of(JavaThread, _lock_stack) + LockStack::base_offset(); }
 
 
   static OopStorage* thread_oop_storage();

--- a/src/hotspot/share/runtime/lockStack.cpp
+++ b/src/hotspot/share/runtime/lockStack.cpp
@@ -24,60 +24,28 @@
 
 #include "precompiled.hpp"
 #include "memory/allocation.hpp"
-#include "runtime/lockStack.hpp"
+#include "runtime/lockStack.inline.hpp"
 #include "runtime/safepoint.hpp"
 #include "runtime/thread.hpp"
 #include "utilities/copy.hpp"
 #include "utilities/ostream.hpp"
 
 LockStack::LockStack() :
-  _base(UseFastLocking && !UseHeavyMonitors ? _initial : NULL),
-  _limit(_base + INITIAL_CAPACITY),
-  _current(_base) {
+  _offset(in_bytes(JavaThread::lock_stack_base_offset())) {
 }
 
-LockStack::~LockStack() {
-  if (UseFastLocking && !UseHeavyMonitors) {
-    if (_base != _initial) {
-      FREE_C_HEAP_ARRAY(oop, _base);
-    }
-  }
+int LockStack::end_offset() {
+  return in_bytes(JavaThread::lock_stack_base_offset()) + CAPACITY * oopSize;
 }
 
 #ifndef PRODUCT
 void LockStack::validate(const char* msg) const {
   assert(UseFastLocking && !UseHeavyMonitors, "never use lock-stack when fast-locking is disabled");
-  for (oop* loc1 = _base; loc1 < _current - 1; loc1++) {
-    for (oop* loc2 = loc1 + 1; loc2 < _current; loc2++) {
-      assert(*loc1 != *loc2, "entries must be unique: %s", msg);
+  int end = to_index(_offset);
+  for (int i = 0; i < end; i++) {
+    for (int j = i + 1; j < end; j++) {
+      assert(_base[i] != _base[j], "entries must be unique: %s", msg);
     }
   }
 }
 #endif
-
-void LockStack::grow(size_t min_capacity) {
-  // Grow stack.
-  assert(_limit > _base, "invariant");
-  size_t capacity = _limit - _base;
-  size_t index = _current - _base;
-  size_t new_capacity = MAX2(min_capacity, capacity * 2);
-  if (_base == _initial) {
-    oop* new_stack = NEW_C_HEAP_ARRAY(oop, new_capacity, mtSynchronizer);
-    for (size_t i = 0; i < index; i++) {
-      *(new_stack + i) = *(_base + i);
-    }
-    _base = new_stack;
-  } else {
-    _base = REALLOC_C_HEAP_ARRAY(oop, _base, new_capacity, mtSynchronizer);
-  }
-  _limit = _base + new_capacity;
-  _current = _base + index;
-  assert(_current < _limit, "must fit after growing");
-  assert((_limit - _base) >= (ptrdiff_t) min_capacity, "must grow enough");
-}
-
-void LockStack::ensure_lock_stack_size(oop* required_limit) {
-  JavaThread* jt = JavaThread::current();
-  LockStack& lock_stack = jt->lock_stack();
-  lock_stack.grow(required_limit - lock_stack._base);
-}

--- a/src/hotspot/share/runtime/lockStack.hpp
+++ b/src/hotspot/share/runtime/lockStack.hpp
@@ -35,25 +35,25 @@ class OopClosure;
 class LockStack {
   friend class VMStructs;
 private:
-  static const size_t INITIAL_CAPACITY = 4;
-  oop* _base;
-  oop* _limit;
-  oop* _current;
-  oop _initial[INITIAL_CAPACITY];
-
-  void grow(size_t min_capacity);
+  static const int CAPACITY = 8;
+  // The offset of the next element, in bytes, relative to the JavaThread structure.
+  // We do this instead of a simple index into the array because this allows for
+  // efficient addressing in generated code.
+  int _offset;
+  oop _base[CAPACITY];
 
   void validate(const char* msg) const PRODUCT_RETURN;
-public:
-  static ByteSize current_offset()    { return byte_offset_of(LockStack, _current); }
-  static ByteSize base_offset()       { return byte_offset_of(LockStack, _base); }
-  static ByteSize limit_offset()      { return byte_offset_of(LockStack, _limit); }
 
-  static void ensure_lock_stack_size(oop* _required_limit);
+  static inline int to_index(int offset);
+
+public:
+  static ByteSize offset_offset()    { return byte_offset_of(LockStack, _offset); }
+  static ByteSize base_offset()      { return byte_offset_of(LockStack, _base); }
 
   LockStack();
-  ~LockStack();
 
+  static int end_offset();
+  inline bool can_push() const;
   inline void push(oop o);
   inline oop pop();
   inline void remove(oop o);

--- a/src/hotspot/share/runtime/lockStack.inline.hpp
+++ b/src/hotspot/share/runtime/lockStack.inline.hpp
@@ -26,26 +26,32 @@
 #define SHARE_RUNTIME_LOCKSTACK_INLINE_HPP
 
 #include "memory/iterator.hpp"
+#include "runtime/javaThread.hpp"
 #include "runtime/lockStack.hpp"
+
+inline int LockStack::to_index(int offset) {
+  return (offset - in_bytes(JavaThread::lock_stack_base_offset())) / oopSize;
+}
+
+inline bool LockStack::can_push() const {
+  return to_index(_offset) < CAPACITY;
+}
 
 inline void LockStack::push(oop o) {
   validate("pre-push");
   assert(oopDesc::is_oop(o), "must be");
   assert(!contains(o), "entries must be unique");
-  if (_current >= _limit) {
-    grow((_limit - _base) + 1);
-  }
-  *_current = o;
-  _current++;
+  assert(can_push(), "must have room");
+  _base[to_index(_offset)] = o;
+  _offset += oopSize;
   validate("post-push");
 }
 
 inline oop LockStack::pop() {
   validate("pre-pop");
-  oop* new_loc = _current - 1;
-  assert(new_loc < _current, "underflow, probably unbalanced push/pop");
-  _current = new_loc;
-  oop o = *_current;
+  assert(to_index(_offset) > 0, "underflow, probably unbalanced push/pop");
+  _offset -= oopSize;
+  oop o = _base[to_index(_offset)];
   assert(!contains(o), "entries must be unique");
   validate("post-pop");
   return o;
@@ -54,13 +60,14 @@ inline oop LockStack::pop() {
 inline void LockStack::remove(oop o) {
   validate("pre-remove");
   assert(contains(o), "entry must be present");
-  for (oop* loc = _base; loc < _current; loc++) {
-    if (*loc == o) {
-      oop* last = _current - 1;
-      for (; loc < last; loc++) {
-        *loc = *(loc + 1);
+  int end = to_index(_offset);
+  for (int i = 0; i < end; i++) {
+    if (_base[i] == o) {
+      int last = end - 1;
+      for (; i < last; i++) {
+        _base[i] = _base[i + 1];
       }
-      _current--;
+      _offset -= oopSize;
       break;
     }
   }
@@ -70,11 +77,10 @@ inline void LockStack::remove(oop o) {
 
 inline bool LockStack::contains(oop o) const {
   validate("pre-contains");
-  bool found = false;
-  size_t i = 0;
-  size_t found_i = 0;
-  for (oop* loc = _current - 1; loc >= _base; loc--) {
-    if (*loc == o) {
+  int end = to_index(_offset);
+  for (int i = end - 1; i >= 0; i--) {
+    if (_base[i] == o) {
+      validate("post-contains");
       return true;
     }
   }
@@ -84,8 +90,9 @@ inline bool LockStack::contains(oop o) const {
 
 inline void LockStack::oops_do(OopClosure* cl) {
   validate("pre-oops-do");
-  for (oop* loc = _base; loc < _current; loc++) {
-    cl->do_oop(loc);
+  int end = to_index(_offset);
+  for (int i = 0; i < end; i++) {
+    cl->do_oop(&_base[i]);
   }
   validate("post-oops-do");
 }

--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -489,25 +489,27 @@ void ObjectSynchronizer::enter(Handle obj, BasicLock* lock, JavaThread* current)
 
   if (!useHeavyMonitors()) {
     if (UseFastLocking) {
+      // fast-locking does not use the 'lock' parameter.
       LockStack& lock_stack = current->lock_stack();
-
-      markWord header = obj()->mark_acquire();
-      while (true) {
-        if (header.is_neutral()) {
-          assert(!lock_stack.contains(obj()), "thread must not already hold the lock");
-          // Try to swing into 'fast-locked' state without inflating.
-          markWord locked_header = header.set_fast_locked();
-          markWord witness = obj()->cas_set_mark(locked_header, header);
-          if (witness == header) {
-            // Successfully fast-locked, push object to lock-stack and return.
-            lock_stack.push(obj());
-            return;
+      if (lock_stack.can_push()) {
+        markWord header = obj()->mark_acquire();
+        while (true) {
+          if (header.is_neutral()) {
+            assert(!lock_stack.contains(obj()), "thread must not already hold the lock");
+            // Try to swing into 'fast-locked' state without inflating.
+            markWord locked_header = header.set_fast_locked();
+            markWord witness = obj()->cas_set_mark(locked_header, header);
+            if (witness == header) {
+              // Successfully fast-locked, push object to lock-stack and return.
+              lock_stack.push(obj());
+              return;
+            }
+            // Otherwise retry.
+            header = witness;
+          } else {
+            // Fall-through to inflate-enter.
+            break;
           }
-          // Otherwise retry.
-          header = witness;
-        } else {
-          // Fall-through to inflate-enter.
-          break;
         }
       }
     } else {

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -700,8 +700,8 @@
   nonstatic_field(Thread,                      _tlab,                                         ThreadLocalAllocBuffer)                \
   nonstatic_field(Thread,                      _allocated_bytes,                              jlong)                                 \
   nonstatic_field(JavaThread,                  _lock_stack,                                   LockStack)                             \
-  nonstatic_field(LockStack,                   _current,                                      oop*)                                  \
-  nonstatic_field(LockStack,                   _base,                                         oop*)                                  \
+  nonstatic_field(LockStack,                   _offset,                                       int)                                   \
+  nonstatic_field(LockStack,                   _base[0],                                      oop)                                   \
   nonstatic_field(NamedThread,                 _name,                                         char*)                                 \
   nonstatic_field(NamedThread,                 _processed_thread,                             Thread*)                               \
   nonstatic_field(JavaThread,                  _threadObj,                                    OopHandle)                             \


### PR DESCRIPTION
Until now, we used to have a variable-sized lock-stack: when pushing an object to it and capacity is exceeded, it would re-allocate a new stack and use that. However, experiments show that the lock-stack very rarely exceeds 5 slots (I have not yet found a workload that does actually exceed it). It makes sense to make the lock-stack a fixed-size array: it makes addressing the lock-stack simpler and more efficient and it increases the likelyhood of the lock-stack being in CPU cache. If the lock-stack is ever exceeded, we would not do stack-locking at all, but instead inflate the monitor and use that.

This is already integrated in the related upstream PR: https://github.com/openjdk/jdk/pull/10907

Testing:
 - [x] tier1
 - [ ] tier2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Integration blocker
&nbsp;⚠️ Whitespace errors (failed with the updated jcheck configuration)

### Issue
 * [JDK-8304341](https://bugs.openjdk.org/browse/JDK-8304341): [Lilliput] Use fixed-size lock-stack (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput.git pull/81/head:pull/81` \
`$ git checkout pull/81`

Update a local copy of the PR: \
`$ git checkout pull/81` \
`$ git pull https://git.openjdk.org/lilliput.git pull/81/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 81`

View PR using the GUI difftool: \
`$ git pr show -t 81`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput/pull/81.diff">https://git.openjdk.org/lilliput/pull/81.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput/pull/81#issuecomment-1472090819)