### PR TITLE
8304690: [Lilliput] Increase size of C2HandleAnonOMOwnerStub on x86

### DIFF
--- a/src/hotspot/cpu/x86/c2_CodeStubs_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_CodeStubs_x86.cpp
@@ -86,7 +86,7 @@ void C2CheckLockStackStub::emit(C2_MacroAssembler& masm) {
 
 #ifdef _LP64
 int C2HandleAnonOMOwnerStub::max_size() const {
-  return 17;
+  return 18;
 }
 
 void C2HandleAnonOMOwnerStub::emit(C2_MacroAssembler& masm) {


### PR DESCRIPTION
Deeper testing has revealed that the C2HandleAnonOMOwnerStub can take 18 bytes instead of currently used 17. We shall increase the max_size() for that stub. I haven't seen it on any of my machines, but it came up in testing of [JDK-8291555](https://bugs.openjdk.org/browse/JDK-8291555) in Oracle's testing infra. It's probably rare and/or machine dependent.

Testing:
 - [x] tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8304690](https://bugs.openjdk.org/browse/JDK-8304690): [Lilliput] Increase size of C2HandleAnonOMOwnerStub on x86


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput.git pull/82/head:pull/82` \
`$ git checkout pull/82`

Update a local copy of the PR: \
`$ git checkout pull/82` \
`$ git pull https://git.openjdk.org/lilliput.git pull/82/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 82`

View PR using the GUI difftool: \
`$ git pr show -t 82`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput/pull/82.diff">https://git.openjdk.org/lilliput/pull/82.diff</a>

</details>
