### PR TITLE
8305926: [Lilliput] Revert some ZGC changes

### DIFF
--- a/src/hotspot/share/gc/z/zLiveMap.inline.hpp
+++ b/src/hotspot/share/gc/z/zLiveMap.inline.hpp
@@ -144,11 +144,15 @@ inline void ZLiveMap::iterate_segment(ObjectClosure* cl, BitMap::idx_t segment, 
     // Calculate object address
     const uintptr_t addr = page_start + ((index / 2) << page_object_alignment_shift);
 
+    // Get the size of the object before calling the closure, which
+    // might overwrite the object in case we are relocating in-place.
+    const size_t size = ZUtils::object_size(addr);
+
     // Apply closure
     cl->do_object(ZOop::from_address(addr));
 
     // Find next bit after this object
-    const uintptr_t next_addr = align_up(addr + 1, 1 << page_object_alignment_shift);
+    const uintptr_t next_addr = align_up(addr + size, 1 << page_object_alignment_shift);
     const BitMap::idx_t next_index = ((next_addr - page_start) >> page_object_alignment_shift) * 2;
     if (next_index >= end_index) {
       // End of live map


### PR DESCRIPTION
I'm cleaning up some stuff and found these changes in ZGC that we don't need anymore.

Testing:
 - [x] hotspot_gc
 - [x] tier1
 - [x] tier2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8305926](https://bugs.openjdk.org/browse/JDK-8305926): [Lilliput] Revert some ZGC changes


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput.git pull/84/head:pull/84` \
`$ git checkout pull/84`

Update a local copy of the PR: \
`$ git checkout pull/84` \
`$ git pull https://git.openjdk.org/lilliput.git pull/84/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 84`

View PR using the GUI difftool: \
`$ git pr show -t 84`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput/pull/84.diff">https://git.openjdk.org/lilliput/pull/84.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput/pull/84#issuecomment-1505728069)