### PR TITLE
JDK-8307002: [Lilliput] [Metaspace] Make use of Klass alignment gaps

### DIFF
--- a/src/hotspot/share/memory/metaspace.cpp
+++ b/src/hotspot/share/memory/metaspace.cpp
@@ -1052,10 +1052,11 @@ bool Metaspace::contains(const void* ptr) {
   return contains_non_shared(ptr);
 }
 
-bool Metaspace::contains_non_shared(const void* ptr) {
-  if (using_class_space() && VirtualSpaceList::vslist_class()->contains((MetaWord*)ptr)) {
-     return true;
-  }
+bool Metaspace::class_space_contains(const void* ptr) {
+  return using_class_space() && VirtualSpaceList::vslist_class()->contains((MetaWord*)ptr);
+}
 
-  return VirtualSpaceList::vslist_nonclass()->contains((MetaWord*)ptr);
+bool Metaspace::contains_non_shared(const void* ptr) {
+  return class_space_contains(ptr) ||
+         VirtualSpaceList::vslist_nonclass()->contains((MetaWord*)ptr);
 }

--- a/src/hotspot/share/memory/metaspace.cpp
+++ b/src/hotspot/share/memory/metaspace.cpp
@@ -873,7 +873,7 @@ void Metaspace::post_initialize() {
 }
 
 size_t Metaspace::max_allocation_word_size() {
-  return metaspace::chunklevel::MAX_CHUNK_WORD_SIZE;
+  return metaspace::chunklevel::MAX_CHUNK_WORD_SIZE - KlassAlignmentInWords;
 }
 
 #ifdef _LP64

--- a/src/hotspot/share/memory/metaspace.hpp
+++ b/src/hotspot/share/memory/metaspace.hpp
@@ -121,6 +121,7 @@ public:
                             MetaspaceObj::Type type);
 
   static bool contains(const void* ptr);
+  static bool class_space_contains(const void* ptr);
   static bool contains_non_shared(const void* ptr);
 
   // Free empty virtualspaces

--- a/src/hotspot/share/memory/metaspace/binList.hpp
+++ b/src/hotspot/share/memory/metaspace/binList.hpp
@@ -32,7 +32,6 @@
 #include "utilities/debug.hpp"
 #include "utilities/globalDefinitions.hpp"
 
-
 namespace metaspace {
 
 // BinList is a data structure to manage small to very small memory blocks

--- a/src/hotspot/share/memory/metaspace/binList.hpp
+++ b/src/hotspot/share/memory/metaspace/binList.hpp
@@ -32,6 +32,7 @@
 #include "utilities/debug.hpp"
 #include "utilities/globalDefinitions.hpp"
 
+
 namespace metaspace {
 
 // BinList is a data structure to manage small to very small memory blocks

--- a/src/hotspot/share/memory/metaspace/blockTree.hpp
+++ b/src/hotspot/share/memory/metaspace/blockTree.hpp
@@ -362,7 +362,7 @@ public:
   //  larger than that size. Upon return, *p_real_word_size contains the actual
   //  block size.
   MetaWord* remove_block(size_t word_size, size_t* p_real_word_size) {
-    assert(word_size >= MinWordSize, "invalid block size " SIZE_FORMAT, word_size);
+    assert(word_size > 0, "invalid block size " SIZE_FORMAT, word_size);
 
     Node* n = find_closest_fit(word_size);
 

--- a/src/hotspot/share/memory/metaspace/freeBlocks.cpp
+++ b/src/hotspot/share/memory/metaspace/freeBlocks.cpp
@@ -27,6 +27,7 @@
 #include "memory/metaspace/freeBlocks.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/globalDefinitions.hpp"
+#include "utilities/ostream.hpp"
 
 namespace metaspace {
 
@@ -69,6 +70,11 @@ MetaWord* FreeBlocks::remove_block(size_t requested_word_size) {
     }
   }
   return p;
+}
+
+void FreeBlocks::print_on(outputStream* st) const {
+  st->print("small_blocks: %u blocks, " SIZE_FORMAT " words; tree: %u nodes, " SIZE_FORMAT " words.",
+            _small_blocks.count(), _small_blocks.total_size(), _tree.count(), _tree.total_size());
 }
 
 } // namespace metaspace

--- a/src/hotspot/share/memory/metaspace/freeBlocks.hpp
+++ b/src/hotspot/share/memory/metaspace/freeBlocks.hpp
@@ -110,6 +110,8 @@ public:
     return _small_blocks.is_empty() && _tree.is_empty();
   }
 
+  void print_on(outputStream* st) const;
+
 };
 
 } // namespace metaspace

--- a/src/hotspot/share/memory/metaspace/internalStats.hpp
+++ b/src/hotspot/share/memory/metaspace/internalStats.hpp
@@ -55,6 +55,15 @@ class InternalStats : public AllStatic {
   /*  from deallocated blocks. */                   \
   DEBUG_ONLY(x_atomic(num_allocs_from_deallocated_blocks)) \
                                                     \
+  /* Number of times an non-class allocation was */ \
+  /*  satisfied via deallocated blocks from      */ \
+  /*  class space. */                               \
+  DEBUG_ONLY(x_atomic(num_allocs_stolen_from_class_space)) \
+                                                   \
+  /* Number of splinter blocks added from        */ \
+  /*  Klass alignment gaps                       */ \
+  DEBUG_ONLY(x_atomic(num_klass_alignment_splinters_added)) \
+                                                    \
   /* Number of times an arena retired a chunk */    \
   DEBUG_ONLY(x_atomic(num_chunks_retired))          \
                                                     \

--- a/src/hotspot/share/memory/metaspace/testHelpers.cpp
+++ b/src/hotspot/share/memory/metaspace/testHelpers.cpp
@@ -53,8 +53,21 @@ MetaWord* MetaspaceTestArena::allocate(size_t word_size) {
   return _arena->allocate(word_size);
 }
 
+MetaWord* MetaspaceTestArena::allocate_for_klass(size_t word_size) {
+  return _arena->allocate_for_klass(word_size);
+}
+
+MetaWord* MetaspaceTestArena::allocate_from_freeblocks_only(size_t word_size) {
+  return _arena->allocate_from_freeblocks_only(word_size);
+}
+
 void MetaspaceTestArena::deallocate(MetaWord* p, size_t word_size) {
   return _arena->deallocate(p, word_size);
+}
+
+// Update statistics. This walks all in-use chunks.
+void MetaspaceTestArena::add_to_statistics(ArenaStats* out) const {
+  return _arena->add_to_statistics(out);
 }
 
 ///// MetaspaceTestArea //////
@@ -98,7 +111,7 @@ MetaspaceTestArena* MetaspaceTestContext::create_arena(Metaspace::MetaspaceType 
   MetaspaceArena* arena = nullptr;
   {
     MutexLocker ml(lock,  Mutex::_no_safepoint_check_flag);
-    arena = new MetaspaceArena(_context->cm(), growth_policy, MetaspaceMinAlignmentWords,
+    arena = new MetaspaceArena(_context->cm(), growth_policy,
                                lock, &_used_words_counter, _name);
   }
   return new MetaspaceTestArena(lock, arena);

--- a/src/hotspot/share/memory/metaspace/testHelpers.hpp
+++ b/src/hotspot/share/memory/metaspace/testHelpers.hpp
@@ -43,6 +43,7 @@ class outputStream;
 
 namespace metaspace {
 
+struct ArenaStats;
 class MetaspaceContext;
 class MetaspaceArena;
 
@@ -62,8 +63,10 @@ public:
   ~MetaspaceTestArena();
 
   MetaWord* allocate(size_t word_size);
+  MetaWord* allocate_for_klass(size_t word_size);
+  MetaWord* allocate_from_freeblocks_only(size_t word_size);
   void deallocate(MetaWord* p, size_t word_size);
-
+  void add_to_statistics(ArenaStats* out) const;
 };
 
 // Wraps an instance of a MetaspaceContext together with some side objects for easy use in test beds (whitebox, gtests)

--- a/src/hotspot/share/memory/metaspace/virtualSpaceNode.cpp
+++ b/src/hotspot/share/memory/metaspace/virtualSpaceNode.cpp
@@ -229,7 +229,8 @@ VirtualSpaceNode::VirtualSpaceNode(ReservedSpace rs, bool owns_rs, CommitLimiter
   _total_reserved_words_counter(reserve_counter),
   _total_committed_words_counter(commit_counter)
 {
-  UL2(debug, "born (word_size " SIZE_FORMAT ").", _word_size);
+  UL2(debug, "born: [" PTR_FORMAT ".." PTR_FORMAT "), (word_size " SIZE_FORMAT ").",
+      p2i(_rs.base()), p2i(_rs.end()), _word_size);
 
   // Update reserved counter in vslist
   _total_reserved_words_counter->increment_by(_word_size);

--- a/src/hotspot/share/oops/compressedKlass.cpp
+++ b/src/hotspot/share/oops/compressedKlass.cpp
@@ -36,6 +36,7 @@ int CompressedKlassPointers::_shift_copy = 0;
 #ifdef _LP64
 int LogKlassAlignmentInBytes = -1;
 int KlassAlignmentInBytes    = -1;
+int KlassAlignmentInWords    = -1;
 int MaxNarrowKlassPointerBits = -1;
 uint64_t  NarrowKlassPointerBitMask = 0;
 uint64_t KlassEncodingMetaspaceMax = 0;

--- a/src/hotspot/share/oops/compressedKlass.hpp
+++ b/src/hotspot/share/oops/compressedKlass.hpp
@@ -38,6 +38,7 @@ class Klass;
 // All these depend on UseCompactObjectHeaders
 extern int LogKlassAlignmentInBytes;
 extern int KlassAlignmentInBytes;
+extern int KlassAlignmentInWords;
 
 // Max. allowed size of compressed class pointer, in bits
 extern int MaxNarrowKlassPointerBits;
@@ -52,6 +53,7 @@ extern uint64_t KlassEncodingMetaspaceMax;
 // Why is this even needed in 32-bit? Todo: fix.
 const int LogKlassAlignmentInBytes = 3; // traditional 64-bit alignment
 const int KlassAlignmentInBytes    = 1 << LogKlassAlignmentInBytes;
+const int KlassAlignmentInWords = KlassAlignmentInBytes / BytesPerWord;
 const int MaxNarrowKlassPointerBits = 22; // should never be used.
 const uint64_t  NarrowKlassPointerBitMask = ((((uint64_t)1) << MaxNarrowKlassPointerBits) - 1);
 const uint64_t KlassEncodingMetaspaceMax = (uint64_t(max_juint) + 1) << LogKlassAlignmentInBytes;

--- a/src/hotspot/share/oops/klass.cpp
+++ b/src/hotspot/share/oops/klass.cpp
@@ -195,7 +195,9 @@ Method* Klass::uncached_lookup_method(const Symbol* name, const Symbol* signatur
 
 void* Klass::operator new(size_t size, ClassLoaderData* loader_data, size_t word_size, TRAPS) throw() {
   MetaWord* p = Metaspace::allocate(loader_data, word_size, MetaspaceObj::ClassType, THREAD);
-  assert(is_aligned(p, KlassAlignmentInBytes), "metaspace returned badly aligned memory.");
+  assert(is_aligned(p, KlassAlignmentInBytes),
+         "metaspace returned badly aligned memory (" PTR_FORMAT "), alignment required: %u",
+         p2i(p), (unsigned)KlassAlignmentInBytes);
   return p;
 }
 

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -1500,6 +1500,8 @@ void Arguments::set_use_compressed_klass_ptrs() {
   }
 
   KlassAlignmentInBytes = 1 << LogKlassAlignmentInBytes;
+  assert(is_aligned(KlassAlignmentInBytes, BytesPerWord), "Must be at least word-sized");
+  KlassAlignmentInWords = KlassAlignmentInBytes / BytesPerWord;
   NarrowKlassPointerBitMask = ((((uint64_t)1) << MaxNarrowKlassPointerBits) - 1);
   KlassEncodingMetaspaceMax = UCONST64(1) << (MaxNarrowKlassPointerBits + LogKlassAlignmentInBytes);
 

--- a/test/hotspot/gtest/metaspace/test_metaspacearena_stress.cpp
+++ b/test/hotspot/gtest/metaspace/test_metaspacearena_stress.cpp
@@ -34,10 +34,14 @@
 #include "runtime/mutexLocker.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/globalDefinitions.hpp"
+
+
 //#define LOG_PLEASE
 #include "metaspaceGtestCommon.hpp"
 #include "metaspaceGtestContexts.hpp"
 #include "metaspaceGtestSparseArray.hpp"
+
+#include "unittest.hpp"
 
 using metaspace::ArenaGrowthPolicy;
 using metaspace::ChunkManager;
@@ -57,11 +61,11 @@ static bool fifty_fifty() {
 // It keeps track of allocations done from this MetaspaceArena.
 class MetaspaceArenaTestBed : public CHeapObj<mtInternal> {
 
-  const SizeRange _allocation_range;
-  const int _alignment_words;
-
   MetaspaceArena* _arena;
+
   Mutex* _lock;
+
+  const SizeRange _allocation_range;
   size_t _size_of_last_failed_allocation;
 
   // We keep track of all allocations done thru the MetaspaceArena to
@@ -83,8 +87,7 @@ class MetaspaceArenaTestBed : public CHeapObj<mtInternal> {
   allocation_t* _allocations;
 
   // We count how much we did allocate and deallocate
-  MemRangeCounter _alloc_count_net; // net used bytes
-  MemRangeCounter _alloc_count_raw; // net used bytes + internal overhead
+  MemRangeCounter _alloc_count;
   MemRangeCounter _dealloc_count;
 
   // Check statistics returned by MetaspaceArena::add_to_statistics() against what
@@ -96,8 +99,8 @@ class MetaspaceArenaTestBed : public CHeapObj<mtInternal> {
     _arena->add_to_statistics(&stats);
     InUseChunkStats in_use_stats = stats.totals();
 
-    assert(_dealloc_count.total_size() <= _alloc_count_net.total_size() &&
-           _dealloc_count.count() <= _alloc_count_net.count(), "Sanity");
+    assert(_dealloc_count.total_size() <= _alloc_count.total_size() &&
+           _dealloc_count.count() <= _alloc_count.count(), "Sanity");
 
     // Check consistency of stats
     ASSERT_GE(in_use_stats._word_size, in_use_stats._committed_words);
@@ -113,40 +116,37 @@ class MetaspaceArenaTestBed : public CHeapObj<mtInternal> {
 
     // Since what we deallocated may have been given back to us in a following allocation,
     // we only know fore sure we allocated what we did not give back.
-    const size_t at_least_allocated = _alloc_count_net.total_size() - _dealloc_count.total_size();
+    const size_t at_least_allocated = _alloc_count.total_size() - _dealloc_count.total_size();
 
     // At most we allocated this:
-    size_t max_word_overhead_per_alloc = align_up(4, _alignment_words);
-    // Guard fences come as a separate, secondary block
-    if (metaspace::Settings::use_allocation_guard()) {
-      max_word_overhead_per_alloc *= 2;
-    }
-    const size_t at_most_allocated = _alloc_count_raw.total_size() + max_word_overhead_per_alloc * _alloc_count_raw.count();
+    const size_t max_word_overhead_per_alloc =
+        4 + (metaspace::Settings::use_allocation_guard() ? 4 : 0);
+    const size_t at_most_allocated = _alloc_count.total_size() + max_word_overhead_per_alloc * _alloc_count.count();
 
     ASSERT_LE(at_least_allocated, in_use_stats._used_words - stats._free_blocks_word_size);
     ASSERT_GE(at_most_allocated, in_use_stats._used_words - stats._free_blocks_word_size);
+
   }
 
 public:
 
   MetaspaceArena* arena() { return _arena; }
 
-  MetaspaceArenaTestBed(ChunkManager* cm, const ArenaGrowthPolicy* alloc_sequence, int alignment_words,
+  MetaspaceArenaTestBed(ChunkManager* cm, const ArenaGrowthPolicy* alloc_sequence,
                         SizeAtomicCounter* used_words_counter, SizeRange allocation_range) :
-    _allocation_range(allocation_range),
-    _alignment_words(alignment_words),
     _arena(NULL),
     _lock(NULL),
+    _allocation_range(allocation_range),
     _size_of_last_failed_allocation(0),
     _allocations(NULL),
-    _alloc_count_net(),
+    _alloc_count(),
     _dealloc_count()
   {
     _lock = new Mutex(Monitor::nosafepoint, "gtest-MetaspaceArenaTestBed_lock");
     // Lock during space creation, since this is what happens in the VM too
     //  (see ClassLoaderData::metaspace_non_null(), which we mimick here).
     MutexLocker ml(_lock,  Mutex::_no_safepoint_check_flag);
-    _arena = new MetaspaceArena(cm, alloc_sequence, alignment_words, _lock, used_words_counter, "gtest-MetaspaceArenaTestBed-sm");
+    _arena = new MetaspaceArena(cm, alloc_sequence, _lock, used_words_counter, "gtest-MetaspaceArenaTestBed-sm");
   }
 
   ~MetaspaceArenaTestBed() {
@@ -169,30 +169,25 @@ public:
 
   }
 
-  size_t words_allocated() const        { return _alloc_count_net.total_size(); }
-  int num_allocations() const           { return _alloc_count_net.count(); }
+  size_t words_allocated() const        { return _alloc_count.total_size(); }
+  int num_allocations() const           { return _alloc_count.count(); }
 
   size_t size_of_last_failed_allocation() const { return _size_of_last_failed_allocation; }
-
-  size_t calc_expected_usage_for_allocated_words(size_t word_size) {
-    return metaspace::get_raw_word_size_for_requested_word_size(word_size, _alignment_words);
-  }
 
   // Allocate a random amount. Return false if the allocation failed.
   bool checked_random_allocate() {
     size_t word_size = 1 + _allocation_range.random_value();
     MetaWord* p = _arena->allocate(word_size);
     if (p != NULL) {
-      EXPECT_TRUE(is_aligned(p, _alignment_words * BytesPerWord));
+      EXPECT_TRUE(is_aligned(p, sizeof(MetaWord)));
       allocation_t* a = NEW_C_HEAP_OBJ(allocation_t, mtInternal);
       a->word_size = word_size;
       a->p = p;
       a->mark();
       a->next = _allocations;
       _allocations = a;
-      _alloc_count_net.add(word_size);
-      _alloc_count_raw.add(calc_expected_usage_for_allocated_words(word_size));
-      if ((_alloc_count_net.count() % 20) == 0) {
+      _alloc_count.add(word_size);
+      if ((_alloc_count.count() % 20) == 0) {
         verify_arena_statistics();
         DEBUG_ONLY(_arena->verify();)
       }
@@ -234,9 +229,9 @@ class MetaspaceArenaTest {
 
   //////// Bed creation, destruction ///////
 
-  void create_new_test_bed_at(int slotindex, const ArenaGrowthPolicy* growth_policy, int alignment_words, SizeRange allocation_range) {
+  void create_new_test_bed_at(int slotindex, const ArenaGrowthPolicy* growth_policy, SizeRange allocation_range) {
     DEBUG_ONLY(_testbeds.check_slot_is_null(slotindex));
-    MetaspaceArenaTestBed* bed = new MetaspaceArenaTestBed(&_context.cm(), growth_policy, alignment_words,
+    MetaspaceArenaTestBed* bed = new MetaspaceArenaTestBed(&_context.cm(), growth_policy,
                                                        &_used_words_counter, allocation_range);
     _testbeds.set_at(slotindex, bed);
     _num_beds.increment();
@@ -247,10 +242,7 @@ class MetaspaceArenaTest {
     const ArenaGrowthPolicy* growth_policy = ArenaGrowthPolicy::policy_for_space_type(
         (fifty_fifty() ? Metaspace::StandardMetaspaceType : Metaspace::ReflectionMetaspaceType),
          fifty_fifty());
-    const int alignment_bytes =
-        1 << IntRange(metaspace::LogMetaspaceMinimalAlignment,
-                      metaspace::LogMetaspaceMinimalAlignment + 7).random_value(); // zw 8 byte and 1K
-    create_new_test_bed_at(slotindex, growth_policy, alignment_bytes / BytesPerWord, allocation_range);
+    create_new_test_bed_at(slotindex, growth_policy, allocation_range);
    }
 
   // Randomly create a random test bed at a random slot, and return its slot index
@@ -261,6 +253,15 @@ class MetaspaceArenaTest {
       create_random_test_bed_at(slot);
     }
     return slot;
+  }
+
+  // Create test beds for all slots
+  void create_all_test_beds() {
+    for (int slot = 0; slot < _testbeds.size(); slot++) {
+      if (_testbeds.slot_is_null(slot)) {
+        create_random_test_bed_at(slot);
+      }
+    }
   }
 
   void delete_test_bed_at(int slotindex) {
@@ -298,7 +299,7 @@ class MetaspaceArenaTest {
     if (success == false) {
       // We must have hit a limit.
       EXPECT_LT(_context.commit_limiter().possible_expansion_words(),
-                bed->calc_expected_usage_for_allocated_words(bed->size_of_last_failed_allocation()));
+                metaspace::get_raw_word_size_for_requested_word_size(bed->size_of_last_failed_allocation()));
     }
     return success;
   }

--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -377,8 +377,6 @@ tier1_runtime = \
  -runtime/memory/ReserveMemory.java \
  -runtime/Metaspace/FragmentMetaspace.java \
  -runtime/Metaspace/FragmentMetaspaceSimple.java \
- -runtime/Metaspace/elastic/TestMetaspaceAllocationMT1.java \
- -runtime/Metaspace/elastic/TestMetaspaceAllocationMT2.java \
  -runtime/MirrorFrame/Test8003720.java \
  -runtime/modules/LoadUnloadModuleStress.java \
  -runtime/modules/ModuleStress/ExportModuleStressTest.java \


### PR DESCRIPTION
https://github.com/openjdk/lilliput/pull/13 changed nKlass encoding by increasing the Klass alignment gap to 512. Works fine and gives us a nKlass-value-point-to-class ratio of about 1.5:1, which means we get close to the goal of representing each class with a single value of nKlass without changing Klass to a fixed-sized Layout. It has two disadvantages, though. The most obvious one - the memory waste caused by alignment shadows - is addressed by this issue. 

(The second disadvantage that I don't address in this issue is what John Rose called "naive overalignment", but it has effects on the patch, see below)

That waste matters little for normal programs: the average waste is 256 bytes per class, and if Lilliput saves 4 bytes per object, we break even if we create more than 64 objects per class on average. We usually do that.

But class-generation scenarios are a different matter. There, we often only have a single or very few objects per class, and many many more classes, so the numbers don't add up anymore. So we need a way to eliminate the gaps.

The simple solution is to save non-class metadata from the same class loader into these gaps. This works fine since much of our non-class metadata is very fine granular. Like sand into cracks, they settle into the gaps and fill them nicely. And it is not even complicated since we already have the machinery (the descendant of Coleen's original dark-matter-prevention-structure that we use to manage prematurely deallocated metaspace). 

----

Numbers:

Memory usage is almost back to baseline now. Volkers insane lambda generation test from JDK-8302154, loading 1 million lambdas, -Xshare:off, shows a reduction of 1.74GB->1.32GB, very close to the original 1.31GB baseline:

(interesting because scenarios like these will be the worst case from a metaspace perspective - metaspace usage of normal apps is unexciting with or without Lilliput):

```
Lilliput unpatched:
Virtual space:                                    
  Non-class space:      832,00 MB reserved,     807,12 MB ( 97%) committed,  13 nodes.
      Class space:        1,00 GB reserved,     977,31 MB ( 95%) committed,  1 nodes.                                                     
             Both:        1,81 GB reserved,       1,74 GB ( 96%) committed. 

Lilliput patched:
Virtual space:                                    
  Non-class space:      384,00 MB reserved,     370,75 MB ( 97%) committed,  6 nodes.
      Class space:        1,00 GB reserved,     977,31 MB ( 95%) committed,  1 nodes.                                                     
             Both:        1,38 GB reserved,       1,32 GB ( 96%) committed. 

Stock VM:
Virtual space:                                    
  Non-class space:      832,00 MB reserved,     822,44 MB ( 99%) committed,  13 nodes.
      Class space:        1,00 GB reserved,     521,31 MB ( 51%) committed,  1 nodes.
             Both:        1,81 GB reserved,       1,31 GB ( 72%) committed. 
```

----

Patch:

https://github.com/openjdk/lilliput/pull/13 introduced the notion that every MetaspaceArena has an alignment - instead, as in the stock VM - working with one global alignment. This patch reverts much of this code (makes it easier to merge too). Instead, it treats alignment as an allocation option. An arena can satisfy allocations with different alignment requirements and will do its best to salvage the alignment waste.

That is the core of the patch. The rest is fluff and tests.

---

Notes:

Numbers are somewhat fluid: at the moment, we use a Klass alignment of 512 and a nKlass size of 21 bits. We will probably change nKlass width to 24 or 26 bits for Lilliputs first milestone.

And once this patch is in, the disadvantage of memory waste is eliminated, so we could increase the Klass alignment. Both 512 and 1K are good values: on average a Klass is between 400b...1K. A 1K alignment would spread out the nKlass value points more. Shift the nKlass-value-point-to-class ratio closer to 1:1.

The still unsolved problem is naive overalignment. We may change the encoding scheme of Klass*->nKlass to take that into account. But not in this patch. But this uncertainty is the reason why I opted for a new method `MetaspaceArena::allocate_for_klass` instead of just giving the existing `Metaspace::allocate` method an alignment parameter.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8307002](https://bugs.openjdk.org/browse/JDK-8307002): [Lilliput] [Metaspace] Make use of Klass alignment gaps


### Reviewers
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**) ⚠️ Review applies to [3338fb0e](https://git.openjdk.org/lilliput/pull/86/files/3338fb0e71d27c8fd5586f86225945f8b9a36d6f)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput.git pull/86/head:pull/86` \
`$ git checkout pull/86`

Update a local copy of the PR: \
`$ git checkout pull/86` \
`$ git pull https://git.openjdk.org/lilliput.git pull/86/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 86`

View PR using the GUI difftool: \
`$ git pr show -t 86`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput/pull/86.diff">https://git.openjdk.org/lilliput/pull/86.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput/pull/86#issuecomment-1525925791)