### PR TITLE
8307392: [Lilliput] Revert deflation of dead object's monitors

### DIFF
--- a/src/hotspot/share/gc/shared/oopStorage.inline.hpp
+++ b/src/hotspot/share/gc/shared/oopStorage.inline.hpp
@@ -29,7 +29,6 @@
 
 #include "memory/allocation.hpp"
 #include "oops/oop.hpp"
-#include "runtime/objectMonitor.hpp"
 #include "runtime/safepoint.hpp"
 #include "utilities/align.hpp"
 #include "utilities/count_trailing_zeros.hpp"
@@ -263,7 +262,6 @@ public:
       if (_is_alive->do_object_b(v)) {
         result = _f(ptr);
       } else {
-        ObjectMonitor::maybe_deflate_dead(ptr);
         *ptr = nullptr;            // Clear dead value.
       }
     }

--- a/src/hotspot/share/gc/shared/weakProcessor.inline.hpp
+++ b/src/hotspot/share/gc/shared/weakProcessor.inline.hpp
@@ -65,7 +65,6 @@ public:
       _keep_alive->do_oop(p);
       ++_live;
     } else {
-      ObjectMonitor::maybe_deflate_dead(p);
       *p = nullptr;
       ++_new_dead;
     }

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -771,6 +771,7 @@ public:
   void work(uint worker_id) {
     ShenandoahConcurrentWorkerSession worker_session(worker_id);
     {
+      ShenandoahSuspendibleThreadSetJoiner sts_join;
       ShenandoahEvacOOMScope oom;
       // jni_roots and weak_roots are OopStorage backed roots, concurrent iteration
       // may race against OopStorage::release() calls.

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -771,7 +771,6 @@ public:
   void work(uint worker_id) {
     ShenandoahConcurrentWorkerSession worker_session(worker_id);
     {
-      ShenandoahSuspendibleThreadSetJoiner sts_join;
       ShenandoahEvacOOMScope oom;
       // jni_roots and weak_roots are OopStorage backed roots, concurrent iteration
       // may race against OopStorage::release() calls.

--- a/src/hotspot/share/runtime/objectMonitor.cpp
+++ b/src/hotspot/share/runtime/objectMonitor.cpp
@@ -600,22 +600,6 @@ bool ObjectMonitor::deflate_monitor() {
   return true;  // Success, ObjectMonitor has been deflated.
 }
 
-// We might access the dead object headers for parsable heap walk, make sure
-// headers are in correct shape, e.g. monitors deflated.
-void ObjectMonitor::maybe_deflate_dead(oop* p) {
-  oop obj = *p;
-  assert(obj != NULL, "must not yet been cleared");
-  markWord mark = obj->mark();
-  if (mark.has_monitor()) {
-    ObjectMonitor* monitor = mark.monitor();
-    if (p == monitor->_object.ptr_raw()) {
-      assert(monitor->object_peek() == obj, "lock object must match");
-      markWord dmw = monitor->header();
-      obj->set_mark(dmw);
-    }
-  }
-}
-
 // Install the displaced mark word (dmw) of a deflating ObjectMonitor
 // into the header of the object associated with the monitor. This
 // idempotent method is called by a thread that is deflating a

--- a/src/hotspot/share/runtime/objectMonitor.hpp
+++ b/src/hotspot/share/runtime/objectMonitor.hpp
@@ -343,8 +343,6 @@ class ObjectMonitor : public CHeapObj<mtObjectMonitor> {
   // Use the following at your own risk
   intx      complete_exit(JavaThread* current);
 
-  static void maybe_deflate_dead(oop* p);
-
  private:
   void      AddWaiter(ObjectWaiter* waiter);
   void      INotify(JavaThread* current);


### PR DESCRIPTION
In https://github.com/openjdk/lilliput/pull/28, I introduced some code that forces deflation of monitors on objects that are about to die. Discussions around a possible upstreaming of this code (https://github.com/openjdk/jdk/pull/13721) comes to the conclusion that this should not be necessary, and indeed, I could not reproduce the original problem that I was having in Lilliput with the code removed. I assume some changes in upstream and/or Lilliput since then have fixed the root cause. Let's remove that code and see what explodes.

Testing: (All with -XX:+UseHeavyMonitors to amplify monitor traffic)
 - [x] hotspot_gc
 - [x] tier1
 - [x] tier2
 - [x] SPECjvm workloads

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8307392](https://bugs.openjdk.org/browse/JDK-8307392): [Lilliput] Revert deflation of dead object's monitors


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput.git pull/88/head:pull/88` \
`$ git checkout pull/88`

Update a local copy of the PR: \
`$ git checkout pull/88` \
`$ git pull https://git.openjdk.org/lilliput.git pull/88/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 88`

View PR using the GUI difftool: \
`$ git pr show -t 88`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput/pull/88.diff">https://git.openjdk.org/lilliput/pull/88.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput/pull/88#issuecomment-1533619413)