### PR TITLE
8307394: [Lilliput] Cleanup GC code

### DIFF
--- a/src/hotspot/share/gc/parallel/psPromotionManager.hpp
+++ b/src/hotspot/share/gc/parallel/psPromotionManager.hpp
@@ -105,7 +105,7 @@ class PSPromotionManager {
 
   void push_depth(ScannerTask task);
 
-  inline void promotion_trace_event(oop new_obj, oop old_obj, Klass* klass, size_t obj_size,
+  inline void promotion_trace_event(oop new_obj, oop old_obj, size_t obj_size,
                                     uint age, bool tenured,
                                     const PSPromotionLAB* lab);
 

--- a/src/hotspot/share/gc/serial/defNewGeneration.cpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.cpp
@@ -891,21 +891,7 @@ void DefNewGeneration::remove_forwarding_pointers() {
   struct ResetForwardedMarkWord : ObjectClosure {
     void do_object(oop obj) override {
       if (obj->is_forwarded()) {
-#ifdef _LP64
-        if (UseCompactObjectHeaders) {
-          oop forwardee = obj->forwardee();
-          markWord header = forwardee->mark();
-          if (header.has_displaced_mark_helper()) {
-            header = header.displaced_mark_helper();
-          }
-          assert(UseCompressedClassPointers, "assume +UseCompressedClassPointers");
-          narrowKlass nklass = header.narrow_klass();
-          obj->set_mark(markWord::prototype().set_narrow_klass(nklass));
-        } else
-#endif
-        {
-          obj->init_mark();
-        }
+        obj->safe_init_mark();
       }
     }
   } cl;

--- a/src/hotspot/share/gc/serial/markSweep.cpp
+++ b/src/hotspot/share/gc/serial/markSweep.cpp
@@ -180,17 +180,10 @@ void MarkSweep::mark_object(oop obj) {
   markWord mark = obj->mark();
 #ifdef _LP64
   if (UseCompactObjectHeaders) {
-    markWord real_mark = mark;
-    if (real_mark.has_displaced_mark_helper()) {
-      real_mark = real_mark.displaced_mark_helper();
-    }
-    Klass* klass = real_mark.klass();
-    obj->set_mark(klass->prototype_header().set_marked());
+    obj->set_mark(obj->klass()->prototype_header().set_marked());
   } else
 #endif
-  {
-    obj->set_mark(markWord::prototype().set_marked());
-  }
+  obj->set_mark(markWord::prototype().set_marked());
 
   if (obj->mark_must_be_preserved(mark)) {
     preserve_mark(obj, mark);

--- a/src/hotspot/share/oops/oop.hpp
+++ b/src/hotspot/share/oops/oop.hpp
@@ -72,6 +72,16 @@ class oopDesc {
   inline markWord  mark_acquire()  const;
   inline markWord* mark_addr() const;
 
+  // Fetches the mark-word. If the object is locked
+  // by a monitor, then the mark-word will be fetched
+  // from the monitor.
+  inline markWord resolve_mark() const;
+
+  // Safely fetches the mark-word (when using compact headers):
+  // - When object is forwarded, then fetch mark-word from forwardee.
+  // - When object is locked by monitor, fetch mark-word from monitor.
+  inline markWord safe_mark() const;
+
   inline void set_mark(markWord m);
   static inline void set_mark(HeapWord* mem, markWord m);
 
@@ -80,17 +90,21 @@ class oopDesc {
   inline markWord cas_set_mark(markWord new_mark, markWord old_mark);
   inline markWord cas_set_mark(markWord new_mark, markWord old_mark, atomic_memory_order order);
 
-  inline markWord resolve_mark() const;
-
   // Used only to re-initialize the mark word (e.g., of promoted
   // objects during a GC) -- requires a valid klass pointer
   inline void init_mark();
+  inline void safe_init_mark();
 
   inline Klass* klass() const;
   inline Klass* klass_or_null() const;
   inline Klass* klass_or_null_acquire() const;
   // Get the raw value without any checks.
   inline Klass* klass_raw() const;
+
+  // Safely fetches the Klass* (when using compact headers):
+  // - When object is forwarded, then fetch Klass* from forwardee.
+  // - When object is locked by monitor, fetch Klass* from monitor.
+  inline Klass* safe_klass() const;
 
   void set_narrow_klass(narrowKlass nk) NOT_CDS_JAVA_HEAP_RETURN;
   inline void set_klass(Klass* k);
@@ -114,6 +128,8 @@ class oopDesc {
 
   // Returns the actual oop size of the object in machine words
   inline size_t size();
+
+  inline size_t safe_size();
 
   // Sometimes (for complicated concurrency-related reasons), it is useful
   // to be able to figure out the size of an object knowing its klass.

--- a/src/hotspot/share/oops/oop.inline.hpp
+++ b/src/hotspot/share/oops/oop.inline.hpp
@@ -182,9 +182,12 @@ Klass* oopDesc::klass_raw() const {
 }
 
 Klass* oopDesc::safe_klass() const {
+#ifdef _LP64
   if (UseCompactObjectHeaders) {
     return safe_mark().klass();
-  } else {
+  } else
+#endif
+  {
     return klass();
   }
 }


### PR DESCRIPTION
GC code has collected some cruft over the months. Let's clean it up and reduce the diff vs upstream.

Testing:
- [ ] tier1
- [ ] tier2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8307394](https://bugs.openjdk.org/browse/JDK-8307394): [Lilliput] Cleanup GC code (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput.git pull/89/head:pull/89` \
`$ git checkout pull/89`

Update a local copy of the PR: \
`$ git checkout pull/89` \
`$ git pull https://git.openjdk.org/lilliput.git pull/89/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 89`

View PR using the GUI difftool: \
`$ git pr show -t 89`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput/pull/89.diff">https://git.openjdk.org/lilliput/pull/89.diff</a>

</details>
