### PR TITLE
Print Klass address in VM.metaspace show-classes

### DIFF
--- a/src/hotspot/share/memory/metaspace/printMetaspaceInfoKlassClosure.cpp
+++ b/src/hotspot/share/memory/metaspace/printMetaspaceInfoKlassClosure.cpp
@@ -40,6 +40,8 @@ void PrintMetaspaceInfoKlassClosure::do_klass(Klass* k) {
   _out->cr_indent();
   _out->print(UINTX_FORMAT_W(4) ": ", _cnt);
 
+  _out->print("Klass @" PTR_FORMAT " ", p2i(k));
+
   // Print a 's' for shared classes
   _out->put(k->is_shared() ? 's': ' ');
 


### PR DESCRIPTION
Trivial change to print out Klass address (similar to we already print CLD address) in jcmd VM.metaspace.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput.git pull/91/head:pull/91` \
`$ git checkout pull/91`

Update a local copy of the PR: \
`$ git checkout pull/91` \
`$ git pull https://git.openjdk.org/lilliput.git pull/91/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 91`

View PR using the GUI difftool: \
`$ git pr show -t 91`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput/pull/91.diff">https://git.openjdk.org/lilliput/pull/91.diff</a>

</details>
