### PR TITLE
JDK-8307737: [Lilliput] Reduce number of loads used for Klass decoding in static code

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -4590,7 +4590,6 @@ MacroAssembler::KlassDecodeMode MacroAssembler::klass_decode_mode() {
 // Given an arbitrary base address, return the KlassDecodeMode that would be used. Return KlassDecodeNone
 // if base address is not valid for encoding.
 MacroAssembler::KlassDecodeMode MacroAssembler::klass_decode_mode_for_base(address base) {
-  assert(CompressedKlassPointers::shift() != 0, "not lilliput?");
 
   const uint64_t base_u64 = (uint64_t) base;
 
@@ -4603,7 +4602,7 @@ MacroAssembler::KlassDecodeMode MacroAssembler::klass_decode_mode_for_base(addre
     return KlassDecodeXor;
   }
 
-  const uint64_t shifted_base = base_u64 >> CompressedKlassPointers::shift();
+  const uint64_t shifted_base = base_u64 >> LogKlassAlignmentInBytes;
   if ((shifted_base & 0xffff0000ffffffff) == 0) {
     return KlassDecodeMovk;
   }

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -5456,7 +5456,6 @@ MacroAssembler::KlassDecodeMode MacroAssembler::klass_decode_mode() {
 // Given an arbitrary base address, return the KlassDecodeMode that would be used. Return KlassDecodeNone
 // if base address is not valid for encoding.
 MacroAssembler::KlassDecodeMode MacroAssembler::klass_decode_mode_for_base(address base) {
-  assert(CompressedKlassPointers::shift() != 0, "not lilliput?");
 
   const uint64_t base_u64 = (uint64_t) base;
 

--- a/src/hotspot/share/memory/metaspace.cpp
+++ b/src/hotspot/share/memory/metaspace.cpp
@@ -829,7 +829,6 @@ void Metaspace::global_initialize() {
 
     // Set up compressed class pointer encoding.
     CompressedKlassPointers::initialize((address)rs.base(), rs.size());
-
   }
 
 #endif

--- a/src/hotspot/share/memory/metaspace.cpp
+++ b/src/hotspot/share/memory/metaspace.cpp
@@ -829,6 +829,7 @@ void Metaspace::global_initialize() {
 
     // Set up compressed class pointer encoding.
     CompressedKlassPointers::initialize((address)rs.base(), rs.size());
+
   }
 
 #endif

--- a/src/hotspot/share/oops/compressedKlass.cpp
+++ b/src/hotspot/share/oops/compressedKlass.cpp
@@ -97,6 +97,7 @@ void CompressedKlassPointers::initialize(address addr, size_t len) {
 
   assert(LogKlassAlignmentInBytes < (1 << encodingShiftWidth), "Shift too large");
   assert((((uintptr_t)thebase) & ~baseAddressMask) == 0, "Base address " PTR_FORMAT " unaligned", p2i(thebase));
+
   _value = (UseCompactObjectHeaders ? ((uintptr_t)1 << useCompactObjectHeadersShift) : 0) |
            (UseCompressedClassPointers ? ((uintptr_t)1 << useCompressedClassPointersShift) : 0) |
            ((uintptr_t)LogKlassAlignmentInBytes << encodingShiftShift) |

--- a/src/hotspot/share/oops/compressedKlass.cpp
+++ b/src/hotspot/share/oops/compressedKlass.cpp
@@ -31,7 +31,7 @@
 #include "utilities/debug.hpp"
 #include "runtime/globals.hpp"
 
-uintptr_t CompressedKlassPointers::_value = 0;
+uintptr_t CompressedKlassPointers::_config = 0;
 address CompressedKlassPointers::_base_copy = nullptr;
 int CompressedKlassPointers::_shift_copy = 0;
 
@@ -98,7 +98,7 @@ void CompressedKlassPointers::initialize(address addr, size_t len) {
   assert(LogKlassAlignmentInBytes < (1 << encodingShiftWidth), "Shift too large");
   assert((((uintptr_t)thebase) & ~baseAddressMask) == 0, "Base address " PTR_FORMAT " unaligned", p2i(thebase));
 
-  _value = (UseCompactObjectHeaders ? ((uintptr_t)1 << useCompactObjectHeadersShift) : 0) |
+  _config = (UseCompactObjectHeaders ? ((uintptr_t)1 << useCompactObjectHeadersShift) : 0) |
            (UseCompressedClassPointers ? ((uintptr_t)1 << useCompressedClassPointersShift) : 0) |
            ((uintptr_t)LogKlassAlignmentInBytes << encodingShiftShift) |
            ((uintptr_t)thebase & baseAddressMask);

--- a/src/hotspot/share/oops/compressedKlass.cpp
+++ b/src/hotspot/share/oops/compressedKlass.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2021 SAP SE. All rights reserved.
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023 Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -25,12 +26,13 @@
  */
 
 #include "precompiled.hpp"
-#include "oops/compressedKlass.hpp"
+#include "oops/compressedKlass.inline.hpp"
 #include "utilities/ostream.hpp"
 #include "utilities/debug.hpp"
 #include "runtime/globals.hpp"
 
-address CompressedKlassPointers::_base = nullptr;
+uintptr_t CompressedKlassPointers::_value = 0;
+address CompressedKlassPointers::_base_copy = nullptr;
 int CompressedKlassPointers::_shift_copy = 0;
 
 #ifdef _LP64
@@ -54,6 +56,8 @@ void CompressedKlassPointers::initialize(address addr, size_t len) {
   assert(len <= (size_t)KlassEncodingMetaspaceMax, "Range " SIZE_FORMAT " too large "
          "- cannot be contained fully in narrow Klass pointer encoding range.", len);
 
+  address thebase = nullptr;
+
   if (UseSharedSpaces || DumpSharedSpaces) {
 
     // Special requirements if CDS is active:
@@ -71,24 +75,37 @@ void CompressedKlassPointers::initialize(address addr, size_t len) {
     //  encoding. We also set the expected value range to 4G (encoding range
     //  cannot be larger than that).
 
-    _base = addr;
+    thebase = addr;
 
   } else {
 
     // (Note that this case is almost not worth optimizing for. CDS is typically on.)
     if ((addr + len) <= (address)KlassEncodingMetaspaceMax) {
-      _base = 0;
+      thebase = nullptr;
     } else {
-      _base = addr;
+      thebase = addr;
     }
   }
 
-  assert(is_valid_base(_base), "Address " PTR_FORMAT " was chosen as encoding base for range ["
-                               PTR_FORMAT ", " PTR_FORMAT ") but is not a valid encoding base",
-                               p2i(_base), p2i(addr), p2i(addr + len));
+  assert(is_valid_base(thebase), "Address " PTR_FORMAT " was chosen as encoding base for range ["
+                              PTR_FORMAT ", " PTR_FORMAT ") but is not a valid encoding base",
+                              p2i(thebase), p2i(addr), p2i(addr + len));
 
   // For SA
+  _base_copy = thebase;
   _shift_copy = LogKlassAlignmentInBytes;
+
+  assert(LogKlassAlignmentInBytes < (1 << encodingShiftWidth), "Shift too large");
+  assert((((uintptr_t)thebase) & ~baseAddressMask) == 0, "Base address " PTR_FORMAT " unaligned", p2i(thebase));
+  _value = (UseCompactObjectHeaders ? ((uintptr_t)1 << useCompactObjectHeadersShift) : 0) |
+           (UseCompressedClassPointers ? ((uintptr_t)1 << useCompressedClassPointersShift) : 0) |
+           ((uintptr_t)LogKlassAlignmentInBytes << encodingShiftShift) |
+           ((uintptr_t)thebase & baseAddressMask);
+
+  assert(use_compact_object_headers() == UseCompactObjectHeaders, "Sanity");
+  assert(use_compressed_class_pointers() == UseCompressedClassPointers, "Sanity");
+  assert(shift() == LogKlassAlignmentInBytes, "Sanity");
+  assert(base() == thebase, "Sanity");
 
 #else
   ShouldNotReachHere(); // 64-bit only
@@ -119,4 +136,3 @@ bool CompressedKlassPointers::is_valid_base(address p) {
   return false;
 }
 #endif
-

--- a/src/hotspot/share/oops/compressedKlass.hpp
+++ b/src/hotspot/share/oops/compressedKlass.hpp
@@ -74,7 +74,7 @@ class CompressedKlassPointers : public AllStatic {
   // base will always be page aligned, so we have a 12-bit alignment shadow to store the rest
   // of the data.
 
-  static uintptr_t _value;
+  static uintptr_t _config;
   static constexpr int useCompactObjectHeadersShift = 0;
   static constexpr int useCompressedClassPointersShift = 1;
   static constexpr int encodingShiftShift = 2;
@@ -119,7 +119,7 @@ public:
   // The encoding base. Note: this is not necessarily the base address of the
   // class space nor the base address of the CDS archive.
   static inline address base() {
-    return (address)(_value & baseAddressMask);
+    return (address)(_config & baseAddressMask);
   }
 
   // End of the encoding range.
@@ -129,11 +129,11 @@ public:
 
   // Shift == LogKlassAlignmentInBytes (TODO: unify)
   static inline int shift() {
-    return (_value >> encodingShiftShift) & right_n_bits(encodingShiftWidth);
+    return (_config >> encodingShiftShift) & right_n_bits(encodingShiftWidth);
   }
 
-  static inline bool use_compact_object_headers()    { return (_value >> useCompactObjectHeadersShift) & 1; }
-  static inline bool use_compressed_class_pointers() { return (_value >> useCompressedClassPointersShift) & 1; }
+  static inline bool use_compact_object_headers()    { return (_config >> useCompactObjectHeadersShift) & 1; }
+  static inline bool use_compressed_class_pointers() { return (_config >> useCompressedClassPointersShift) & 1; }
 
   static bool is_null(Klass* v)      { return v == nullptr; }
   static bool is_null(narrowKlass v) { return v == 0; }

--- a/src/hotspot/share/oops/compressedKlass.hpp
+++ b/src/hotspot/share/oops/compressedKlass.hpp
@@ -66,11 +66,29 @@ class CompressedKlassPointers : public AllStatic {
   friend class VMStructs;
   friend class ArchiveBuilder;
 
-  // Encoding base
-  static address _base;
+  // A dense representation of values one often loads in quick succession, in order to fold
+  // all of them into a single load:
+  // - UseCompactObjectHeaders and UseCompressedClassPointers flags
+  // - encoding base and encoding shift
+  // We can encode everything (including the encoding base) in a 64-bit word. The encoding
+  // base will always be page aligned, so we have a 12-bit alignment shadow to store the rest
+  // of the data.
 
-  // Shift is actually a constant; we keep this just for the SA (see vmStructs.cpp and
+  static uintptr_t _value;
+  static constexpr int useCompactObjectHeadersShift = 0;
+  static constexpr int useCompressedClassPointersShift = 1;
+  static constexpr int encodingShiftShift = 2;
+  static constexpr int encodingShiftWidth = 5;
+  static constexpr int baseAddressMask = ~right_n_bits(12);
+
+  static void set_encoding_base(address base);
+  static void set_encoding_shift(int shift);
+  static void set_use_compact_headers(bool b);
+  static void set_use_compressed_class_pointers(bool b);
+
+  // These members hold copies of encoding base and shift and only exist for SA (see vmStructs.cpp and
   // sun/jvm/hotspot/oops/CompressedKlassPointers.java)
+  static address _base_copy;
   static int _shift_copy;
 
   // The decode/encode versions taking an explicit base are for the sole use of CDS
@@ -96,17 +114,26 @@ public:
   //  structures outside this range).
   static void initialize(address addr, size_t len);
 
-  static void     print_mode(outputStream* st);
+  static void print_mode(outputStream* st);
 
   // The encoding base. Note: this is not necessarily the base address of the
   // class space nor the base address of the CDS archive.
-  static address  base()             { return  _base; }
+  static inline address base() {
+    return (address)(_value & baseAddressMask);
+  }
 
   // End of the encoding range.
-  static address  end()              { return base() + KlassEncodingMetaspaceMax; }
+  static inline address  end() {
+    return base() + KlassEncodingMetaspaceMax;
+  }
 
   // Shift == LogKlassAlignmentInBytes (TODO: unify)
-  static int      shift()            { return  LogKlassAlignmentInBytes; }
+  static inline int shift() {
+    return (_value >> encodingShiftShift) & right_n_bits(encodingShiftWidth);
+  }
+
+  static inline bool use_compact_object_headers()    { return (_value >> useCompactObjectHeadersShift) & 1; }
+  static inline bool use_compressed_class_pointers() { return (_value >> useCompressedClassPointersShift) & 1; }
 
   static bool is_null(Klass* v)      { return v == nullptr; }
   static bool is_null(narrowKlass v) { return v == 0; }

--- a/src/hotspot/share/oops/oop.inline.hpp
+++ b/src/hotspot/share/oops/oop.inline.hpp
@@ -100,7 +100,7 @@ void oopDesc::init_mark() {
 #ifdef _LP64
   if (UseCompactObjectHeaders) {
     markWord header = resolve_mark();
-    assert(UseCompressedClassPointers, "expect compressed klass pointers");
+    assert(CompressedKlassPointers::use_compressed_class_pointers(), "expect compressed klass pointers");
     set_mark(markWord((header.value() & markWord::klass_mask_in_place) | markWord::prototype().value()));
   } else
 #endif
@@ -109,11 +109,11 @@ void oopDesc::init_mark() {
 
 Klass* oopDesc::klass() const {
 #ifdef _LP64
-  if (UseCompactObjectHeaders) {
-    assert(UseCompressedClassPointers, "only with compressed class pointers");
+  if (CompressedKlassPointers::use_compact_object_headers()) {
+    assert(CompressedKlassPointers::use_compressed_class_pointers(), "only with compressed class pointers");
     markWord header = resolve_mark();
     return header.klass();
-  } else if (UseCompressedClassPointers) {
+  } else if (CompressedKlassPointers::use_compressed_class_pointers()) {
     return CompressedKlassPointers::decode_not_null(_metadata._compressed_klass);
   } else
 #endif
@@ -122,11 +122,11 @@ Klass* oopDesc::klass() const {
 
 Klass* oopDesc::klass_or_null() const {
 #ifdef _LP64
-  if (UseCompactObjectHeaders) {
-    assert(UseCompressedClassPointers, "only with compressed class pointers");
+  if (CompressedKlassPointers::use_compact_object_headers()) {
+    assert(CompressedKlassPointers::use_compressed_class_pointers(), "only with compressed class pointers");
     markWord header = resolve_mark();
     return header.klass_or_null();
-  } else if (UseCompressedClassPointers) {
+  } else if (CompressedKlassPointers::use_compressed_class_pointers()) {
     return CompressedKlassPointers::decode(_metadata._compressed_klass);
   } else
 #endif
@@ -135,14 +135,14 @@ Klass* oopDesc::klass_or_null() const {
 
 Klass* oopDesc::klass_or_null_acquire() const {
 #ifdef _LP64
-  if (UseCompactObjectHeaders) {
-    assert(UseCompressedClassPointers, "only with compressed class pointers");
+  if (CompressedKlassPointers::use_compact_object_headers()) {
+    assert(CompressedKlassPointers::use_compressed_class_pointers(), "only with compressed class pointers");
     markWord header = mark_acquire();
     if (header.has_monitor()) {
       header = header.monitor()->header();
     }
     return header.klass_or_null();
-  } else if (UseCompressedClassPointers) {
+  } else if (CompressedKlassPointers::use_compressed_class_pointers()) {
      narrowKlass nklass = Atomic::load_acquire(&_metadata._compressed_klass);
      return CompressedKlassPointers::decode(nklass);
   } else
@@ -157,7 +157,7 @@ Klass* oopDesc::klass_raw() const {
 void oopDesc::set_klass(Klass* k) {
   assert(Universe::is_bootstrapping() || (k != NULL && k->is_klass()), "incorrect Klass");
   assert(!UseCompactObjectHeaders, "don't set Klass* with compact headers");
-  if (UseCompressedClassPointers) {
+  if (CompressedKlassPointers::use_compressed_class_pointers()) {
     _metadata._compressed_klass = CompressedKlassPointers::encode_not_null(k);
   } else {
     _metadata._klass = k;
@@ -168,7 +168,7 @@ void oopDesc::release_set_klass(HeapWord* mem, Klass* k) {
   assert(Universe::is_bootstrapping() || (k != NULL && k->is_klass()), "incorrect Klass");
   assert(!UseCompactObjectHeaders, "don't set Klass* with compact headers");
   char* raw_mem = ((char*)mem + klass_offset_in_bytes());
-  if (UseCompressedClassPointers) {
+  if (CompressedKlassPointers::use_compressed_class_pointers()) {
     Atomic::release_store((narrowKlass*)raw_mem,
                           CompressedKlassPointers::encode_not_null(k));
   } else {
@@ -178,7 +178,7 @@ void oopDesc::release_set_klass(HeapWord* mem, Klass* k) {
 
 void oopDesc::set_klass_gap(HeapWord* mem, int v) {
   assert(!UseCompactObjectHeaders, "don't set Klass* gap with compact headers");
-  if (UseCompressedClassPointers) {
+  if (CompressedKlassPointers::use_compressed_class_pointers()) {
     *(int*)(((char*)mem) + klass_gap_offset_in_bytes()) = v;
   }
 }

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -378,7 +378,7 @@
   /* CompressedKlassPointers */                                                                                                      \
   /***************************/                                                                                                      \
                                                                                                                                      \
-     static_field(CompressedKlassPointers,     _base,                           address)                                             \
+     static_field(CompressedKlassPointers,     _base_copy,                           address)                                        \
      static_field(CompressedKlassPointers,     _shift_copy,                          int)                                            \
                                                                                                                                      \
   /**********/                                                                                                                       \

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/CompressedKlassPointers.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/CompressedKlassPointers.java
@@ -58,7 +58,7 @@ public class CompressedKlassPointers {
   private static synchronized void initialize(TypeDataBase db) {
     Type type = db.lookupType("CompressedKlassPointers");
 
-    baseField = type.getAddressField("_base");
+    baseField = type.getAddressField("_base_copy");
     shiftField = type.getCIntegerField("_shift_copy");
   }
 


### PR DESCRIPTION
Klass decode depends on several runtime parameters. In 64-bit header mode, these are:

- UseCompactObjectHeaders
- Encoding Base
- Encoding Shift

In Legacy header mode, these are:

- UseCompactObjectHeaders
- UseCompressedClassPointers
- Encoding Base
- Encoding Shift

These values are stored at distinct locations and require three resp. four loads (see disassmbly [1]). Unfortunately, Legacy mode is more expensive with Lilliput, since we now need to load two switches.

I want to minimize the number of loads. There are several ways to do this, but the most simple would be to use a denser representation in memory of these values. We always load them together anyway.

All four values (UseCompactObjectHeaders, UseCompressedClassPointers, Encoding Base+Shift) can be coded into a single 64-bit value. The encoding base will always be page-aligned. That leaves us an alignment shadow of 12 bits to hide all the rest of the information. UseCompactObjectHeaders and UseCompressedClassPointers can be represented by single bits. The encoding shift will not be larger than 31, so we can store the shift in 5 bits.

The result is that the three resp. four loads can be folded into a single 64-bit load without too much trouble.

Alternatives. 

- Generating a stub routine is not an option if one wants to keep decoding inlined
- We could generate different variants of the decoding routines via template, parametrized for each permutation of (shift, UseCompressedClassPointers, UseCompactObjectHeaders) and the most common encoding base. But: 
	- we would need a different solution for uncommon base addresses
	- we may want to make shift an adjustable runtime parameter
	- we would need to decide, at runtime, which code variant to use - again, introduces a runtime switch we need to load from memory - nothing gained compared to the proposed solution.

----------------

The patch changes the way the static helper class `CompressedKlassPointers` stores encoding base and shift to a denser format. The format also contains copies of UseCompressedClassPointers and UseCompactObjectHeaders:

```
Bit#
0:	UseCompactObjectHeaders
1:	UseCompressedClassPointers
2-6:	Encoding shift (5 bits)
7-11:   Unused
12-63:  Encoding Base address
```

Patch then changes some frequently used oop methods to use the dense representation of UseCompactObjectHeaders/UseCompressedClassPointers.

The result: we now only need one load for Klass decoding/encoding (see disassembly [2]).

-----------------------

[1] https://bugs.openjdk.org/secure/attachment/103772/KlassExtraction.txt
[2] https://bugs.openjdk.org/secure/attachment/103773/KlassExtraction-patched.txt

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8307737](https://bugs.openjdk.org/browse/JDK-8307737): [Lilliput] Reduce number of loads used for Klass decoding in static code


### Reviewers
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput.git pull/92/head:pull/92` \
`$ git checkout pull/92`

Update a local copy of the PR: \
`$ git checkout pull/92` \
`$ git pull https://git.openjdk.org/lilliput.git pull/92/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 92`

View PR using the GUI difftool: \
`$ git pr show -t 92`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput/pull/92.diff">https://git.openjdk.org/lilliput/pull/92.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput/pull/92#issuecomment-1540173467)