### PR TITLE
8307991: [Lilliput] Use narrow i-hash only when +UseCompactObjectHeaders

### DIFF
--- a/src/hotspot/cpu/x86/sharedRuntime_x86.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86.cpp
@@ -68,8 +68,13 @@ void SharedRuntime::inline_check_hashcode_from_object_header(MacroAssembler* mas
   // Read the header and build a mask to get its hash field.
   // Depend on hash_mask being at most 32 bits and avoid the use of hash_mask_in_place
   // because it could be larger than 32 bits in a 64-bit vm. See markWord.hpp.
-  __ shrptr(result, markWord::hash_shift);
-  __ andptr(result, markWord::hash_mask);
+  if (UseCompactObjectHeaders) {
+    __ shrptr(result, markWord::hash_shift_compact);
+    __ andptr(result, markWord::hash_mask_compact);
+  } else {
+    __ shrptr(result, markWord::hash_shift);
+    __ andptr(result, markWord::hash_mask);
+  }
 #else
   __ andptr(result, markWord::hash_mask_in_place);
 #endif //_LP64

--- a/src/hotspot/share/oops/markWord.hpp
+++ b/src/hotspot/share/oops/markWord.hpp
@@ -41,7 +41,11 @@
 //
 //  64 bits:
 //  --------
-//  nklass:32 hash:25 -->| unused_gap:1  age:4  unused_gap:1  lock:2 (normal object)
+//  unused:25 hash:31 -->| unused_gap:1  age:4  unused_gap:1  lock:2 (normal object)
+//
+//  64 bits (with compact headers):
+//  -------------------------------
+//  nklass:32 hash:25 -->| unused_gap:1  age:4  self-fwded:1  lock:2 (normal object)
 //
 //  - hash contains the identity hash value: largest value is
 //    31 bits, see os::random().  Also, 64-bit vm's require
@@ -104,8 +108,12 @@ class markWord {
   static const int lock_bits                      = 2;
   static const int self_forwarded_bits            = 1;
   static const int max_hash_bits                  = BitsPerWord - age_bits - lock_bits - self_forwarded_bits;
-  static const int hash_bits                      = max_hash_bits > 25 ? 25 : max_hash_bits;
+  static const int hash_bits                      = max_hash_bits > 31 ? 31 : max_hash_bits;
+  static const int hash_bits_compact              = max_hash_bits > 25 ? 25 : max_hash_bits;
+  // Used only without compact headers.
+  static const int unused_gap_bits                = LP64_ONLY(1) NOT_LP64(0);
 #ifdef _LP64
+  // Used only with compact headers.
   static const int klass_bits                     = 32;
 #endif
 
@@ -113,8 +121,10 @@ class markWord {
   static const int self_forwarded_shift           = lock_shift + lock_bits;
   static const int age_shift                      = self_forwarded_shift + self_forwarded_bits;
   static const int hash_shift                     = age_shift + age_bits;
+  static const int hash_shift_compact             = age_shift + age_bits;
 #ifdef _LP64
-  static const int klass_shift                    = hash_shift + hash_bits;
+  // Used only with compact headers.
+  static const int klass_shift                    = hash_shift_compact + hash_bits_compact;
 #endif
 
   static const uintptr_t lock_mask                = right_n_bits(lock_bits);
@@ -125,7 +135,8 @@ class markWord {
   static const uintptr_t age_mask_in_place        = age_mask << age_shift;
   static const uintptr_t hash_mask                = right_n_bits(hash_bits);
   static const uintptr_t hash_mask_in_place       = hash_mask << hash_shift;
-
+  static const uintptr_t hash_mask_compact        = right_n_bits(hash_bits_compact);
+  static const uintptr_t hash_mask_in_place_compact = hash_mask_compact << hash_shift_compact;
 #ifdef _LP64
   static const uintptr_t klass_mask               = right_n_bits(klass_bits);
   static const uintptr_t klass_mask_in_place      = klass_mask << klass_shift;
@@ -213,9 +224,15 @@ class markWord {
   markWord displaced_mark_helper() const;
   void set_displaced_mark_helper(markWord m) const;
   markWord copy_set_hash(intptr_t hash) const {
-    uintptr_t tmp = value() & (~hash_mask_in_place);
-    tmp |= ((hash & hash_mask) << hash_shift);
-    return markWord(tmp);
+    if (UseCompactObjectHeaders) {
+      uintptr_t tmp = value() & (~hash_mask_in_place_compact);
+      tmp |= ((hash & hash_mask_compact) << hash_shift_compact);
+      return markWord(tmp);
+    } else {
+      uintptr_t tmp = value() & (~hash_mask_in_place);
+      tmp |= ((hash & hash_mask) << hash_shift);
+      return markWord(tmp);
+    }
   }
   // it is only used to be stored into BasicLock as the
   // indicator that the lock is using heavyweight monitor
@@ -248,7 +265,11 @@ class markWord {
 
   // hash operations
   intptr_t hash() const {
-    return mask_bits(value() >> hash_shift, hash_mask);
+    if (UseCompactObjectHeaders) {
+      return mask_bits(value() >> hash_shift_compact, hash_mask_compact);
+    } else {
+      return mask_bits(value() >> hash_shift, hash_mask);
+    }
   }
 
   bool has_no_hash() const {

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -4404,8 +4404,8 @@ bool LibraryCallKit::inline_native_hashcode(bool is_virtual, bool is_static) {
   // We depend on hash_mask being at most 32 bits and avoid the use of
   // hash_mask_in_place because it could be larger than 32 bits in a 64-bit
   // vm: see markWord.hpp.
-  Node *hash_mask      = _gvn.intcon(markWord::hash_mask);
-  Node *hash_shift     = _gvn.intcon(markWord::hash_shift);
+  Node *hash_mask      = _gvn.intcon(UseCompactObjectHeaders ? markWord::hash_mask_compact  : markWord::hash_mask);
+  Node *hash_shift     = _gvn.intcon(UseCompactObjectHeaders ? markWord::hash_shift_compact : markWord::hash_shift);
   Node *hshifted_header= _gvn.transform(new URShiftXNode(header, hash_shift));
   // This hack lets the hash bits live anywhere in the mark object now, as long
   // as the shift drops the relevant bits into the low 32 bits.  Note that

--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -882,7 +882,7 @@ static inline intptr_t get_next_hash(Thread* current, oop obj) {
     value = v;
   }
 
-  value &= markWord::hash_mask;
+  value &= UseCompactObjectHeaders ? markWord::hash_mask_compact : markWord::hash_mask;
   if (value == 0) value = 0xBAD;
   assert(value != markWord::no_hash, "invariant");
   return value;


### PR DESCRIPTION
Currently, we use a narrow 25bit identity-hash-code in Lilliput. That is even the case when running without compact object headers, even though we could just as well use the original 31bit identity hash-code then.

The fix is relatively simple. Also, this brings the code in line with what we're currently proposing in upstream https://github.com/openjdk/jdk/pull/13844.

Yes, going forward we would trade Klass* bits to get the full 31 i-hash back, and we're going to do that soon, but let's first fix this issue at hand (also in preparation for a clean backport, where we don't currently have the metaspace improvements).

Testing:
 - [ ] tier1 +UseCompactObjectHeaders
 - [ ] tier2 +UseCompactObjectHeaders
 - [ ] tier1 -UseCompactObjectHeaders
 - [ ] tier2 -UseCompactObjectHeaders