### PR TITLE
8310010: [Lilliput] SA: Fix oop array element alignment

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/memory/Universe.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/memory/Universe.java
@@ -114,13 +114,6 @@ public class Universe {
     heap().printOn(tty);
   }
 
-  // Check whether an element of a typeArrayOop with the given type must be
-  // aligned 0 mod 8.  The typeArrayOop itself must be aligned at least this
-  // strongly.
-  public static boolean elementTypeShouldBeAligned(BasicType type) {
-    return type == BasicType.T_DOUBLE || type == BasicType.T_LONG;
-  }
-
   // Check whether an object field (static/non-static) of the given type must be
   // aligned 0 mod 8.
   public static boolean fieldTypeShouldBeAligned(BasicType type) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/Array.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/Array.java
@@ -57,6 +57,18 @@ public class Array extends Oop {
   private static long lengthOffsetInBytes=0;
   private static long typeSize;
 
+  // Check whether an element of a typeArrayOop with the given type must be
+  // aligned 0 mod 8.  The typeArrayOop itself must be aligned at least this
+  // strongly.
+  private static boolean elementTypeShouldBeAligned(BasicType type) {
+    if (VM.getVM().isLP64()) {
+      if (type == BasicType.T_OBJECT || type == BasicType.T_ARRAY) {
+        return !VM.getVM().isCompressedOopsEnabled();
+      }
+    }
+    return type == BasicType.T_DOUBLE || type == BasicType.T_LONG;
+  }
+
   private static long headerSizeInBytes() {
     if (headerSize != 0) {
       return headerSize;
@@ -75,7 +87,7 @@ public class Array extends Oop {
   }
 
    private static long headerSize(BasicType type) {
-     if (Universe.elementTypeShouldBeAligned(type)) {
+     if (elementTypeShouldBeAligned(type)) {
         return alignObjectSize(headerSizeInBytes())/VM.getVM().getHeapWordSize();
      } else {
        return headerSizeInBytes()/VM.getVM().getHeapWordSize();
@@ -118,7 +130,7 @@ public class Array extends Oop {
   public static long baseOffsetInBytes(BasicType type) {
     if (VM.getVM().isCompactObjectHeadersEnabled()) {
       long typeSizeInBytes = headerSizeInBytes();
-      if (Universe.elementTypeShouldBeAligned(type)) {
+      if (elementTypeShouldBeAligned(type)) {
         VM vm = VM.getVM();
         return vm.alignUp(typeSizeInBytes, vm.getVM().getHeapWordSize());
       } else {


### PR DESCRIPTION
When running with -COOPS, oop array elements need to be 8-byte-aligned. We have this correct in runtime, but not in the SA. Notably, the problem manifests with ZGC.
The problem is already fixed in #11044.

Testing:
 - [x] serviceability/sa -XX:-UseCompressedOops

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8310010](https://bugs.openjdk.org/browse/JDK-8310010): [Lilliput] SA: Fix oop array element alignment (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput.git pull/96/head:pull/96` \
`$ git checkout pull/96`

Update a local copy of the PR: \
`$ git checkout pull/96` \
`$ git pull https://git.openjdk.org/lilliput.git pull/96/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 96`

View PR using the GUI difftool: \
`$ git pr show -t 96`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput/pull/96.diff">https://git.openjdk.org/lilliput/pull/96.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput/pull/96#issuecomment-1590917898)