### PR TITLE
8310214: [Lilliput] Disable compact headers by default

### DIFF
--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -129,8 +129,8 @@ const size_t minimumSymbolTableSize = 1024;
           "Use 32-bit class pointers in 64-bit VM. "                        \
           "lp64_product means flag is always constant in 32 bit VM")        \
                                                                             \
-  product(bool, UseCompactObjectHeaders, true, EXPERIMENTAL,                \
-                "Use 64-bit object headers instead of 96-bit headers")      \
+  product(bool, UseCompactObjectHeaders, false, EXPERIMENTAL,               \
+          "Use 64-bit object headers instead of 96-bit headers")            \
                                                                             \
   product(int, ObjectAlignmentInBytes, 8,                                   \
           "Default object alignment in bytes, 8 is minimum")                \

--- a/test/hotspot/jtreg/gc/metaspace/TestMetaspacePerfCounters.java
+++ b/test/hotspot/jtreg/gc/metaspace/TestMetaspacePerfCounters.java
@@ -297,6 +297,6 @@ public class TestMetaspacePerfCounters {
     }
 
     private static boolean isUsingCompressedClassPointers() {
-        return Platform.is64bit() && !InputArguments.contains("-XX:-UseCompressedClassPointers") && !InputArguments.contains("-XX:-UseCompactObjectHeaders");
+        return Platform.is64bit() && InputArguments.contains("-XX:+UseCompressedClassPointers");
     }
 }

--- a/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointerEncoding.java
+++ b/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointerEncoding.java
@@ -323,6 +323,8 @@ public class CompressedClassPointerEncoding {
         // $1 with force base address
         // $2 with compressed class space size
         String[] vmOptionsTemplate = new String[] {
+                "-XX:+UnlockExperimentalVMOptions",
+                "-XX:+UseCompactObjectHeaders",
                 "-XX:CompressedClassSpaceBaseAddress=$1",
                 "-XX:CompressedClassSpaceSize=$2",
                 "-Xshare:off",                         // Disable CDS

--- a/test/jtreg-ext/requires/VMProps.java
+++ b/test/jtreg-ext/requires/VMProps.java
@@ -621,7 +621,11 @@ public class VMProps implements Callable<Map<String, String>> {
                 // added by run-test framework
                 "MaxRAMPercentage",
                 // added by test environment
-                "CreateCoredumpOnCrash"
+                "CreateCoredumpOnCrash",
+                // experimental features unlocking flag does not affect behavior
+                "UnlockExperimentalVMOptions",
+                // all compact headers settings should run flagless tests
+                "UseCompactObjectHeaders"
         );
         result &= allFlags.stream()
                           .filter(s -> s.startsWith("-XX:"))


### PR DESCRIPTION
This would match the PRs that we eventually upstream, and would capture the tests that are failing/misbehaving without compact headers better. This would require enabling `UCOH` for testing explicitly. I took additional care to allow `@flagless` tests with `-XX:+UnlockExperimentalVMOptions -XX:+UseCompactObjectHeaders`.

Additional testing:
 - [x] Checked sample `@flagless` tests run with/without `UCOH`
 - [x] Linux x86_64 tier1, out of box
 - [x] Linux x86_64 tier1, `-XX:+UnlockExperimentalVMOptions -XX:+UseCompactObjectHeaders`
 - [x] Linux x86_64 tier1, `-XX:+UnlockExperimentalVMOptions -XX:-UseCompactObjectHeaders`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8310214](https://bugs.openjdk.org/browse/JDK-8310214): [Lilliput] Disable compact headers by default (**Enhancement** - P4)


### Reviewers
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput.git pull/99/head:pull/99` \
`$ git checkout pull/99`

Update a local copy of the PR: \
`$ git checkout pull/99` \
`$ git pull https://git.openjdk.org/lilliput.git pull/99/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 99`

View PR using the GUI difftool: \
`$ git pr show -t 99`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput/pull/99.diff">https://git.openjdk.org/lilliput/pull/99.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput/pull/99#issuecomment-1594877133)