### PR TITLE
8310528: [Lilliput] Provide infrastructure for Lilliput-specific ProblemList

### DIFF
--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -829,6 +829,11 @@ define SetupRunJtregTestBody
     $1_JTREG_BASIC_OPTIONS += $$(addprefix $$(JTREG_PROBLEM_LIST_PREFIX), $$($1_JTREG_PROBLEM_LIST))
   endif
 
+  # Add more Lilliput-specific ProblemLists when UCOH is enabled
+  ifneq ($$(findstring -XX:+UseCompactObjectHeaders, $$(TEST_OPTS)), )
+    JTREG_EXTRA_PROBLEM_LISTS += $(TOPDIR)/test/hotspot/jtreg/ProblemList-lilliput.txt
+  endif
+
   ifneq ($$(JTREG_EXTRA_PROBLEM_LISTS), )
     # Accept both absolute paths as well as relative to the current test root.
     $1_JTREG_BASIC_OPTIONS += $$(addprefix $$(JTREG_PROBLEM_LIST_PREFIX), $$(wildcard \

--- a/test/hotspot/jtreg/ProblemList-lilliput.txt
+++ b/test/hotspot/jtreg/ProblemList-lilliput.txt
@@ -1,0 +1,29 @@
+#
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+#
+# These tests are problematic when +UseCompactObjectHeaders is enabled.
+# The test exclusions are for the cases when we are sure the tests would fail
+# for the known and innocuous implementation reasons.
+#
+


### PR DESCRIPTION
Same as https://github.com/openjdk/lilliput-jdk17u/pull/36 for JDK 17. But in here, I have not moved any current `ProblemList` items from a generic list to this list, because some of those tests fail even with `-UCOH`.