### PR TITLE
8311875: [Lilliput] Disallow accessing oop metadata vmStructs with +UCOH

### DIFF
--- a/src/hotspot/share/runtime/threads.cpp
+++ b/src/hotspot/share/runtime/threads.cpp
@@ -111,6 +111,9 @@
 #if INCLUDE_JFR
 #include "jfr/jfr.hpp"
 #endif
+#if INCLUDE_VM_STRUCTS
+#include "runtime/vmStructs.hpp"
+#endif
 
 // Initialization after module runtime initialization
 void universe_post_module_init();  // must happen after call_initPhase2
@@ -496,6 +499,13 @@ jint Threads::create_vm(JavaVMInitArgs* args, bool* canTryAgain) {
 
   // Initialize output stream logging
   ostream_init_log();
+
+  // Should happen before any agent attaches and pokes into vmStructs
+#if INCLUDE_VM_STRUCTS
+  if (UseCompactObjectHeaders) {
+    VMStructs::compact_headers_overrides();
+  }
+#endif
 
   // Launch -agentlib/-agentpath and converted -Xrun agents
   JvmtiAgentList::load_agents();

--- a/src/hotspot/share/runtime/vmStructs.hpp
+++ b/src/hotspot/share/runtime/vmStructs.hpp
@@ -146,6 +146,9 @@ private:
   // Returns 1 if found, 0 if not.
   static int findType(const char* typeName) NOT_VM_STRUCTS_RETURN_(0);
 #endif // ASSERT
+
+public:
+  static void compact_headers_overrides() NOT_VM_STRUCTS_RETURN;
 };
 
 // This utility macro quotes the passed string


### PR DESCRIPTION
Same as for JDK 17, but for mainline. I had to deal with some upstream reshufflings that moved the agent initialization block.

Additional testing:
 - [x] Eyeballing async-profiler initialization path in default mode and with `+UCOH`
 - [x] Linux x86_65 fastdebug `serviceability/sa tier1 tier2`, default
 - [x] Linux x86_65 fastdebug `serviceability/sa tier1 tier2`, `+UCOH`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8311875](https://bugs.openjdk.org/browse/JDK-8311875): [Lilliput] Disallow accessing oop metadata vmStructs with +UCOH (**Bug** - P4)


### Reviewers
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput.git pull/101/head:pull/101` \
`$ git checkout pull/101`

Update a local copy of the PR: \
`$ git checkout pull/101` \
`$ git pull https://git.openjdk.org/lilliput.git pull/101/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 101`

View PR using the GUI difftool: \
`$ git pr show -t 101`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput/pull/101.diff">https://git.openjdk.org/lilliput/pull/101.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput/pull/101#issuecomment-1630977113)