### PR TITLE
8314130: [Lilliput] Make loadNKlassCompactHeaders not use a TEMP registers

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -7333,7 +7333,7 @@ instruct loadNKlass(iRegNNoSp dst, memory4 mem)
 instruct loadNKlassLilliput(iRegNNoSp dst, memory4 mem, rFlagsReg cr)
 %{
   match(Set dst (LoadNKlass mem));
-  effect(TEMP_DEF dst, KILL cr);
+  effect(KILL cr);
   predicate(!needs_acquiring_load(n) && UseCompactObjectHeaders);
 
   ins_cost(4 * INSN_COST);

--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -5329,7 +5329,7 @@ instruct loadNKlassLilliput(rRegN dst, indOffset8 mem, rFlagsReg cr)
 %{
   predicate(UseCompactObjectHeaders);
   match(Set dst (LoadNKlass mem));
-  effect(TEMP_DEF dst, KILL cr);
+  effect(KILL cr);
   ins_cost(125); // XXX
   format %{ "movl    $dst, $mem\t# compressed klass ptr" %}
   ins_encode %{


### PR DESCRIPTION
The loadNKlassCompactHeaders template in the .ad files currently declares dst as TEMP_DEF. This has historic reasons: We needed to ensure that dst doesn't overlap with src, because we needed src for calling into the slow-path. In addition to that, there seems to be a related bug in C2's matcher which sometimes seems to create an oopmap entry for a temp reg, which would make GCs crash if they scan uninitialized slot (see [JDK-8051805](https://bugs.openjdk.org/browse/JDK-8051805)). That problem should also go away with this change. In addition to that, relaxing the type of dst might also lead to performance enhancements when register pressure is high, because we don't need two registers for loadNKlass - 1 register would be enough.

Testing:
- [x] tier1 (x86_64, aarch64)
- [x] tier2 (x86_64, aarch64)