### PR TITLE
8314545: [Lilliput] Revert changes in zRelocate.cpp

### DIFF
--- a/src/hotspot/share/gc/z/zRelocate.cpp
+++ b/src/hotspot/share/gc/z/zRelocate.cpp
@@ -894,10 +894,6 @@ private:
       to_page = start_in_place_relocation(ZAddress::offset(addr));
       set_target(to_age, to_page);
     }
-
-    if (SuspendibleThreadSet::should_yield()) {
-      SuspendibleThreadSet::yield();
-    }
   }
 
 public:
@@ -1098,7 +1094,6 @@ public:
     ZRelocateWork<ZRelocateSmallAllocator> small(&_small_allocator, _generation);
     ZRelocateWork<ZRelocateMediumAllocator> medium(&_medium_allocator, _generation);
 
-    SuspendibleThreadSetJoiner sts_joiner;
     const auto do_forwarding = [&](ZForwarding* forwarding) {
       ZPage* const page = forwarding->page();
       if (page->is_small()) {


### PR DESCRIPTION
We have a bunch of STS additions in zRelocate.cpp . The guidance that I've got from @fisk  is that those are not needed and may in-fact cause deadlocks. Let's remove those changes and figure out if anything else is needed to deal with ZGC sync with ObjectMonitor deflation.

Testing:
 - [ ] hotspot_gc +UCOH
 - [ ] tier1 +UCOH

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8314545](https://bugs.openjdk.org/browse/JDK-8314545): [Lilliput] Revert changes in zRelocate.cpp (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput.git pull/105/head:pull/105` \
`$ git checkout pull/105`

Update a local copy of the PR: \
`$ git checkout pull/105` \
`$ git pull https://git.openjdk.org/lilliput.git pull/105/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 105`

View PR using the GUI difftool: \
`$ git pr show -t 105`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput/pull/105.diff">https://git.openjdk.org/lilliput/pull/105.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput/pull/105#issuecomment-1682964141)