### PR TITLE
8314863: [Lilliput] Revert changes in zRelocate, prevent ZGC with Lilliput

### DIFF
--- a/src/hotspot/share/gc/z/zRelocate.cpp
+++ b/src/hotspot/share/gc/z/zRelocate.cpp
@@ -894,10 +894,6 @@ private:
       to_page = start_in_place_relocation(ZAddress::offset(addr));
       set_target(to_age, to_page);
     }
-
-    if (SuspendibleThreadSet::should_yield()) {
-      SuspendibleThreadSet::yield();
-    }
   }
 
 public:
@@ -1098,7 +1094,6 @@ public:
     ZRelocateWork<ZRelocateSmallAllocator> small(&_small_allocator, _generation);
     ZRelocateWork<ZRelocateMediumAllocator> medium(&_medium_allocator, _generation);
 
-    SuspendibleThreadSetJoiner sts_joiner;
     const auto do_forwarding = [&](ZForwarding* forwarding) {
       ZPage* const page = forwarding->page();
       if (page->is_small()) {

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -3094,12 +3094,8 @@ jint Arguments::finalize_vm_init_args(bool patch_mod_javabase) {
 
 #ifdef _LP64
   if (UseCompactObjectHeaders && UseZGC) {
-    if (FLAG_IS_DEFAULT(UseCompactObjectHeaders)) {
-      warning("ZGC does not work with compact object headers, disabling UseCompactObjectHeaders");
-      FLAG_SET_DEFAULT(UseCompactObjectHeaders, false);
-    } else {
-      vm_exit_during_initialization("Incompatible options: +UseZGC can not currently be used together with +UseCompactObjectHeaders");
-    }
+    warning("ZGC does not work with compact object headers, disabling UseCompactObjectHeaders");
+    FLAG_SET_DEFAULT(UseCompactObjectHeaders, false);
   }
 
   if (UseCompactObjectHeaders && FLAG_IS_CMDLINE(UseCompressedClassPointers) && !UseCompressedClassPointers) {

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -3098,7 +3098,7 @@ jint Arguments::finalize_vm_init_args(bool patch_mod_javabase) {
       warning("ZGC does not work with compact object headers, disabling UseCompactObjectHeaders");
       FLAG_SET_DEFAULT(UseCompactObjectHeaders, false);
     } else {
-      fatal("Incompatible options: +UseZGC can not currently be used together with +UseCompactObjectHeaders");
+      vm_exit_during_initialization("Incompatible options: +UseZGC can not currently be used together with +UseCompactObjectHeaders");
     }
   }
 

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -3093,6 +3093,15 @@ jint Arguments::finalize_vm_init_args(bool patch_mod_javabase) {
 #endif // CAN_SHOW_REGISTERS_ON_ASSERT
 
 #ifdef _LP64
+  if (UseCompactObjectHeaders && UseZGC) {
+    if (FLAG_IS_DEFAULT(UseCompactObjectHeaders)) {
+      warning("ZGC does not work with compact object headers, disabling UseCompactObjectHeaders");
+      FLAG_SET_DEFAULT(UseCompactObjectHeaders, false);
+    } else {
+      fatal("Incompatible options: +UseZGC can not currently be used together with +UseCompactObjectHeaders");
+    }
+  }
+
   if (UseCompactObjectHeaders && FLAG_IS_CMDLINE(UseCompressedClassPointers) && !UseCompressedClassPointers) {
     // If user specifies -UseCompressedClassPointers, disable compact headers with a warning.
     warning("Compact object headers require compressed class pointers. Disabling compact object headers.");


### PR DESCRIPTION
The additions of SuspendibleThreadSet in [zRelocate.cpp](https://builds.shipilev.net/patch-openjdk-lilliput/src/hotspot/share/gc/z/zRelocate.cpp.udiff.html) can cause deadlocks. This problem can not easily be solved without major work in Lilliput. Let's revert those changes and prevent usage of ZGC together with Lilliput.

Testing:
 - [x] hotspot_gc +UCOH
 - [x] hotspot_gc -UCOH (default)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8314863](https://bugs.openjdk.org/browse/JDK-8314863): [Lilliput] Revert changes in zRelocate, prevent ZGC with Lilliput (**Bug** - P2)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput.git pull/107/head:pull/107` \
`$ git checkout pull/107`

Update a local copy of the PR: \
`$ git checkout pull/107` \
`$ git pull https://git.openjdk.org/lilliput.git pull/107/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 107`

View PR using the GUI difftool: \
`$ git pr show -t 107`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput/pull/107.diff">https://git.openjdk.org/lilliput/pull/107.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput/pull/107#issuecomment-1689608729)