### PR TITLE
8317812: [Lilliput] Make C2 LoadNKlassCompactHeader more robust

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -7346,9 +7346,7 @@ instruct loadNKlassCompactHeaders(iRegNNoSp dst, memory4 mem, rFlagsReg cr)
   ins_cost(4 * INSN_COST);
   format %{ "ldrw  $dst, $mem\t# compressed class ptr" %}
   ins_encode %{
-    assert($mem$$disp == oopDesc::klass_offset_in_bytes(), "expect correct offset");
-    assert($mem$$index$$Register == noreg, "expect no index");
-    __ load_nklass_compact($dst$$Register, $mem$$base$$Register);
+    __ load_nklass_compact($dst$$Register, $mem$$base$$Register, $mem$$index$$Register, $mem$$scale, $mem$$disp);
   %}
   ins_pipe(pipe_slow);
 %}

--- a/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.cpp
@@ -2059,10 +2059,25 @@ bool C2_MacroAssembler::in_scratch_emit_size() {
   return MacroAssembler::in_scratch_emit_size();
 }
 
-void C2_MacroAssembler::load_nklass_compact(Register dst, Register obj) {
+void C2_MacroAssembler::load_nklass_compact(Register dst, Register obj, Register index, int scale, int disp) {
   C2LoadNKlassStub* stub = new (Compile::current()->comp_arena()) C2LoadNKlassStub(dst);
   Compile::current()->output()->add_stub(stub);
-  ldr(dst, Address(obj, oopDesc::mark_offset_in_bytes()));
+
+  // Note: Don't clobber obj anywhere in that method!
+
+  // The incoming address is pointing into obj-start + klass_offset_in_bytes. We need to extract
+  // obj-start, so that we can load from the object's mark-word instead. Usually the address
+  // comes as obj-start in obj and klass_offset_in_bytes in disp. However, sometimes C2
+  // emits code that pre-computes obj-start + klass_offset_in_bytes into a register, and
+  // then passes that register as obj and 0 in disp. The following code extracts the base
+  // and offset to load the mark-word.
+  int offset = oopDesc::mark_offset_in_bytes() + disp - oopDesc::klass_offset_in_bytes();
+  if (index == noreg) {
+    ldr(dst, Address(obj, offset));
+  } else {
+    lea(dst, Address(obj, index, Address::lsl(scale)));
+    ldr(dst, Address(dst, offset));
+  }
   // NOTE: We can't use tbnz here, because the target is sometimes too far away
   // and cannot be encoded.
   tst(dst, markWord::monitor_value);

--- a/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.hpp
@@ -172,6 +172,6 @@
   void vector_signum_sve(FloatRegister dst, FloatRegister src, FloatRegister zero,
                          FloatRegister one, FloatRegister vtmp, PRegister pgtmp, SIMD_RegVariant T);
 
-  void load_nklass_compact(Register dst, Register obj);
+  void load_nklass_compact(Register dst, Register obj, Register index, int scale, int disp);
 
 #endif // CPU_AARCH64_C2_MACROASSEMBLER_AARCH64_HPP


### PR DESCRIPTION
Lilliput's C2 code for generating LoadNKlass currently assumes that the disp of the incoming address is klass_offset_in_bytes. It then extracts the base register and loads from the mark_offset_in_bytes instead.
Sometimes (apparently very rarely) it happens that C2 emits code that pre-adds obj+klass_offset into a register, and uses that as base, but with offset 0. In this case we would trip the assert or crash in release builds.