### PR TITLE
8318011: [Lilliput] Fix CDS narrowKlass encoding

### DIFF
--- a/src/hotspot/share/cds/archiveBuilder.cpp
+++ b/src/hotspot/share/cds/archiveBuilder.cpp
@@ -727,13 +727,9 @@ void ArchiveBuilder::make_klasses_shareable() {
 #ifdef _LP64
     if (UseCompactObjectHeaders) {
       Klass* requested_k = to_requested(k);
-#if INCLUDE_CDS_JAVA_HEAP
       address narrow_klass_base = _requested_static_archive_bottom; // runtime encoding base == runtime mapping start
-      const int narrow_klass_shift = ArchiveHeapWriter::precomputed_narrow_klass_shift;
+      const int narrow_klass_shift = precomputed_narrow_klass_shift;
       narrowKlass nk = CompressedKlassPointers::encode_not_null(requested_k, narrow_klass_base, narrow_klass_shift);
-#else
-      narrowKlass nk = CompressedKlassPointers::encode_not_null(requested_k);
-#endif
       k->set_prototype_header(markWord::prototype().set_narrow_klass(nk));
     }
 #endif //_LP64
@@ -839,7 +835,7 @@ narrowKlass ArchiveBuilder::get_requested_narrow_klass(Klass* k) {
   k = get_buffered_klass(k);
   Klass* requested_k = to_requested(k);
   address narrow_klass_base = _requested_static_archive_bottom; // runtime encoding base == runtime mapping start
-  const int narrow_klass_shift = ArchiveHeapWriter::precomputed_narrow_klass_shift;
+  const int narrow_klass_shift = precomputed_narrow_klass_shift;
   return CompressedKlassPointers::encode_not_null(requested_k, narrow_klass_base, narrow_klass_shift);
 }
 #endif // INCLUDE_CDS_JAVA_HEAP

--- a/src/hotspot/share/cds/archiveBuilder.hpp
+++ b/src/hotspot/share/cds/archiveBuilder.hpp
@@ -90,6 +90,18 @@ const int SharedSpaceObjectAlignment = KlassAlignmentInBytes;
 //    buffered_address + _buffer_to_requested_delta == requested_address
 //
 class ArchiveBuilder : public StackObj {
+public:
+  // Archived heap object headers carry pre-computed narrow Klass ids calculated with the
+  // following scheme:
+  // 1) the encoding base must be the mapping start address.
+  // 2) shift must be large enough to result in an encoding range that covers the runtime Klass range.
+  //    That Klass range is defined by CDS archive size and runtime class space size. Luckily, the maximum
+  //    size can be predicted: archive size is assumed to be <1G, class space size capped at 3G, and at
+  //    runtime we put both regions adjacent to each other. Therefore, runtime Klass range size < 4G.
+  //    Since nKlass itself is 32 bit, our encoding range len is 4G, and since we set the base directly
+  //    at mapping start, these 4G are enough. Therefore, we don't need to shift at all (shift=0).
+  static constexpr int precomputed_narrow_klass_shift = 0;
+
 protected:
   DumpRegion* _current_dump_space;
   address _buffer_bottom;                      // for writing the contents of rw/ro regions

--- a/src/hotspot/share/cds/archiveBuilder.hpp
+++ b/src/hotspot/share/cds/archiveBuilder.hpp
@@ -91,8 +91,10 @@ const int SharedSpaceObjectAlignment = KlassAlignmentInBytes;
 //
 class ArchiveBuilder : public StackObj {
 public:
-  // Archived heap object headers carry pre-computed narrow Klass ids calculated with the
-  // following scheme:
+  // The archive contains pre-computed narrow Klass IDs in two places:
+  // - in the header of archived java objects (only if the archive contains java heap portions)
+  // - within the prototype markword of archived Klass structures.
+  // These narrow Klass ids have been computed at dump time with the following scheme:
   // 1) the encoding base must be the mapping start address.
   // 2) shift must be large enough to result in an encoding range that covers the runtime Klass range.
   //    That Klass range is defined by CDS archive size and runtime class space size. Luckily, the maximum

--- a/src/hotspot/share/cds/archiveHeapWriter.hpp
+++ b/src/hotspot/share/cds/archiveHeapWriter.hpp
@@ -233,17 +233,6 @@ public:
   static oop buffered_addr_to_source_obj(address buffered_addr);
   static address buffered_addr_to_requested_addr(address buffered_addr);
 
-  // Archived heap object headers carry pre-computed narrow Klass ids calculated with the
-  // following scheme:
-  // 1) the encoding base must be the mapping start address.
-  // 2) shift must be large enough to result in an encoding range that covers the runtime Klass range.
-  //    That Klass range is defined by CDS archive size and runtime class space size. Luckily, the maximum
-  //    size can be predicted: archive size is assumed to be <1G, class space size capped at 3G, and at
-  //    runtime we put both regions adjacent to each other. Therefore, runtime Klass range size < 4G.
-  //    Since nKlass itself is 32 bit, our encoding range len is 4G, and since we set the base directly
-  //    at mapping start, these 4G are enough. Therefore, we don't need to shift at all (shift=0).
-  static constexpr int precomputed_narrow_klass_shift = 0;
-
 };
 #endif // INCLUDE_CDS_JAVA_HEAP
 #endif // SHARE_CDS_ARCHIVEHEAPWRITER_HPP

--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -2004,11 +2004,11 @@ bool FileMapInfo::can_use_heap_region() {
   }
 
   // We pre-compute narrow Klass IDs with the runtime mapping start intended to be the base, and a shift of
-  // ArchiveHeapWriter::precomputed_narrow_klass_shift. We enforce this encoding at runtime (see
+  // ArchiveBuilder::precomputed_narrow_klass_shift. We enforce this encoding at runtime (see
   // CompressedKlassPointers::initialize_for_given_encoding()). Therefore, the following assertions must
   // hold:
   address archive_narrow_klass_base = (address)header()->mapped_base_address();
-  const int archive_narrow_klass_shift = ArchiveHeapWriter::precomputed_narrow_klass_shift;
+  const int archive_narrow_klass_shift = ArchiveBuilder::precomputed_narrow_klass_shift;
 
   log_info(cds)("CDS archive was created with max heap size = " SIZE_FORMAT "M, and the following configuration:",
                 max_heap_size()/M);

--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -1151,10 +1151,10 @@ MapArchiveResult MetaspaceShared::map_archives(FileMapInfo* static_mapinfo, File
 #if INCLUDE_CDS_JAVA_HEAP
           // We archived objects with pre-computed narrow Klass id. Set up encoding such that these Ids stay valid.
           address precomputed_narrow_klass_base = cds_base;
-          const int precomputed_narrow_klass_shift = ArchiveHeapWriter::precomputed_narrow_klass_shift;
+          const int precomputed_narrow_klass_shift = ArchiveBuilder::precomputed_narrow_klass_shift;
           CompressedKlassPointers::initialize_for_given_encoding(
             cds_base, ccs_end - cds_base, // Klass range
-            precomputed_narrow_klass_base, precomputed_narrow_klass_shift // precomputed encoding, see ArchiveHeapWriter
+            precomputed_narrow_klass_base, precomputed_narrow_klass_shift // precomputed encoding, see ArchiveBuilder
             );
 #else
           CompressedKlassPointers::initialize (


### PR DESCRIPTION
With Lilliput, we need to store the correct narrowKlass in the archived Klass instances. For this, we need the ArchiveHeapWriter::precomputed_narrow_klass_shift. However, ArchiveHeapWriter is only available when building with INCLUDE_CDS_JAVA_HEAP, i.e. currently not with Windows. This field should be moved to ArchiveBuilder, so that we can access it even when INCLUDE_CDS_JAVA_HEAP is not enabled.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8318011](https://bugs.openjdk.org/browse/JDK-8318011): [Lilliput] Fix CDS narrowKlass encoding (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - Committer) ⚠️ Review applies to [331a7e5c](https://git.openjdk.org/lilliput/pull/112/files/331a7e5cfce3d5adf7a8a321da21538ccda0a6cd)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - Committer) ⚠️ Review applies to [331a7e5c](https://git.openjdk.org/lilliput/pull/112/files/331a7e5cfce3d5adf7a8a321da21538ccda0a6cd)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput.git pull/112/head:pull/112` \
`$ git checkout pull/112`

Update a local copy of the PR: \
`$ git checkout pull/112` \
`$ git pull https://git.openjdk.org/lilliput.git pull/112/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 112`

View PR using the GUI difftool: \
`$ git pr show -t 112`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput/pull/112.diff">https://git.openjdk.org/lilliput/pull/112.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput/pull/112#issuecomment-1759719401)