### PR TITLE
8319135: [Lilliput] Fix objArrayOop gtest

### DIFF
--- a/test/hotspot/gtest/oops/test_objArrayOop.cpp
+++ b/test/hotspot/gtest/oops/test_objArrayOop.cpp
@@ -48,14 +48,14 @@ TEST_VM(objArrayOop, osize) {
     { 8,          false,  true,     true,   2 },  // 12 byte header, 4 byte oops
     { 8,          true,   false,    true,   3 },  // 16 byte header, 8 byte oops
     { 8,          true,   true,     true,   2 },  // 12 byte header, 4 byte oops
-    { 16,         false,  false,    true,   4 },  // 20 byte header, 8 byte oops, 16-byte align
-    { 16,         false,  true,     true,   2 },  // 20 byte header, 4 byte oops, 16-byte align
+    { 16,         false,  false,    true,   4 },  // 16 byte header, 8 byte oops, 16-byte align
+    { 16,         false,  true,     true,   2 },  // 12 byte header, 4 byte oops, 16-byte align
     { 16,         true,   false,    true,   4 },  // 16 byte header, 8 byte oops, 16-byte align
-    { 16,         true,   true,     true,   2 },  // 16 byte header, 4 byte oops, 16-byte align
-    { 256,        false,  false,    true,   32 }, // 20 byte header, 8 byte oops, 256-byte align
-    { 256,        false,  true,     true,   32 }, // 20 byte header, 4 byte oops, 256-byte align
+    { 16,         true,   true,     true,   2 },  // 12 byte header, 4 byte oops, 16-byte align
+    { 256,        false,  false,    true,   32 }, // 16 byte header, 8 byte oops, 256-byte align
+    { 256,        false,  true,     true,   32 }, // 12 byte header, 4 byte oops, 256-byte align
     { 256,        true,   false,    true,   32 }, // 16 byte header, 8 byte oops, 256-byte align
-    { 256,        true,   true,     true,   32 }, // 16 byte header, 4 byte oops, 256-byte align
+    { 256,        true,   true,     true,   32 }, // 12 byte header, 4 byte oops, 256-byte align
 #else
     { 8,          false,  false,    false,  4 }, // 12 byte header, 4 byte oops, wordsize 4
 #endif

--- a/test/hotspot/gtest/oops/test_objArrayOop.cpp
+++ b/test/hotspot/gtest/oops/test_objArrayOop.cpp
@@ -57,9 +57,9 @@ TEST_VM(objArrayOop, osize) {
     { 256,        true,   false,    true,   32 }, // 16 byte header, 8 byte oops, 256-byte align
     { 256,        true,   true,     true,   32 }, // 16 byte header, 4 byte oops, 256-byte align
 #else
-    { 8,          false,  false,    4 }, // 12 byte header, 4 byte oops, wordsize 4
+    { 8,          false,  false,    false,  4 }, // 12 byte header, 4 byte oops, wordsize 4
 #endif
-    { -1,         false,  false,   -1 }
+    { -1,         false,  false,    false, -1 }
   };
   for (int i = 0; x[i].result != -1; i++) {
     if (x[i].objal == (int)ObjectAlignmentInBytes && x[i].ccp == UseCompressedClassPointers && x[i].coops == UseCompressedOops && x[i].coh == UseCompactObjectHeaders) {

--- a/test/hotspot/gtest/oops/test_objArrayOop.cpp
+++ b/test/hotspot/gtest/oops/test_objArrayOop.cpp
@@ -28,29 +28,41 @@
 
 TEST_VM(objArrayOop, osize) {
   static const struct {
-    int objal; bool ccp; bool coops; int result;
+    int objal; bool ccp; bool coops; bool coh; int result;
   } x[] = {
-//    ObjAligInB, UseCCP, UseCoops, object size in heap words
+//    ObjAligInB, UseCCP, UseCoops, UseCOH, object size in heap words
 #ifdef _LP64
-    { 8,          false,  false,    4 },  // 20 byte header, 8 byte oops
-    { 8,          false,  true,     3 },  // 20 byte header, 4 byte oops
-    { 8,          true,   false,    3 },  // 16 byte header, 8 byte oops
-    { 8,          true,   true,     3 },  // 16 byte header, 4 byte oops
-    { 16,         false,  false,    4 },  // 20 byte header, 8 byte oops, 16-byte align
-    { 16,         false,  true,     4 },  // 20 byte header, 4 byte oops, 16-byte align
-    { 16,         true,   false,    4 },  // 16 byte header, 8 byte oops, 16-byte align
-    { 16,         true,   true,     4 },  // 16 byte header, 4 byte oops, 16-byte align
-    { 256,        false,  false,    32 }, // 20 byte header, 8 byte oops, 256-byte align
-    { 256,        false,  true,     32 }, // 20 byte header, 4 byte oops, 256-byte align
-    { 256,        true,   false,    32 }, // 16 byte header, 8 byte oops, 256-byte align
-    { 256,        true,   true,     32 }, // 16 byte header, 4 byte oops, 256-byte align
+    { 8,          false,  false,    false,  4 },  // 20 byte header, 8 byte oops
+    { 8,          false,  true,     false,  3 },  // 20 byte header, 4 byte oops
+    { 8,          true,   false,    false,  3 },  // 16 byte header, 8 byte oops
+    { 8,          true,   true,     false,  3 },  // 16 byte header, 4 byte oops
+    { 16,         false,  false,    false,  4 },  // 20 byte header, 8 byte oops, 16-byte align
+    { 16,         false,  true,     false,  4 },  // 20 byte header, 4 byte oops, 16-byte align
+    { 16,         true,   false,    false,  4 },  // 16 byte header, 8 byte oops, 16-byte align
+    { 16,         true,   true,     false,  4 },  // 16 byte header, 4 byte oops, 16-byte align
+    { 256,        false,  false,    false,  32 }, // 20 byte header, 8 byte oops, 256-byte align
+    { 256,        false,  true,     false,  32 }, // 20 byte header, 4 byte oops, 256-byte align
+    { 256,        true,   false,    false,  32 }, // 16 byte header, 8 byte oops, 256-byte align
+    { 256,        true,   true,     false,  32 }, // 16 byte header, 4 byte oops, 256-byte align
+    { 8,          false,  false,    true,   3 },  // 16 byte header, 8 byte oops
+    { 8,          false,  true,     true,   2 },  // 12 byte header, 4 byte oops
+    { 8,          true,   false,    true,   3 },  // 16 byte header, 8 byte oops
+    { 8,          true,   true,     true,   2 },  // 12 byte header, 4 byte oops
+    { 16,         false,  false,    true,   4 },  // 20 byte header, 8 byte oops, 16-byte align
+    { 16,         false,  true,     true,   2 },  // 20 byte header, 4 byte oops, 16-byte align
+    { 16,         true,   false,    true,   4 },  // 16 byte header, 8 byte oops, 16-byte align
+    { 16,         true,   true,     true,   2 },  // 16 byte header, 4 byte oops, 16-byte align
+    { 256,        false,  false,    true,   32 }, // 20 byte header, 8 byte oops, 256-byte align
+    { 256,        false,  true,     true,   32 }, // 20 byte header, 4 byte oops, 256-byte align
+    { 256,        true,   false,    true,   32 }, // 16 byte header, 8 byte oops, 256-byte align
+    { 256,        true,   true,     true,   32 }, // 16 byte header, 4 byte oops, 256-byte align
 #else
     { 8,          false,  false,    4 }, // 12 byte header, 4 byte oops, wordsize 4
 #endif
     { -1,         false,  false,   -1 }
   };
   for (int i = 0; x[i].result != -1; i++) {
-    if (x[i].objal == (int)ObjectAlignmentInBytes && x[i].ccp == UseCompressedClassPointers && x[i].coops == UseCompressedOops) {
+    if (x[i].objal == (int)ObjectAlignmentInBytes && x[i].ccp == UseCompressedClassPointers && x[i].coops == UseCompressedOops && x[i].coh == UseCompactObjectHeaders) {
       EXPECT_EQ(objArrayOopDesc::object_size(1), (size_t)x[i].result);
     }
   }


### PR DESCRIPTION
The objArrayOop gtest is broken with Lilliput. The test checks the size of obj-arrays under various settings (coops, ccp) and different alignments, but it does not consider UseCompactObjectHeaders, yet.

The change adds handling of UseCompactObjectHeaders.

Testing:
 - [x] gtest:objArrayOop (+UCOH)
 - [x] gtest:objArrayOop (-UCOH)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8319135](https://bugs.openjdk.org/browse/JDK-8319135): [Lilliput] Fix objArrayOop gtest (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - Committer) ⚠️ Review applies to [02b5da1d](https://git.openjdk.org/lilliput/pull/114/files/02b5da1d02b8e36eadf5278f0c81fd338cce4d25)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput.git pull/114/head:pull/114` \
`$ git checkout pull/114`

Update a local copy of the PR: \
`$ git checkout pull/114` \
`$ git pull https://git.openjdk.org/lilliput.git pull/114/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 114`

View PR using the GUI difftool: \
`$ git pr show -t 114`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput/pull/114.diff">https://git.openjdk.org/lilliput/pull/114.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput/pull/114#issuecomment-1786853435)