### PR TITLE
8319524: [Lilliput] Only warn when compact headers are explicitly enabled

### DIFF
--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -3091,7 +3091,9 @@ jint Arguments::finalize_vm_init_args(bool patch_mod_javabase) {
 
 #ifdef _LP64
   if (UseCompactObjectHeaders && UseZGC && !ZGenerational) {
-    warning("Single-generational ZGC does not work with compact object headers, disabling UseCompactObjectHeaders");
+    if (FLAG_IS_CMDLINE(UseCompactObjectHeaders)) {
+      warning("Single-generational ZGC does not work with compact object headers, disabling UseCompactObjectHeaders");
+    }
     FLAG_SET_DEFAULT(UseCompactObjectHeaders, false);
   }
   if (UseCompactObjectHeaders && FLAG_IS_CMDLINE(UseCompressedClassPointers) && !UseCompressedClassPointers) {


### PR DESCRIPTION
We currently print a warning when a user specifies +UseZGC together with +UseCompactObjectHeaders. We should only print the warning when +UCOH is explicitly enabled at the command-line. This may not be very relevant at the moment, but might be in the future, or in downstreams which may want to enable compact headers by default.

When building with +UCOH by default, a number of langtools:tier1 tests are failing because of the warning.

Testing:
  - [x] langtools:tier1 (+UseZGC and hardcoded +UCOH)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8319524](https://bugs.openjdk.org/browse/JDK-8319524): [Lilliput] Only warn when compact headers are explicitly enabled (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput.git pull/115/head:pull/115` \
`$ git checkout pull/115`

Update a local copy of the PR: \
`$ git checkout pull/115` \
`$ git pull https://git.openjdk.org/lilliput.git pull/115/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 115`

View PR using the GUI difftool: \
`$ git pr show -t 115`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput/pull/115.diff">https://git.openjdk.org/lilliput/pull/115.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput/pull/115#issuecomment-1794598260)