### PR TITLE
8319724: [Lilliput] ParallelGC: Forwarded objects found during heap inspection

### DIFF
--- a/src/hotspot/share/gc/parallel/mutableSpace.hpp
+++ b/src/hotspot/share/gc/parallel/mutableSpace.hpp
@@ -67,6 +67,9 @@ class MutableSpace: public CHeapObj<mtGC> {
   void set_last_setup_region(MemRegion mr) { _last_setup_region = mr;   }
   MemRegion last_setup_region() const      { return _last_setup_region; }
 
+  template<bool COMPACT_HEADERS>
+  void object_iterate_impl(ObjectClosure* cl);
+
  public:
   virtual ~MutableSpace();
   MutableSpace(size_t page_size);


### PR DESCRIPTION
This is the Lilliput variant of [JDK-8319376](https://bugs.openjdk.org/browse/JDK-8319376). With Lilliput we need special treatment of the fix, because the iterator needs to access the Klass*, which it can only get via the forwardee.

Testing:
 - [x] gc/logging/TestUnifiedLoggingSwitchStress.java +UseParallelGC +UCOH
 - [x] gc/logging/TestUnifiedLoggingSwitchStress.java +UseParallelGC -UCOH
 - [x] hotspot_gc +UCOH
 - [x] tier1 +UCOH
 - [x] tier2 +UCOH

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8319724](https://bugs.openjdk.org/browse/JDK-8319724): [Lilliput] ParallelGC: Forwarded objects found during heap inspection (**Bug** - P2)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput.git pull/116/head:pull/116` \
`$ git checkout pull/116`

Update a local copy of the PR: \
`$ git checkout pull/116` \
`$ git pull https://git.openjdk.org/lilliput.git pull/116/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 116`

View PR using the GUI difftool: \
`$ git pr show -t 116`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput/pull/116.diff">https://git.openjdk.org/lilliput/pull/116.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput/pull/116#issuecomment-1802183183)