### PR TITLE
8319185: [Lilliput] Enable and fix vectorization tests

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizationMismatchedAccess.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizationMismatchedAccess.java
@@ -102,20 +102,20 @@ public class TestVectorizationMismatchedAccess {
         Arrays.fill(byteArray, (byte)0);
         test.run();
         int i;
-	// Check head (including possibly unaligned part). Those elements must be zero.
+        // Check head (including possibly unaligned part). Those elements must be zero.
         for (i = 0; i < Math.max(offset, 0) + ALIGNED_BASE_INDEX; i++) {
             if (byteArray[i] != 0) {
                 throw new RuntimeException("Incorrect result at " + i + " " + byteArray[i] + " != 0");
             }
         }
-	// Check the copied body bytes.
-	int alignedArrayEnd = byteArray.length - ALIGNED_END_OFFSET;
+        // Check the copied body bytes.
+        int alignedArrayEnd = byteArray.length - ALIGNED_END_OFFSET;
         for (; i < Math.min(alignedArrayEnd + offset, alignedArrayEnd); i++) {
             if (byteArray[i] != verifyByteArray[i - offset]) {
                 throw new RuntimeException("Incorrect result at " + i + " " + byteArray[i] + " != " + verifyByteArray[i-offset]);
             }
         }
-	// Check the tail (including possibly unaligned part). Those elements must be zero.
+        // Check the tail (including possibly unaligned part). Those elements must be zero.
         for (; i < byteArray.length; i++) {
             if (byteArray[i] != 0) {
                 throw new RuntimeException("Incorrect result at " + i + " " + byteArray[i] + " != 0");
@@ -127,33 +127,33 @@ public class TestVectorizationMismatchedAccess {
         System.arraycopy(verifyByteArray, 0, byteArray, 0, byteArray.length);
         test.run();
         int i;
-	// Check head (including possibly unaligned part). Those elements must be equal.
+        // Check head (including possibly unaligned part). Those elements must be equal.
         for (i = 0; i < Math.max(offset, 0) + ALIGNED_BASE_INDEX; i++) {
             if (byteArray[i] != verifyByteArray[i]) {
                 throw new RuntimeException("Incorrect result at " + i + " " + byteArray[i] + " != " + verifyByteArray[i]);
             }
         }
-	// Check the copied body bytes.
-	// 
-	// When the offset is negative (i.e. backwarts-copy within the array),
-	// the elements at i in byteArray must match the elements at i + offset
-	// in the verifyByteArray.
-	//
-	// When the offset is positive (i.e. forward-copy within the array),
-	// the same 8 elements would have been copied over and over again, and
-	// thus every 8-bytes-block must match the first 8 bytes.
-	int alignedArrayEnd = byteArray.length - ALIGNED_END_OFFSET;
+        // Check the copied body bytes.
+        // 
+        // When the offset is negative (i.e. backwarts-copy within the array),
+        // the elements at i in byteArray must match the elements at i + offset
+        // in the verifyByteArray.
+        //
+        // When the offset is positive (i.e. forward-copy within the array),
+        // the same 8 elements would have been copied over and over again, and
+        // thus every 8-bytes-block must match the first 8 bytes.
+        int alignedArrayEnd = byteArray.length - ALIGNED_END_OFFSET;
         for (; i < Math.min(alignedArrayEnd + offset, alignedArrayEnd); i++) {
-	    int idx = i - offset;
-	    if (offset > 0) {
-		idx = (idx - ALIGNED_BASE_INDEX) % 8 + ALIGNED_BASE_INDEX;
-	    }
-	    int val = verifyByteArray[idx];
+            int idx = i - offset;
+            if (offset > 0) {
+                idx = (idx - ALIGNED_BASE_INDEX) % 8 + ALIGNED_BASE_INDEX;
+            }
+            int val = verifyByteArray[idx];
             if (byteArray[i] != val) {
                 throw new RuntimeException("Incorrect result at " + i + " " + byteArray[i] + " != " + verifyByteArray[i-offset]);
             }
-	}
-	// Check the tail (including possibly unaligned part). Those elements must be equal.
+        }
+        // Check the tail (including possibly unaligned part). Those elements must be equal.
         for (; i < byteArray.length; i++) {
             if (byteArray[i] != verifyByteArray[i]) {
                 throw new RuntimeException("Incorrect result at " + i + " " + byteArray[i] + " != " + verifyByteArray[i]);
@@ -254,19 +254,19 @@ public class TestVectorizationMismatchedAccess {
     }
 
     static int alignedStartOffset() {
-	int unitSize = 8;
-	return UNSAFE.ARRAY_BYTE_BASE_OFFSET % unitSize;
+        int unitSize = 8;
+        return UNSAFE.ARRAY_BYTE_BASE_OFFSET % unitSize;
     }
 
     static int alignedEndOffset() {
-	int unitSize = 8;
-	return (unitSize - alignedStartOffset()) % unitSize;
+        int unitSize = 8;
+        return (unitSize - alignedStartOffset()) % unitSize;
     }
 
     @Test
     @IR(counts = { IRNode.LOAD_VECTOR_L, ">=1", IRNode.STORE_VECTOR, ">=1" })
     public static void testByteByte1(byte[] dest, byte[] src) {
-	int offset = ALIGNED_BASE_OFFSET;
+        int offset = ALIGNED_BASE_OFFSET;
         for (int i = 0; i < size; i++) {
             UNSAFE.putLongUnaligned(dest, offset + 8 * i, UNSAFE.getLongUnaligned(src, offset + 8 * i));
         }
@@ -280,7 +280,7 @@ public class TestVectorizationMismatchedAccess {
     @Test
     @IR(counts = { IRNode.LOAD_VECTOR_L, ">=1", IRNode.STORE_VECTOR, ">=1" })
     public static void testByteByte2(byte[] dest, byte[] src) {
-	int offset = ALIGNED_BASE_OFFSET;
+        int offset = ALIGNED_BASE_OFFSET;
         for (int i = 1; i < size; i++) {
             UNSAFE.putLongUnaligned(dest, offset + 8 * (i - 1), UNSAFE.getLongUnaligned(src, offset + 8 * i));
         }
@@ -294,7 +294,7 @@ public class TestVectorizationMismatchedAccess {
     @Test
     @IR(failOn = { IRNode.LOAD_VECTOR_L, IRNode.STORE_VECTOR })
     public static void testByteByte3(byte[] dest, byte[] src) {
-	int offset = ALIGNED_BASE_OFFSET;
+        int offset = ALIGNED_BASE_OFFSET;
         for (int i = 0; i < size - 1; i++) {
             UNSAFE.putLongUnaligned(dest, offset + 8 * (i + 1), UNSAFE.getLongUnaligned(src, offset + 8 * i));
         }

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizationMismatchedAccess.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizationMismatchedAccess.java
@@ -134,7 +134,7 @@ public class TestVectorizationMismatchedAccess {
             }
         }
         // Check the copied body bytes.
-        // 
+        //
         // When the offset is negative (i.e. backwarts-copy within the array),
         // the elements at i in byteArray must match the elements at i + offset
         // in the verifyByteArray.

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizationNotRun.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizationNotRun.java
@@ -41,12 +41,15 @@ import java.util.Random;
 public class TestVectorizationNotRun {
     private static final Unsafe UNSAFE = Unsafe.getUnsafe();
 
+    // The unsafe offset of the first long-aligned array element in a byte array.
+    private static final int ALIGNED_BASE_OFFSET = UNSAFE.ARRAY_BYTE_BASE_OFFSET + UNSAFE.ARRAY_BYTE_BASE_OFFSET % Long.BYTES;
+
     public static void main(String[] args) {
         TestFramework.runWithFlags("--add-modules", "java.base", "--add-exports", "java.base/jdk.internal.misc=ALL-UNNAMED");
     }
 
     static int size = 1024;
-    static int sizeBytes = 8 * size;
+    static int sizeBytes = 8 * size + 8;
     static byte[] byteArray = new byte[sizeBytes];
     static long[] longArray = new long[size];
 
@@ -57,7 +60,7 @@ public class TestVectorizationNotRun {
             if ((i < 0) || (8 > sizeBytes - i)) {
                 throw new IndexOutOfBoundsException();
             }
-            UNSAFE.putLongUnaligned(dest, UNSAFE.ARRAY_BYTE_BASE_OFFSET + i * 8, src[i]);
+            UNSAFE.putLongUnaligned(dest, ALIGNED_BASE_OFFSET + i * 8, src[i]);
         }
     }
 

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
@@ -141,7 +141,8 @@ public class TestFramework {
                     "UseZbb",
                     "UseRVV",
                     "Xlog",
-                    "LogCompilation"
+                    "LogCompilation",
+		    "UseCompactObjectHeaders"
             )
     );
 

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
@@ -142,7 +142,7 @@ public class TestFramework {
                     "UseRVV",
                     "Xlog",
                     "LogCompilation",
-		    "UseCompactObjectHeaders"
+                    "UseCompactObjectHeaders"
             )
     );
 

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestIndependentPacksWithCyclicDependency.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestIndependentPacksWithCyclicDependency.java
@@ -253,10 +253,13 @@ public class TestIndependentPacksWithCyclicDependency {
         }
     }
 
+    private static final int ALIGNED_INT_BASE_OFFSET   = unsafe.ARRAY_INT_BASE_OFFSET   + unsafe.ARRAY_INT_BASE_OFFSET   % Long.BYTES;
+    private static final int ALIGNED_FLOAT_BASE_OFFSET = unsafe.ARRAY_FLOAT_BASE_OFFSET + unsafe.ARRAY_FLOAT_BASE_OFFSET % Long.BYTES;
+
     @Run(test = "test6")
     public void runTest6() {
-        int[]   dataI = new int[RANGE];
-        float[] dataF = new float[RANGE];
+        int[]   dataI = new int[RANGE + Long.BYTES];
+        float[] dataF = new float[RANGE + Long.BYTES];
         long[]  dataL = new long[RANGE];
         init(dataI, dataF, dataL);
         test6(dataI, dataI, dataF, dataF, dataL, dataL);
@@ -272,18 +275,18 @@ public class TestIndependentPacksWithCyclicDependency {
                       long[] dataLa, long[] dataLb) {
         for (int i = 0; i < RANGE; i+=2) {
             // Chain of parallelizable op and conversion
-            int v00 = unsafe.getInt(dataIa, unsafe.ARRAY_INT_BASE_OFFSET + 4 * i + 0) + 3;
-            int v01 = unsafe.getInt(dataIa, unsafe.ARRAY_INT_BASE_OFFSET + 4 * i + 4) + 3;
-            unsafe.putInt(dataFa, unsafe.ARRAY_FLOAT_BASE_OFFSET + 4 * i + 0, v00);
-            unsafe.putInt(dataFa, unsafe.ARRAY_FLOAT_BASE_OFFSET + 4 * i + 4, v01);
-            int v10 = unsafe.getInt(dataFb, unsafe.ARRAY_FLOAT_BASE_OFFSET + 4 * i + 0) * 45;
-            int v11 = unsafe.getInt(dataFb, unsafe.ARRAY_FLOAT_BASE_OFFSET + 4 * i + 4) * 45;
+            int v00 = unsafe.getInt(dataIa, ALIGNED_INT_BASE_OFFSET + 4 * i + 0) + 3;
+            int v01 = unsafe.getInt(dataIa, ALIGNED_INT_BASE_OFFSET + 4 * i + 4) + 3;
+            unsafe.putInt(dataFa, ALIGNED_FLOAT_BASE_OFFSET + 4 * i + 0, v00);
+            unsafe.putInt(dataFa, ALIGNED_FLOAT_BASE_OFFSET + 4 * i + 4, v01);
+            int v10 = unsafe.getInt(dataFb, ALIGNED_FLOAT_BASE_OFFSET + 4 * i + 0) * 45;
+            int v11 = unsafe.getInt(dataFb, ALIGNED_FLOAT_BASE_OFFSET + 4 * i + 4) * 45;
             unsafe.putInt(dataLa, unsafe.ARRAY_LONG_BASE_OFFSET + 4 * i + 0, v10);
             unsafe.putInt(dataLa, unsafe.ARRAY_LONG_BASE_OFFSET + 4 * i + 4, v11);
             float v20 = unsafe.getFloat(dataLb, unsafe.ARRAY_LONG_BASE_OFFSET + 4 * i + 0) + 0.55f;
             float v21 = unsafe.getFloat(dataLb, unsafe.ARRAY_LONG_BASE_OFFSET + 4 * i + 4) + 0.55f;
-            unsafe.putFloat(dataIb, unsafe.ARRAY_INT_BASE_OFFSET + 4 * i + 0, v20);
-            unsafe.putFloat(dataIb, unsafe.ARRAY_INT_BASE_OFFSET + 4 * i + 4, v21);
+            unsafe.putFloat(dataIb, ALIGNED_INT_BASE_OFFSET + 4 * i + 0, v20);
+            unsafe.putFloat(dataIb, ALIGNED_INT_BASE_OFFSET + 4 * i + 4, v21);
         }
     }
 


### PR DESCRIPTION
The change does two (related) things:
- It white-lists the UseCompactObjectHeaders flag in the IR testing framework. Without this, the flag would not be passed through to any IR framework test.
- That first change makes 3 tests fail. Those are all vectorization tests, and they are failing because 'small' array types (4-byte-elements and smaller) no longer have their elements aligned at 8-byte-boundaries. This throws off vectorization because this only kicks in on aligned accesses. The fix is to allocate those arrays a little larger and align-up the test data to the next 8-byte-boundary. (And no, Lilliput does not break vectorization in general, but it can change the characteristics in particular cases.)

Testing:
 - [x] compiler/c2/irTests/TestVectorizationMismatchedAccess.java +UCOH
 - [x] compiler/c2/irTests/TestVectorizationNotRun.java +UCOH
 - [x] compiler/loopopts/superword/TestIndependentPacksWithCyclicDependency.java +UCOH
 - [x] compiler/c2/irTests/TestVectorizationMismatchedAccess.java -UCOH
 - [x] compiler/c2/irTests/TestVectorizationNotRun.java -UCOH
 - [x] compiler/loopopts/superword/TestIndependentPacksWithCyclicDependency.java -UCOH
 - [x] tier1 +UCOH
 - [x] tier1 -UCOH

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8319185](https://bugs.openjdk.org/browse/JDK-8319185): [Lilliput] Enable and fix vectorization tests (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput.git pull/117/head:pull/117` \
`$ git checkout pull/117`

Update a local copy of the PR: \
`$ git checkout pull/117` \
`$ git pull https://git.openjdk.org/lilliput.git pull/117/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 117`

View PR using the GUI difftool: \
`$ git pr show -t 117`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput/pull/117.diff">https://git.openjdk.org/lilliput/pull/117.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput/pull/117#issuecomment-1820529081)