### PR TITLE
[Lilliput] Implement new Serial Full GC

### DIFF
--- a/src/hotspot/share/gc/serial/serialCompressor.cpp
+++ b/src/hotspot/share/gc/serial/serialCompressor.cpp
@@ -1,0 +1,443 @@
+
+#include "precompiled.hpp"
+
+#include "classfile/classLoaderData.hpp"
+#include "classfile/classLoaderDataGraph.hpp"
+#include "classfile/systemDictionary.hpp"
+#include "code/codeCache.hpp"
+#include "gc/serial/cardTableRS.hpp"
+#include "gc/serial/generation.hpp"
+#include "gc/serial/serialCompressor.hpp"
+#include "gc/serial/serialGcRefProcProxyTask.hpp"
+#include "gc/serial/serialHeap.hpp"
+#include "gc/shared/classUnloadingContext.hpp"
+#include "gc/shared/gcTrace.hpp"
+#include "gc/shared/gcTraceTime.inline.hpp"
+#include "gc/shared/markBitMap.inline.hpp"
+#include "gc/shared/referenceProcessor.hpp"
+#include "gc/shared/referenceProcessorPhaseTimes.hpp"
+#include "gc/shared/space.hpp"
+#include "gc/shared/strongRootsScope.hpp"
+#include "gc/shared/weakProcessor.hpp"
+#include "memory/iterator.hpp"
+#include "memory/universe.hpp"
+#include "oops/access.inline.hpp"
+#include "oops/compressedOops.inline.hpp"
+#include "utilities/copy.hpp"
+#include "utilities/stack.inline.hpp"
+
+#if INCLUDE_JVMCI
+#include "jvmci/jvmci.hpp"
+#endif
+
+SCBlockOffsetTable::SCBlockOffsetTable(MarkBitMap& mark_bitmap) :
+  _table(nullptr),
+  _mark_bitmap(mark_bitmap),
+  _covered(SerialHeap::heap()->reserved_region()) { }
+
+SCBlockOffsetTable::~SCBlockOffsetTable() {
+  FREE_C_HEAP_ARRAY(HeapWord*, _table);
+}
+
+inline size_t SCBlockOffsetTable::addr_to_block_idx(HeapWord* addr) const {
+  assert(addr >= _covered.start() && addr < _covered.end(), "address must be in heap");
+  return (addr - _covered.start()) / WORDS_PER_BLOCK;
+}
+
+void SCBlockOffsetTable::build_table_for_space(ContiguousSpace* space) {
+  HeapWord* start = space->bottom();
+  HeapWord* end = space->top();
+  size_t num_blocks = align_up(end - start, WORDS_PER_BLOCK) / WORDS_PER_BLOCK;
+  size_t start_block = addr_to_block_idx(start);
+  size_t end_block = start_block + num_blocks;
+  HeapWord* block_start = start;
+  HeapWord* compact_to = start;
+  for (size_t idx = start_block; idx < end_block; idx++) {
+    _table[idx] = compact_to;
+    size_t live_words_in_block = _mark_bitmap.count_marked_words_64(block_start);
+    compact_to += live_words_in_block;
+    block_start +=  WORDS_PER_BLOCK;
+  }
+}
+
+void SCBlockOffsetTable::build_table_for_generation(Generation* generation) {
+  ContiguousSpace* space = generation->first_compaction_space();
+  while (space != nullptr) {
+    build_table_for_space(space);
+    space = space->next_compaction_space();
+  }
+}
+
+void SCBlockOffsetTable::build_table() {
+  SerialHeap* heap = SerialHeap::heap();
+  HeapWord* start = _covered.start();
+  HeapWord* end = _covered.end();
+  size_t num_blocks = align_up(end - start, WORDS_PER_BLOCK) / WORDS_PER_BLOCK;
+  _table = NEW_C_HEAP_ARRAY(HeapWord*, num_blocks, mtGC);
+
+  build_table_for_generation(heap->young_gen());
+  build_table_for_generation(heap->old_gen());
+}
+
+inline HeapWord* SCBlockOffsetTable::forwardee(HeapWord* addr) const {
+  HeapWord* block_base = align_down(addr, WORDS_PER_BLOCK * BytesPerWord);
+  size_t block = addr_to_block_idx(addr);
+  return _table[block] + _mark_bitmap.count_marked_words(block_base, addr);
+}
+
+SerialCompressor::SerialCompressor(STWGCTimer* gc_timer):
+  _mark_bitmap(),
+  _marking_stack(),
+  _bot(_mark_bitmap),
+  _gc_timer(gc_timer),
+  _gc_tracer() {
+  SerialHeap* heap = SerialHeap::heap();
+  MemRegion reserved = heap->reserved_region();
+  size_t bitmap_size = MarkBitMap::compute_size(reserved.byte_size());
+  ReservedSpace bitmap(bitmap_size);
+  _mark_bitmap_region = MemRegion((HeapWord*) bitmap.base(), bitmap.size() / HeapWordSize);
+  os::commit_memory_or_exit((char *)_mark_bitmap_region.start(), _mark_bitmap_region.byte_size(), false,
+                            "Cannot commit bitmap memory");
+  _mark_bitmap.initialize(heap->reserved_region(), _mark_bitmap_region);
+}
+
+SerialCompressor::~SerialCompressor() {
+  os::release_memory((char*)_mark_bitmap_region.start(), _mark_bitmap_region.byte_size());
+}
+
+void SerialCompressor::invoke_at_safepoint(bool clear_all_softrefs) {
+  assert(SafepointSynchronize::is_at_safepoint(), "must be at a safepoint");
+
+  SerialHeap* gch = SerialHeap::heap();
+#ifdef ASSERT
+  if (gch->soft_ref_policy()->should_clear_all_soft_refs()) {
+    assert(clear_all_softrefs, "Policy should have been checked earlier");
+  }
+#endif
+
+  gch->trace_heap_before_gc(&_gc_tracer);
+
+  // Increment the invocation count
+  //_total_invocations++;
+
+  // Capture used regions for each generation that will be
+  // subject to collection, so that card table adjustments can
+  // be made intelligently (see clear / invalidate further below).
+  gch->save_used_regions();
+
+  phase1_mark(clear_all_softrefs);
+  phase2_build_bot();
+
+  // Don't add any more derived pointers during phase3
+#if COMPILER2_OR_JVMCI
+  assert(DerivedPointerTable::is_active(), "Sanity");
+  DerivedPointerTable::set_active(false);
+#endif
+
+  phase3_compact_and_update();
+
+  // Set saved marks for allocation profiler (and other things? -- dld)
+  // (Should this be in general part?)
+  gch->save_marks();
+
+  //MarkSweep::_string_dedup_requests->flush();
+
+  bool is_young_gen_empty = (gch->young_gen()->used() == 0);
+  gch->rem_set()->maintain_old_to_young_invariant(gch->old_gen(), is_young_gen_empty);
+
+  gch->prune_scavengable_nmethods();
+
+  // Update heap occupancy information which is used as
+  // input to soft ref clearing policy at the next gc.
+  Universe::heap()->update_capacity_and_used_at_gc();
+
+  // Signal that we have completed a visit to all live objects.
+  Universe::heap()->record_whole_heap_examined_timestamp();
+
+  gch->trace_heap_after_gc(&_gc_tracer);
+}
+
+template<class T>
+void SerialCompressor::mark_and_push(T* p) {
+  T heap_oop = RawAccess<>::oop_load(p);
+  if (!CompressedOops::is_null(heap_oop)) {
+    oop obj = CompressedOops::decode_not_null(heap_oop);
+    if (mark_object(obj)) {
+      _marking_stack.push(obj);
+    }
+  }
+}
+
+class SCMarkAndPushClosure: public ClaimMetadataVisitingOopIterateClosure {
+private:
+  SerialCompressor& _compressor;
+
+  template<typename T>
+  void do_oop_work(T* p) {
+    _compressor.mark_and_push(p);
+  }
+
+public:
+  SCMarkAndPushClosure(int claim, SerialCompressor& compressor) :
+    ClaimMetadataVisitingOopIterateClosure(claim),
+    _compressor(compressor) { }
+
+  void do_oop(oop* p)       { do_oop_work(p); }
+  void do_oop(narrowOop* p) { do_oop_work(p); }
+  void set_ref_discoverer(ReferenceDiscoverer* rd) { set_ref_discoverer_internal(rd); }
+};
+
+class SCFollowRootClosure: public BasicOopIterateClosure {
+private:
+  SerialCompressor& _compressor;
+
+  template<class T>
+  void follow_root(T* p) {
+    assert(!Universe::heap()->is_in(p),
+	   "roots shouldn't be things within the heap");
+    _compressor.mark_and_push(p);
+    _compressor.follow_stack();
+  }
+
+public:
+  SCFollowRootClosure(SerialCompressor& compressor) :
+    _compressor(compressor) { }
+
+  void do_oop(oop* p)       { follow_root(p); }
+  void do_oop(narrowOop* p) { follow_root(p); }
+};
+
+class SCFollowStackClosure: public VoidClosure {
+private:
+  SerialCompressor& _compressor;
+public:
+  SCFollowStackClosure(SerialCompressor& compressor) :
+    _compressor(compressor) { }
+  void do_void() {
+    _compressor.follow_stack();
+  }
+};
+
+class SCIsAliveClosure: public BoolObjectClosure {
+  MarkBitMap& _mark_bitmap;
+public:
+  SCIsAliveClosure(MarkBitMap& mark_bitmap) :
+    _mark_bitmap(mark_bitmap) { }
+  bool do_object_b(oop p) {
+    return _mark_bitmap.is_marked(p);
+  }
+};
+
+class SCKeepAliveClosure: public OopClosure {
+private:
+  SerialCompressor& _compressor;
+  template<class T>
+  void do_oop_work(T* p) {
+    _compressor.mark_and_push(p);
+  }
+public:
+  SCKeepAliveClosure(SerialCompressor& compressor) :
+    _compressor(compressor) { }
+  void do_oop(oop* p)       { do_oop_work(p); }
+  void do_oop(narrowOop* p) { do_oop_work(p); }
+};
+
+bool SerialCompressor::mark_object(oop obj) {
+  HeapWord* addr = cast_from_oop<HeapWord*>(obj);
+  if (!_mark_bitmap.is_marked(addr)) {
+    _mark_bitmap.mark_range(addr, obj->size());
+    return true;
+  } else {
+    return false;
+  }
+}
+
+void SerialCompressor::follow_object(oop obj) {
+  assert(_mark_bitmap.is_marked(obj), "p must be marked");
+  SCMarkAndPushClosure mark_and_push_closure(ClassLoaderData::_claim_stw_fullgc_mark, *this);
+  obj->oop_iterate(&mark_and_push_closure);
+}
+
+void SerialCompressor::follow_stack() {
+  do {
+    while (!_marking_stack.is_empty()) {
+      oop obj = _marking_stack.pop();
+      assert(_mark_bitmap.is_marked(obj), "p must be marked");
+      follow_object(obj);
+    }
+  } while (!_marking_stack.is_empty());
+}
+
+void SerialCompressor::phase1_mark(bool clear_all_softrefs) {
+  // Recursively traverse all live objects and mark them
+  GCTraceTime(Info, gc, phases) tm("Phase 1: Mark live objects", _gc_timer);
+
+  SerialHeap* gch = SerialHeap::heap();
+
+  ClassLoaderDataGraph::verify_claimed_marks_cleared(ClassLoaderData::_claim_stw_fullgc_mark);
+
+  AlwaysTrueClosure always_true_closure;
+  ReferenceProcessor ref_processor(&always_true_closure);
+  ref_processor.start_discovery(clear_all_softrefs);
+
+  {
+    StrongRootsScope srs(0);
+    SCMarkAndPushClosure mark_and_push_closure(ClassLoaderData::_claim_stw_fullgc_mark, *this);
+    CLDToOopClosure follow_cld_closure(&mark_and_push_closure, ClassLoaderData::_claim_stw_fullgc_mark);
+    SCFollowRootClosure follow_root_closure(*this);
+
+    CLDClosure* weak_cld_closure = ClassUnloading ? nullptr : &follow_cld_closure;
+    MarkingCodeBlobClosure mark_code_closure(&follow_root_closure, !CodeBlobToOopClosure::FixRelocations, true);
+    gch->process_roots(SerialHeap::SO_None,
+                       &follow_root_closure,
+                       &follow_cld_closure,
+                       weak_cld_closure,
+                       &mark_code_closure);
+  }
+
+  SCIsAliveClosure is_alive(_mark_bitmap);
+
+  // Process reference objects found during marking
+  {
+    GCTraceTime(Debug, gc, phases) tm_m("Reference Processing", _gc_timer);
+
+    SCKeepAliveClosure keep_alive(*this);
+    SCFollowStackClosure follow_stack_closure(*this);
+    ReferenceProcessorPhaseTimes pt(_gc_timer, ref_processor.max_num_queues());
+    SerialGCRefProcProxyTask task(is_alive, keep_alive, follow_stack_closure);
+    const ReferenceProcessorStats& stats = ref_processor.process_discovered_references(task, pt);
+    pt.print_all_references();
+    _gc_tracer.report_gc_reference_stats(stats);
+  }
+
+  // This is the point where the entire marking should have completed.
+  assert(_marking_stack.is_empty(), "Marking should have completed");
+
+  {
+    GCTraceTime(Debug, gc, phases) tm_m("Weak Processing", _gc_timer);
+    WeakProcessor::weak_oops_do(&is_alive, &do_nothing_cl);
+  }
+
+  {
+    GCTraceTime(Debug, gc, phases) tm_m("Class Unloading", _gc_timer);
+
+    ClassUnloadingContext* ctx = ClassUnloadingContext::context();
+
+    bool unloading_occurred;
+    {
+      CodeCache::UnlinkingScope scope(&is_alive);
+
+      // Unload classes and purge the SystemDictionary.
+      unloading_occurred = SystemDictionary::do_unloading(_gc_timer);
+
+      // Unload nmethods.
+      CodeCache::do_unloading(unloading_occurred);
+    }
+
+    {
+      GCTraceTime(Debug, gc, phases) t("Purge Unlinked NMethods", _gc_timer);
+      // Release unloaded nmethod's memory.
+      ctx->purge_nmethods();
+    }
+    {
+      GCTraceTime(Debug, gc, phases) t("Free Code Blobs", _gc_timer);
+      ctx->free_code_blobs();
+    }
+
+    // Prune dead klasses from subklass/sibling/implementor lists.
+    Klass::clean_weak_klass_links(unloading_occurred);
+
+    // Clean JVMCI metadata handles.
+    JVMCI_ONLY(JVMCI::do_unloading(unloading_occurred));
+  }
+
+  {
+    GCTraceTime(Debug, gc, phases) tm_m("Report Object Count", _gc_timer);
+    _gc_tracer.report_object_count_after_gc(&is_alive, nullptr);
+  }
+}
+
+void SerialCompressor::phase2_build_bot() {
+  GCTraceTime(Info, gc, phases) tm("Phase 2: Build block-offset-table", _gc_timer);
+  _bot.build_table();
+}
+
+class SCUpdateRefsClosure : public BasicOopIterateClosure {
+private:
+  SCBlockOffsetTable& _bot;
+
+  template<class T>
+  void do_oop_work(T* p) {
+    T heap_oop = RawAccess<>::oop_load(p);
+    if (!CompressedOops::is_null(heap_oop)) {
+      oop obj = CompressedOops::decode_raw_not_null(heap_oop);
+      assert(SerialHeap::heap()->is_in_reserved(obj), "should be in heap");
+      oop forwardee = cast_to_oop(_bot.forwardee(cast_from_oop<HeapWord*>(obj)));
+      RawAccess<IS_NOT_NULL>::oop_store(p, forwardee);
+    }
+  }
+public:
+  SCUpdateRefsClosure(SCBlockOffsetTable& bot) :
+    _bot(bot) {}
+
+  void do_oop(oop* p) {
+    do_oop_work(p);
+  }
+  void do_oop(narrowOop* p) {
+    do_oop_work(p);
+  }
+};
+
+void SerialCompressor::compact_and_update_space(ContiguousSpace* space) {
+  HeapWord* start = space->bottom();
+  HeapWord* end = space->top();
+  HeapWord* current = _mark_bitmap.get_next_marked_addr(start, end);
+  HeapWord* new_top = start;
+  SCUpdateRefsClosure cl(_bot);
+  HeapWord* next_fwd = start;
+  while (current < end) {
+    oop obj = cast_to_oop(current);
+    assert(oopDesc::is_oop(obj), "must be oop");
+    size_t size_in_words = obj->size();
+    obj->oop_iterate(&cl);
+    HeapWord* forwardee = _bot.forwardee(current);
+    assert(next_fwd == forwardee, "incorrect forwarwdee");
+    next_fwd = forwardee + size_in_words;
+    if (current != forwardee) {
+      Copy::aligned_conjoint_words(current, forwardee, size_in_words);
+    }
+    current = _mark_bitmap.get_next_marked_addr(current + size_in_words, end);
+    new_top += size_in_words;
+  }
+  space->set_top(new_top);
+}
+
+void SerialCompressor::compact_and_update_generation(Generation* generation) {
+  ContiguousSpace* space = generation->first_compaction_space();
+  while (space != nullptr) {
+    compact_and_update_space(space);
+    space = space->next_compaction_space();
+  }
+}
+
+void SerialCompressor::update_roots() {
+  SerialHeap* heap = SerialHeap::heap();
+  SCUpdateRefsClosure adjust_pointer_closure(_bot);
+  CLDToOopClosure adjust_cld_closure(&adjust_pointer_closure, ClassLoaderData::_claim_stw_fullgc_adjust);
+  CodeBlobToOopClosure code_closure(&adjust_pointer_closure, CodeBlobToOopClosure::FixRelocations);
+  heap->process_roots(SerialHeap::SO_AllCodeCache,
+                      &adjust_pointer_closure,
+                      &adjust_cld_closure,
+                      &adjust_cld_closure,
+                      &code_closure);
+
+  heap->gen_process_weak_roots(&adjust_pointer_closure);
+}
+
+void SerialCompressor::phase3_compact_and_update() {
+  GCTraceTime(Info, gc, phases) tm("Phase 3: Compact heap", _gc_timer);
+  update_roots();
+  SerialHeap* heap = SerialHeap::heap();
+  compact_and_update_generation(heap->young_gen());
+  compact_and_update_generation(heap->old_gen());
+}

--- a/src/hotspot/share/gc/serial/serialCompressor.hpp
+++ b/src/hotspot/share/gc/serial/serialCompressor.hpp
@@ -1,0 +1,72 @@
+
+#ifndef SHARE_GC_SERIAL_SERIALCOMPRESSOR_HPP
+#define SHARE_GC_SERIAL_SERIALCOMPRESSOR_HPP
+
+#include "gc/shared/gcTrace.hpp"
+#include "gc/shared/markBitMap.hpp"
+#include "memory/allocation.hpp"
+#include "memory/iterator.hpp"
+#include "utilities/stack.hpp"
+
+class Generation;
+class Space;
+class STWGCTimer;
+
+class SCBlockOffsetTable {
+private:
+  static const int WORDS_PER_BLOCK = 64;
+
+  HeapWord** _table;
+  MarkBitMap& _mark_bitmap;
+  MemRegion _covered;
+
+  inline size_t addr_to_block_idx(HeapWord* addr) const;
+
+  void build_table_for_space(ContiguousSpace* space);
+  void build_table_for_generation(Generation* generation);
+
+public:
+  SCBlockOffsetTable(MarkBitMap& mark_bitmap);
+  ~SCBlockOffsetTable();
+
+  void build_table();
+
+  inline HeapWord* forwardee(HeapWord* addr) const;
+};
+
+class SerialCompressor : public StackObj {
+private:
+
+  MemRegion  _mark_bitmap_region;
+  MarkBitMap _mark_bitmap;
+  Stack<oop,mtGC> _marking_stack;
+
+  SCBlockOffsetTable _bot;
+
+  STWGCTimer* _gc_timer;
+  SerialOldTracer _gc_tracer;
+
+  void phase1_mark(bool clear_all_softrefs);
+  void phase2_build_bot();
+  void phase3_compact_and_update();
+
+  bool mark_object(oop obj);
+  void follow_object(oop obj);
+
+  void update_roots();
+  void compact_and_update_space(ContiguousSpace* space);
+  void compact_and_update_generation(Generation* generation);
+
+public:
+  SerialCompressor(STWGCTimer* gc_timer);
+  ~SerialCompressor();
+
+  // TODO: better scoping?
+  void follow_stack();
+  template<class T>
+  void mark_and_push(T* p);
+
+  void invoke_at_safepoint(bool clear_all_softrefs);
+};
+
+#endif // SHARE_GC_SERIAL_SERIALCOMPRESSOR_HPP

--- a/src/hotspot/share/gc/serial/tenuredGeneration.cpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.cpp
@@ -26,6 +26,7 @@
 #include "gc/serial/cardTableRS.hpp"
 #include "gc/serial/genMarkSweep.hpp"
 #include "gc/serial/serialBlockOffsetTable.inline.hpp"
+#include "gc/serial/serialCompressor.hpp"
 #include "gc/serial/serialHeap.hpp"
 #include "gc/serial/tenuredGeneration.inline.hpp"
 #include "gc/shared/collectorCounters.hpp"
@@ -434,7 +435,12 @@ void TenuredGeneration::collect(bool   full,
 
   gch->pre_full_gc_dump(gc_timer);
 
-  GenMarkSweep::invoke_at_safepoint(clear_all_soft_refs);
+  if (UseCompressorFullGC) {
+    SerialCompressor full_gc = SerialCompressor(gc_timer);
+    full_gc.invoke_at_safepoint(clear_all_soft_refs);
+  } else {
+    GenMarkSweep::invoke_at_safepoint(clear_all_soft_refs);
+  }
 
   gch->post_full_gc_dump(gc_timer);
 

--- a/src/hotspot/share/gc/shared/gc_globals.hpp
+++ b/src/hotspot/share/gc/shared/gc_globals.hpp
@@ -696,6 +696,9 @@
                                                                             \
   product(bool, UseAltGCForwarding, false, EXPERIMENTAL,                    \
           "Use alternative GC forwarding that preserves object headers")    \
+                                                                            \
+  product(bool, UseCompressorFullGC, false, EXPERIMENTAL,                   \
+          "Use compressor-style full GC")                                   \
 
 // end of GC_FLAGS
 

--- a/src/hotspot/share/gc/shared/markBitMap.hpp
+++ b/src/hotspot/share/gc/shared/markBitMap.hpp
@@ -94,10 +94,19 @@ public:
   inline bool par_mark(HeapWord* addr);
   inline bool par_mark(oop obj);
 
+  inline void mark_range(HeapWord* addr, size_t num_words);
+
   // Clear bitmap.
   void clear()                         { do_clear(_covered, true); }
   void clear_range(MemRegion mr)       { do_clear(mr, false);      }
   void clear_range_large(MemRegion mr) { do_clear(mr, true);       }
+
+  // Count the number of marked words in the range [start, start+64).
+  // NOTE: start must be the beginning of a 64-word region, such
+  // that a single 64-bit word in the marking bitmap covers the
+  // region.
+  inline size_t count_marked_words_64(HeapWord* start) const;
+  inline size_t count_marked_words(HeapWord* start, HeapWord* end) const;
 };
 
 #endif // SHARE_GC_SHARED_MARKBITMAP_HPP

--- a/src/hotspot/share/gc/shared/markBitMap.inline.hpp
+++ b/src/hotspot/share/gc/shared/markBitMap.inline.hpp
@@ -52,6 +52,12 @@ inline void MarkBitMap::mark(oop obj) {
   return mark(cast_from_oop<HeapWord*>(obj));
 }
 
+inline void MarkBitMap::mark_range(HeapWord* addr, size_t num_words) {
+  size_t beg = addr_to_offset(addr);
+  size_t end = addr_to_offset(addr + num_words);
+  _bm.set_range(beg, end);
+}
+
 inline void MarkBitMap::clear(HeapWord* addr) {
   check_mark(addr);
   _bm.clear_bit(addr_to_offset(addr));
@@ -72,6 +78,14 @@ inline bool MarkBitMap::is_marked(oop obj) const{
 
 inline void MarkBitMap::clear(oop obj) {
   clear(cast_from_oop<HeapWord*>(obj));
+}
+
+inline size_t MarkBitMap::count_marked_words_64(HeapWord* start) const {
+  return _bm.count_one_bits_within_aligned_word(addr_to_offset(start));
+}
+
+inline size_t MarkBitMap::count_marked_words(HeapWord* start, HeapWord* end) const {
+  return _bm.count_one_bits_within_word(addr_to_offset(start), addr_to_offset(end));
 }
 
 #endif // SHARE_GC_SHARED_MARKBITMAP_INLINE_HPP

--- a/src/hotspot/share/utilities/bitMap.cpp
+++ b/src/hotspot/share/utilities/bitMap.cpp
@@ -29,7 +29,6 @@
 #include "utilities/bitMap.inline.hpp"
 #include "utilities/copy.hpp"
 #include "utilities/debug.hpp"
-#include "utilities/population_count.hpp"
 
 using bm_word_t = BitMap::bm_word_t;
 using idx_t = BitMap::idx_t;
@@ -602,17 +601,6 @@ BitMap::idx_t BitMap::count_one_bits_in_range_of_words(idx_t beg_full_word, idx_
     sum += population_count(w);
   }
   return sum;
-}
-
-BitMap::idx_t BitMap::count_one_bits_within_word(idx_t beg, idx_t end) const {
-  if (beg != end) {
-    assert(end > beg, "must be");
-    bm_word_t mask = ~inverted_bit_mask_for_range(beg, end);
-    bm_word_t w = *word_addr(beg);
-    w &= mask;
-    return population_count(w);
-  }
-  return 0;
 }
 
 BitMap::idx_t BitMap::count_one_bits() const {

--- a/src/hotspot/share/utilities/bitMap.hpp
+++ b/src/hotspot/share/utilities/bitMap.hpp
@@ -174,8 +174,9 @@ class BitMap {
   void      clear_large_range_of_words (idx_t beg, idx_t end);
 
   static void clear_range_of_words(bm_word_t* map, idx_t beg, idx_t end);
-
-  idx_t count_one_bits_within_word(idx_t beg, idx_t end) const;
+public:
+  inline idx_t count_one_bits_within_word(idx_t beg, idx_t end) const;
+protected:
   idx_t count_one_bits_in_range_of_words(idx_t beg_full_word, idx_t end_full_word) const;
 
   // Set the map and size.
@@ -354,6 +355,8 @@ class BitMap {
   // Like "find_last_set_bit", except requires that "beg" is
   // aligned to bitsizeof(bm_word_t).
   idx_t find_last_set_bit_aligned_left(idx_t beg, idx_t end) const;
+
+  inline idx_t count_one_bits_within_aligned_word(idx_t beg) const;
 
   // Returns the number of bits set in the bitmap.
   idx_t count_one_bits() const;

--- a/src/hotspot/share/utilities/bitMap.inline.hpp
+++ b/src/hotspot/share/utilities/bitMap.inline.hpp
@@ -31,6 +31,7 @@
 #include "utilities/align.hpp"
 #include "utilities/count_trailing_zeros.hpp"
 #include "utilities/powerOfTwo.hpp"
+#include "utilities/population_count.hpp"
 
 inline void BitMap::set_bit(idx_t bit) {
   verify_index(bit);
@@ -585,5 +586,23 @@ inline void BitMap2D::at_put_grow(idx_t slot_index, idx_t bit_within_slot_index,
   }
   _map.at_put(bit, value);
 }
+
+inline BitMap::idx_t BitMap::count_one_bits_within_aligned_word(idx_t idx) const {
+  assert(is_aligned(idx, BitsPerWord), "idx must be word-aligned");
+  bm_word_t w = *word_addr(idx);
+  return population_count(w); //__builtin_popcountll(w);  //std::bitset<8>(w).count();
+}
+
+inline BitMap::idx_t BitMap::count_one_bits_within_word(idx_t beg, idx_t end) const {
+  if (beg != end) {
+    assert(end > beg, "must be");
+    bm_word_t mask = ~inverted_bit_mask_for_range(beg, end);
+    bm_word_t w = *word_addr(beg);
+    w &= mask;
+    return population_count(w); //__builtin_popcountll(w); //std::bitset<8>(w).count();
+  }
+  return 0;
+}
+
 
 #endif // SHARE_UTILITIES_BITMAP_INLINE_HPP


### PR DESCRIPTION
This implements a compressor-style compacting full-GC for the Serial GC, which does not require storing any forwarding pointers in object headers.