### PR TITLE
8326752: Lilliput: OMCache: Add cache lookup unrolling

### DIFF
--- a/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.cpp
@@ -574,18 +574,17 @@ void C2_MacroAssembler::fast_lock_placeholder(Register obj, Register box, Regist
       // Load cache address
       lea(t, Address(rthread, JavaThread::om_cache_oops_offset()));
 
-      const int num_unrolled = OMC2UnrollCacheLookup ? MIN2(OMC2UnrollCacheEntries, OMCacheSize) : 0;
-      if (OMC2UnrollCacheLookup) {
-        for (int i = 0; i < num_unrolled; i++) {
-          ldr(t1, Address(t));
-          cmp(obj, t1);
-          br(Assembler::EQ, monitor_found);
-          if (i + 1 != num_unrolled) {
-            increment(t, in_bytes(OMCache::oop_to_oop_difference()));
-          }
+      const int num_unrolled = MIN2(OMC2UnrollCacheEntries, OMCacheSize);
+      for (int i = 0; i < num_unrolled; i++) {
+        ldr(t1, Address(t));
+        cmp(obj, t1);
+        br(Assembler::EQ, monitor_found);
+        if (i + 1 != num_unrolled) {
+          increment(t, in_bytes(OMCache::oop_to_oop_difference()));
         }
       }
-      if (!OMC2UnrollCacheLookup || (OMC2UnrollCacheLookupLoopTail && num_unrolled != OMCacheSize)) {
+
+      if (num_unrolled == 0 || (OMC2UnrollCacheLookupLoopTail && num_unrolled != OMCacheSize)) {
         if (num_unrolled != 0) {
           // Loop after unrolling, advance iterator.
           increment(t, in_bytes(OMCache::oop_to_oop_difference()));

--- a/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.cpp
@@ -561,73 +561,96 @@ void C2_MacroAssembler::fast_lock_placeholder(Register obj, Register box, Regist
   { // Handle inflated monitor.
     bind(inflated);
 
-  if (!OMUseC2Cache) {
-    // Set Flags == NE
-    cmp(zr, obj);
-    b(slow_path);
-  } else {
-
-    if (OMCacheHitRate) increment(Address(rthread, JavaThread::lock_lookup_offset()));
-
-    Label monitor_found, loop;
-    // Load cache address
-    lea(t, Address(rthread, JavaThread::om_cache_oops_offset()));
-
-    // Search for obj in cache.
-    bind(loop);
-
-    // Check for match.
-    ldr(t1, Address(t));
-    cmp(obj, t1);
-    br(Assembler::EQ, monitor_found);
-
-    // Search until null encountered, guaranteed _null_sentinel at end.
-    increment(t, oopSize);
-    cbnz(t1, loop);
-    // Cache Miss, NE set from cmp above, cbnz does not set flags
-    b(slow_path);
-
-    bind(monitor_found);
-    ldr(t1, Address(t, OMCache::oop_to_monitor_difference()));
-    if (OMCacheHitRate) increment(Address(rthread, JavaThread::lock_hit_offset()));
-
-    // ObjectMonitor* is in t1
-    const Register monitor = t1;
-    const Register owner_addr = t2;
-    const Register owner = t3;
-
-    Label recursive;
-    Label monitor_locked;
-
-    // Compute owner address.
-    lea(owner_addr, Address(monitor, ObjectMonitor::owner_offset()));
-
-    if (OMRecursiveFastPath) {
-      ldr(owner, Address(owner_addr));
-      cmp(owner, rthread);
-      br(Assembler::EQ, recursive);
-    }
-
-    // CAS owner (null => current thread).
-    cmpxchg(owner_addr, zr, rthread, Assembler::xword, /*acquire*/ true,
-            /*release*/ false, /*weak*/ false, owner);
-    br(Assembler::EQ, monitor_locked);
-
-    if (OMRecursiveFastPath) {
+    if (!OMUseC2Cache) {
+      // Set Flags == NE
+      cmp(zr, obj);
       b(slow_path);
     } else {
-      // Check if recursive.
-      cmp(owner, rthread);
-      br(Assembler::NE, slow_path);
+
+      if (OMCacheHitRate) increment(Address(rthread, JavaThread::lock_lookup_offset()));
+
+      Label monitor_found;
+
+      // Load cache address
+      lea(t, Address(rthread, JavaThread::om_cache_oops_offset()));
+
+      const int num_unrolled = OMC2UnrollCacheLookup ? MIN2(OMC2UnrollCacheEntires, OMCacheSize) : 0;
+      if (OMC2UnrollCacheLookup) {
+        for (int i = 0; i < num_unrolled; i++) {
+          ldr(t1, Address(t));
+          cmp(obj, t1);
+          br(Assembler::EQ, monitor_found);
+          if (i + 1 != num_unrolled) {
+            increment(t, in_bytes(OMCache::oop_to_oop_difference()));
+          }
+        }
+      }
+      if (!OMC2UnrollCacheLookup || (OMC2UnrollCacheLookupLoopTail && num_unrolled != OMCacheSize)) {
+        if (num_unrolled != 0) {
+          // Loop after unrolling, advance iterator.
+          increment(t, in_bytes(OMCache::oop_to_oop_difference()));
+        }
+
+        Label loop;
+
+        // Search for obj in cache.
+        bind(loop);
+
+        // Check for match.
+        ldr(t1, Address(t));
+        cmp(obj, t1);
+        br(Assembler::EQ, monitor_found);
+
+        // Search until null encountered, guaranteed _null_sentinel at end.
+        increment(t, in_bytes(OMCache::oop_to_oop_difference()));
+        cbnz(t1, loop);
+        // Cache Miss, NE set from cmp above, cbnz does not set flags
+        b(slow_path);
+      } else {
+        b(slow_path);
+      }
+
+      bind(monitor_found);
+      ldr(t1, Address(t, OMCache::oop_to_monitor_difference()));
+      if (OMCacheHitRate) increment(Address(rthread, JavaThread::lock_hit_offset()));
+
+      // ObjectMonitor* is in t1
+      const Register monitor = t1;
+      const Register owner_addr = t2;
+      const Register owner = t3;
+
+      Label recursive;
+      Label monitor_locked;
+
+      // Compute owner address.
+      lea(owner_addr, Address(monitor, ObjectMonitor::owner_offset()));
+
+      if (OMRecursiveFastPath) {
+        ldr(owner, Address(owner_addr));
+        cmp(owner, rthread);
+        br(Assembler::EQ, recursive);
+      }
+
+      // CAS owner (null => current thread).
+      cmpxchg(owner_addr, zr, rthread, Assembler::xword, /*acquire*/ true,
+              /*release*/ false, /*weak*/ false, owner);
+      br(Assembler::EQ, monitor_locked);
+
+      if (OMRecursiveFastPath) {
+        b(slow_path);
+      } else {
+        // Check if recursive.
+        cmp(owner, rthread);
+        br(Assembler::NE, slow_path);
+      }
+
+      // Recursive.
+      bind(recursive);
+      increment(Address(monitor, ObjectMonitor::recursions_offset()), 1);
+
+      bind(monitor_locked);
+      str(monitor, Address(box, BasicLock::displaced_header_offset_in_bytes()));
     }
-
-    // Recursive.
-    bind(recursive);
-    increment(Address(monitor, ObjectMonitor::recursions_offset()), 1);
-
-    bind(monitor_locked);
-    str(monitor, Address(box, BasicLock::displaced_header_offset_in_bytes()));
-  }
 
   }
 

--- a/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.cpp
@@ -574,7 +574,7 @@ void C2_MacroAssembler::fast_lock_placeholder(Register obj, Register box, Regist
       // Load cache address
       lea(t, Address(rthread, JavaThread::om_cache_oops_offset()));
 
-      const int num_unrolled = OMC2UnrollCacheLookup ? MIN2(OMC2UnrollCacheEntires, OMCacheSize) : 0;
+      const int num_unrolled = OMC2UnrollCacheLookup ? MIN2(OMC2UnrollCacheEntries, OMCacheSize) : 0;
       if (OMC2UnrollCacheLookup) {
         for (int i = 0; i < num_unrolled; i++) {
           ldr(t1, Address(t));

--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
@@ -1263,7 +1263,7 @@ void C2_MacroAssembler::fast_lock_placeholder(Register obj, Register box, Regist
       // Load cache address
       lea(t, Address(thread, JavaThread::om_cache_oops_offset()));
 
-      const int num_unrolled = OMC2UnrollCacheLookup ? MIN2(OMC2UnrollCacheEntires, OMCacheSize) : 0;
+      const int num_unrolled = OMC2UnrollCacheLookup ? MIN2(OMC2UnrollCacheEntries, OMCacheSize) : 0;
       if (OMC2UnrollCacheLookup) {
         for (int i = 0; i < num_unrolled; i++) {
           cmpptr(obj, Address(t));

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1994,7 +1994,7 @@ const int ObjectAlignmentInBytes = 8;
                                                                             \
   product(bool, OMC2UnrollCacheLookupLoopTail, true, "")                    \
                                                                             \
-  product(int, OMC2UnrollCacheEntires, 8, "")                               \
+  product(int, OMC2UnrollCacheEntries, 8, "")                               \
           range(0, OMCache::CAPACITY)                                       \
                                                                             \
   product(int, OMCacheSize, 8, "")                                          \

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1990,6 +1990,13 @@ const int ObjectAlignmentInBytes = 8;
                                                                             \
   product(bool, OMUseC2Cache, true, "")                                     \
                                                                             \
+  product(bool, OMC2UnrollCacheLookup, false, "")                           \
+                                                                            \
+  product(bool, OMC2UnrollCacheLookupLoopTail, true, "")                    \
+                                                                            \
+  product(int, OMC2UnrollCacheEntires, 8, "")                               \
+          range(0, OMCache::CAPACITY)                                       \
+                                                                            \
   product(int, OMCacheSize, 8, "")                                          \
           range(0, OMCache::CAPACITY)                                       \
                                                                             \

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1990,11 +1990,9 @@ const int ObjectAlignmentInBytes = 8;
                                                                             \
   product(bool, OMUseC2Cache, true, "")                                     \
                                                                             \
-  product(bool, OMC2UnrollCacheLookup, false, "")                           \
-                                                                            \
   product(bool, OMC2UnrollCacheLookupLoopTail, true, "")                    \
                                                                             \
-  product(int, OMC2UnrollCacheEntries, 8, "")                               \
+  product(int, OMC2UnrollCacheEntries, 0, "")                               \
           range(0, OMCache::CAPACITY)                                       \
                                                                             \
   product(int, OMCacheSize, 8, "")                                          \

--- a/src/hotspot/share/runtime/lockStack.hpp
+++ b/src/hotspot/share/runtime/lockStack.hpp
@@ -147,6 +147,7 @@ private:
 public:
   static ByteSize oops_offset() { return byte_offset_of(OMCache, _oops); }
   static ByteSize monitors_offset() { return byte_offset_of(OMCache, _monitors); }
+  static ByteSize oop_to_oop_difference() { return in_ByteSize(sizeof(oop)); }
   static ByteSize oop_to_monitor_difference() { return monitors_offset() - oops_offset(); }
 
   explicit OMCache(JavaThread* jt) : _oops(), _null_sentinel(nullptr), _monitors() {};

--- a/test/micro/org/openjdk/bench/vm/lang/LockUnlock.java
+++ b/test/micro/org/openjdk/bench/vm/lang/LockUnlock.java
@@ -55,6 +55,7 @@ public class LockUnlock {
     public Object lockObject1;
     public Object lockObject2;
     public volatile Object lockObject3Inflated;
+    public volatile Object lockObject4Inflated;
     public int factorial;
     public int dummyInt1;
     public int dummyInt2;
@@ -64,11 +65,15 @@ public class LockUnlock {
         lockObject1 = new Object();
         lockObject2 = new Object();
         lockObject3Inflated = new Object();
+        lockObject4Inflated = new Object();
 
         // Inflate the lock to use an ObjectMonitor
         try {
           synchronized (lockObject3Inflated) {
             lockObject3Inflated.wait(1);
+          }
+          synchronized (lockObject4Inflated) {
+            lockObject4Inflated.wait(1);
           }
         } catch (InterruptedException e) {
           throw new RuntimeException(e);
@@ -201,6 +206,32 @@ public class LockUnlock {
             }
             synchronized (lockObject3Inflated) {
                 dummyInt2++;
+            }
+        }
+    }
+
+    /** Perform two synchronized after each other on the same object. */
+    @Benchmark
+    public void testInflatedMultipleSerialLockUnlock() {
+        for (int i = 0; i < innerCount; i++) {
+            synchronized (lockObject3Inflated) {
+                dummyInt1++;
+            }
+            synchronized (lockObject4Inflated) {
+                dummyInt2++;
+            }
+        }
+    }
+
+    /** Perform two synchronized after each other on the same object. */
+    @Benchmark
+    public void testInflatedMultipleRecursiveLockUnlock() {
+        for (int i = 0; i < innerCount; i++) {
+            synchronized (lockObject3Inflated) {
+                dummyInt1++;
+                synchronized (lockObject4Inflated) {
+                    dummyInt2++;
+                }
             }
         }
     }


### PR DESCRIPTION
Implement unrolling of OM cache lookups in C2 so experiments and an evaluation can be performed.

Adds `OMC2UnrollCacheLookup`, `OMC2UnrollCacheLookupLoopTail` and `OMC2UnrollCacheEntires` flags which can be tuned cache lookup unrolling in C2. 

`OMC2UnrollCacheLookup` will unroll up to `OMC2UnrollCacheEntires` (depending on `OMCacheSize`) and if `OMC2UnrollCacheLookupLoopTail` is set and entries are left the rest of the cache will be checked.

All of these flags are temporary to allow for evaluation of the cache lookup in C2 (size and unrolling). See issue JDK-8326759

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326752](https://bugs.openjdk.org/browse/JDK-8326752): Lilliput: OMCache: Add cache lookup unrolling (**Sub-task** - P4)


### Reviewers
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput.git pull/139/head:pull/139` \
`$ git checkout pull/139`

Update a local copy of the PR: \
`$ git checkout pull/139` \
`$ git pull https://git.openjdk.org/lilliput.git pull/139/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 139`

View PR using the GUI difftool: \
`$ git pr show -t 139`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput/pull/139.diff">https://git.openjdk.org/lilliput/pull/139.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput/pull/139#issuecomment-1966118762)