### PR TITLE
8326823: Lilliput: OMWorld: Separate NMT category

### DIFF
--- a/src/hotspot/share/memory/allocation.hpp
+++ b/src/hotspot/share/memory/allocation.hpp
@@ -130,6 +130,7 @@ typedef AllocFailStrategy::AllocFailEnum AllocFailType;
   f(mtMetaspace,      "Metaspace")                                                   \
   f(mtStringDedup,    "String Deduplication")                                        \
   f(mtObjectMonitor,  "Object Monitors")                                             \
+  f(mtOMWorld,        "OM World")                                                    \
   f(mtNone,           "Unknown")                                                     \
   //end
 

--- a/src/hotspot/share/runtime/placeholderSynchronizer.cpp
+++ b/src/hotspot/share/runtime/placeholderSynchronizer.cpp
@@ -52,20 +52,20 @@
 //
 
 // ConcurrentHashTable storing links from objects to ObjectMonitors
-class ObjectMonitorWorld : public CHeapObj<mtThread> {
+class ObjectMonitorWorld : public CHeapObj<mtOMWorld> {
   struct Config {
     using Value = ObjectMonitor*;
     static uintx get_hash(Value const& value, bool* is_dead) {
       return (uintx)value->hash_placeholder();
     }
     static void* allocate_node(void* context, size_t size, Value const& value) {
-      return AllocateHeap(size, mtThread);
+      return AllocateHeap(size, mtOMWorld);
     };
     static void free_node(void* context, void* memory, Value const& value) {
       FreeHeap(memory);
     }
   };
-  using ConcurrentTable = ConcurrentHashTable<Config, mtThread>;
+  using ConcurrentTable = ConcurrentHashTable<Config, mtOMWorld>;
 
   ConcurrentTable* _table;
   volatile bool _resize;


### PR DESCRIPTION
Currently, the OMWorld table uses mtThread NMT category, which seems very wrong. We could instead add it into the mtObjectMonitor or mtSynchronizer categories, but I think it would be more useful to give the table its own category, for measuring overhead and also compare it to ObjectSynchronizer.

Example NMT output would look like:

```
-           Object Monitors (reserved=1750823568, committed=1750823568)
                           (malloc=1750823568 #8417421) (peak=1958719776 #9416922)
-                  OM World (reserved=151456088, committed=151456088)
                           (malloc=151456088 #8417425) (peak=152173976 #8462293)

```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326823](https://bugs.openjdk.org/browse/JDK-8326823): Lilliput: OMWorld: Separate NMT category (**Enhancement** - P4)


### Reviewers
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput.git pull/141/head:pull/141` \
`$ git checkout pull/141`

Update a local copy of the PR: \
`$ git checkout pull/141` \
`$ git pull https://git.openjdk.org/lilliput.git pull/141/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 141`

View PR using the GUI difftool: \
`$ git pr show -t 141`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput/pull/141.diff">https://git.openjdk.org/lilliput/pull/141.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput/pull/141#issuecomment-1966272337)