### PR TITLE
Parallel: modify to-space object in array chunking

### DIFF
--- a/src/hotspot/share/oops/oop.cpp
+++ b/src/hotspot/share/oops/oop.cpp
@@ -219,14 +219,3 @@ void oopDesc::release_float_field_put(int offset, jfloat value)       { Atomic::
 
 jdouble oopDesc::double_field_acquire(int offset) const               { return Atomic::load_acquire(field_addr<jdouble>(offset)); }
 void oopDesc::release_double_field_put(int offset, jdouble value)     { Atomic::release_store(field_addr<jdouble>(offset), value); }
-
-#ifdef ASSERT
-bool oopDesc::size_might_change() {
-  // UseParallelGC and UseG1GC can change the length field
-  // of an "old copy" of an object array in the young gen so it indicates
-  // the grey portion of an already copied array. This will cause the first
-  // disjunct below to fail if the two comparands are computed across such
-  // a concurrent change.
-  return Universe::heap()->is_gc_active() && is_objArray() && is_forwarded() && (UseParallelGC || UseG1GC);
-}
-#endif

--- a/src/hotspot/share/oops/oop.hpp
+++ b/src/hotspot/share/oops/oop.hpp
@@ -378,8 +378,6 @@ public:
 
   // for error reporting
   static void* load_oop_raw(oop obj, int offset);
-
-  DEBUG_ONLY(bool size_might_change();)
 };
 
 // An oopDesc is not initialized via a constructor.  Space is allocated in

--- a/src/hotspot/share/oops/oop.inline.hpp
+++ b/src/hotspot/share/oops/oop.inline.hpp
@@ -213,7 +213,7 @@ size_t oopDesc::size_given_klass(Klass* klass)  {
       // skipping the intermediate round to HeapWordSize.
       s = align_up(size_in_bytes, MinObjAlignmentInBytes) / HeapWordSize;
 
-      assert(s == klass->oop_size(this) || size_might_change(), "wrong array object size");
+      assert(s == klass->oop_size(this), "wrong array object size");
     } else {
       // Must be zero, so bite the bullet and take the virtual call.
       s = klass->oop_size(this);


### PR DESCRIPTION
The ParallelGC chunks arrays so that it can somewhat parallelize the array processing. This is done by rewriting the length field of the from-space object. This causes a problem for Lilliput when one thread copies an object, forwards it, and then rewrites the length of the from-space copy, while another thread tries to figure out if it should copy the object and tries to read the size of the object.

The second thread tries to stay away from calling `oopDesc::klass()` on the from-space object, because the header might have been overwritten by another thread. So, it only reads the mark word, tries to figure out the object has been forwarded, and then calls `size_given_klass` to figure out the size.

The `size_given_klass` has some asserts that checks that the different ways to calculate array sizes are consistent, but since other threads could be updating the length field, there is an escape-hatch that makes that assert less strict. This is the assert:
```
assert(s == klass->oop_size(this) || size_might_change(), "wrong array object size");
```

The problem for Lilliput is that `size_might_change()` rereads the object's klass pointer, which will fail because the header is overwritten with a forwarding pointer.

This can be fixed by passing in the klass or maybe by following the forwarding pointer to find the to-space object and find the klass from there, but I wonder if this all wouldn't be safer if we left the from-space object unmodified and instead changed the length field of the to-space object. In fact, this is exactly what G1 does since many years (which also indicates that the `size_might_change()` really shouldn't be checking for UseG1GC).

The above is a proposal of what this would look like. I'm publishing this here for Lilliput because it fixes a real bug here, but if this is the right way to go forward, then this should likely be upstreamed as well.

I've run this through tier1-3 with both UseParallelGC and UseCompactObjectHeaders enabled, and I'm currently running this through higher Oracle tiers.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput.git pull/149/head:pull/149` \
`$ git checkout pull/149`

Update a local copy of the PR: \
`$ git checkout pull/149` \
`$ git pull https://git.openjdk.org/lilliput.git pull/149/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 149`

View PR using the GUI difftool: \
`$ git pr show -t 149`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput/pull/149.diff">https://git.openjdk.org/lilliput/pull/149.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput/pull/149#issuecomment-2066659531)