### PR TITLE
JVMCI: Don't call CompressedKlassPointers functions with -UCCP

### DIFF
--- a/src/hotspot/share/jvmci/jvmciCompilerToVMInit.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVMInit.cpp
@@ -177,8 +177,14 @@ void CompilerToVM::Data::initialize(JVMCI_TRAPS) {
   Universe_base_vtable_size = Universe::base_vtable_size();
   Universe_narrow_oop_base = CompressedOops::base();
   Universe_narrow_oop_shift = CompressedOops::shift();
-  Universe_narrow_klass_base = CompressedKlassPointers::base();
-  Universe_narrow_klass_shift = CompressedKlassPointers::shift();
+  if (UseCompressedClassPointers) {
+    Universe_narrow_klass_base = CompressedKlassPointers::base();
+    Universe_narrow_klass_shift = CompressedKlassPointers::shift();
+  } else {
+    // TODO: Do we need to set these when running without compressed class pointers?
+    Universe_narrow_klass_base = 0;
+    Universe_narrow_klass_shift = 0;
+  }
   Universe_non_oop_bits = Universe::non_oop_word();
   Universe_verify_oop_mask = Universe::verify_oop_mask();
   Universe_verify_oop_bits = Universe::verify_oop_bits();


### PR DESCRIPTION
We hit this assert when running JVMCI tests and -XX:-UseCompressedClassPointers:
```
#  Internal Error (/home/stefank/git/jdk/open/src/hotspot/share/oops/compressedKlass.hpp:95), pid=1496156, tid=1496350                                                                                                                                                                                                                                                                                                                     
#  assert(var != (T)-1) failed: Not yet initialized
...
V  [libjvm.so+0x10346ec]  CompilerToVM::Data::initialize(JVMCIEnv*)+0x44c  (compressedKlass.hpp:95)                                                                                                                                                                                                                                                                                                                                        
V  [libjvm.so+0x1057999]  readConfiguration0(JNIEnv_*, JVMCIEnv*)+0x159  (jvmciCompilerToVMInit.cpp:382) 
```

A simple fix is to stop calling the CompressedKlassPointers:: functions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput.git pull/151/head:pull/151` \
`$ git checkout pull/151`

Update a local copy of the PR: \
`$ git checkout pull/151` \
`$ git pull https://git.openjdk.org/lilliput.git pull/151/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 151`

View PR using the GUI difftool: \
`$ git pr show -t 151`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput/pull/151.diff">https://git.openjdk.org/lilliput/pull/151.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput/pull/151#issuecomment-2068708602)