### PR TITLE
OMWorld: Remove JavaThread Sync Deflation Code

### DIFF
--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1996,10 +1996,6 @@ const int ObjectAlignmentInBytes = 8;
                                                                             \
   product(int, OMYields, 5, "")                                             \
                                                                             \
-  product(bool, OMDeflateAfterWait, false, "Currently broken due to deflation changes") \
-                                                                            \
-  product(bool, OMDeflateBeforeExit, false, "Currently broken due to deflation changes")\
-                                                                            \
   product(bool, OMCacheHitRate, false, "")                                  \
                                                                             \
   product(bool, OMRecursiveFastPath, true, "Inflated recursion check first")\

--- a/src/hotspot/share/runtime/javaThread.hpp
+++ b/src/hotspot/share/runtime/javaThread.hpp
@@ -1167,9 +1167,6 @@ public:
   size_t _wait_inflation = 0;
   size_t _lock_stack_inflation = 0;
 
-  size_t _wait_deflation = 0;
-  size_t _exit_deflation = 0;
-
   size_t _lock_lookup = 0;
   size_t _lock_hit = 0;
   size_t _unlock_lookup = 0;

--- a/src/hotspot/share/runtime/javaThread.inline.hpp
+++ b/src/hotspot/share/runtime/javaThread.inline.hpp
@@ -289,16 +289,6 @@ inline void JavaThread::om_clear_monitor_cache() {
   _wait_inflation                = 0;
   _lock_stack_inflation          = 0;
 
-  if (_wait_deflation != 0 ||
-      _exit_deflation != 0) {
-    lt.print("Wait: %8zu Exit: %8zu Thread: %s",
-             _wait_deflation,
-             _exit_deflation,
-             name());
-  }
-  _wait_deflation = 0;
-  _exit_deflation = 0;
-
   if (_lock_lookup != 0 ||
       _unlock_lookup != 0) {
     const double lock_hit_rate = (double)_lock_hit / (double)_lock_lookup * 100;

--- a/src/hotspot/share/runtime/lightweightSynchronizer.cpp
+++ b/src/hotspot/share/runtime/lightweightSynchronizer.cpp
@@ -633,8 +633,6 @@ void LightweightSynchronizer::exit(oop object, JavaThread* current) {
   assert(LockingMode == LM_LIGHTWEIGHT, "must be");
   assert(current == Thread::current(), "must be");
 
-  bool first_try = true;
-
   markWord mark = object->mark();
   assert(!mark.is_unlocked(), "must be unlocked");
 
@@ -652,7 +650,6 @@ void LightweightSynchronizer::exit(oop object, JavaThread* current) {
     }
   }
 
-retry:
   // Fast-locking does not use the 'lock' argument.
   while (mark.is_fast_locked()) {
     markWord unlocked_mark = mark.set_unlocked();
@@ -674,17 +671,6 @@ retry:
     monitor->set_owner_from_anonymous(current);
     monitor->set_recursions(current->lock_stack().remove(object) - 1);
     current->_contended_inflation++;
-  }
-
-  if (OMDeflateBeforeExit && first_try && monitor->recursions() == 0) {
-    // Only deflate if recursions are 0 or the lock stack may become
-    // imbalanced.
-    first_try = false;
-    if (monitor->deflate_anon_monitor(current)) {
-      mark = object->mark();
-      current->_exit_deflation++;
-      goto retry;
-    }
   }
 
   monitor->exit(current);
@@ -779,7 +765,6 @@ ObjectMonitor* LightweightSynchronizer::inflate_fast_locked_object(oop object, J
   }
 
   if (cause == ObjectSynchronizer::inflate_cause_wait) {
-    locking_thread->lock_stack().set_wait_was_inflated();
     locking_thread->_wait_inflation++;
   } else if (cause == ObjectSynchronizer::inflate_cause_monitor_enter) {
     locking_thread->_recursive_inflation++;

--- a/src/hotspot/share/runtime/lockStack.hpp
+++ b/src/hotspot/share/runtime/lockStack.hpp
@@ -58,7 +58,6 @@ private:
   // We do this instead of a simple index into the array because this allows for
   // efficient addressing in generated code.
   uint32_t _top;
-  bool _wait_was_inflated;
   // The _bad_oop_sentinel acts as a sentinel value to elide underflow checks in generated code.
   // The correct layout is statically asserted in the constructor.
   const uintptr_t _bad_oop_sentinel = badOopVal;
@@ -127,10 +126,6 @@ public:
 
   // GC support
   inline void oops_do(OopClosure* cl);
-
-  bool wait_was_inflated() const { return _wait_was_inflated; };
-  void set_wait_was_inflated() { _wait_was_inflated = true; };
-  void clear_wait_was_inflated() { _wait_was_inflated = false; };
 
   // Printing
   void print_on(outputStream* st);

--- a/src/hotspot/share/runtime/objectMonitor.cpp
+++ b/src/hotspot/share/runtime/objectMonitor.cpp
@@ -584,14 +584,6 @@ bool ObjectMonitor::deflate_monitor(Thread* current) {
     return false;
   }
 
-  if (LockingMode == LM_LIGHTWEIGHT && is_being_async_deflated()) {
-    // TODO[OMWorld]: Batched deflation exiting early breaks this.
-    // This happens when a locked monitor is deflated by a java thread
-    // returning itself to fast_locked
-    assert(is_owner_anonymous(), "must stay anonymous when the java thread deflates");
-    return true;
-  }
-
   const oop obj = object_peek();
 
   if (obj == nullptr) {
@@ -669,77 +661,6 @@ bool ObjectMonitor::deflate_monitor(Thread* current) {
   }
 
   // We leave owner == DEFLATER_MARKER and contentions < 0
-  // to force any racing threads to retry.
-  return true;  // Success, ObjectMonitor has been deflated.
-}
-
-bool ObjectMonitor::deflate_anon_monitor(JavaThread* current) {
-  assert(owner_raw() == current, "must be");
-  assert(LockingMode == LM_LIGHTWEIGHT, "must be");
-
-  LockStack& lock_stack = current->lock_stack();
-
-  if (!lock_stack.can_push(1 + _recursions)) {
-    // Will not be able to push the oop on the lock stack.
-    return false;
-  }
-
-  if (is_contended()) {
-    // Easy checks are first - the ObjectMonitor is busy so no deflation.
-    return false;
-  }
-
-  // Make sure if a thread sees contentions() < 0 they also see owner == ANONYMOUS_OWNER
-  set_owner_from(current, reinterpret_cast<void*>(ANONYMOUS_OWNER));
-
-    // Recheck after setting owner
-  bool cleanup = is_contended();
-
-
-  if (!cleanup) {
-    // Make a zero contentions field negative to force any contending threads
-    // to retry. Because this is only called while holding the lock, the owner
-    // is anonymous and contentions is held over enter in inflate_and_enter
-    // it means that if the cas succeeds then we can have no other thread
-    // racily inserting themselves on the _waiters or _cxq lists, the
-    // entry list is protected by the lock (_waiter technically too, only
-    // removals are done outside the lock)
-    // TODO: Double check _succ and _responsible invariants
-    if (Atomic::cmpxchg(&_contentions, 0, INT_MIN) != 0) {
-      // Contentions was no longer 0 so we lost the race.
-      cleanup = true;
-    }
-  }
-
-  if (cleanup) {
-    // Could not deflate
-    set_owner_from_anonymous(current);
-    return false;
-  }
-
-  // Sanity checks for the races:
-  guarantee(is_owner_anonymous(), "must be");
-  guarantee(contentions() < 0, "must be negative: contentions=%d",
-            contentions());
-  guarantee(_waiters == 0, "must be 0: waiters=%d", _waiters);
-  guarantee(_cxq == nullptr, "must be no contending threads: cxq="
-            INTPTR_FORMAT, p2i(_cxq));
-  guarantee(_EntryList == nullptr,
-            "must be no entering threads: EntryList=" INTPTR_FORMAT,
-            p2i(_EntryList));
-
-  oop obj = object();
-
-  LightweightSynchronizer::deflate_anon_monitor(current, obj, this);
-
-  // We are deflated, restore the correct lock_stack
-  lock_stack.push(obj);
-  for (int i = 0; i < _recursions; i++) {
-    bool entered = lock_stack.try_recursive_enter(obj);
-    assert(entered, "must have entered here");
-  }
-
-  // We leave owner == ANONYMOUS_OWNER and contentions < 0
   // to force any racing threads to retry.
   return true;  // Success, ObjectMonitor has been deflated.
 }
@@ -1767,17 +1688,8 @@ void ObjectMonitor::wait(jlong millis, bool interruptible, TRAPS) {
   current->inc_held_monitor_count(relock_count); // Deopt never entered these counts.
   _waiters--;             // decrement the number of waiters
 
-  bool deflated = false;
-
-  if (LockingMode == LM_LIGHTWEIGHT && OMDeflateAfterWait && current->lock_stack().wait_was_inflated()) {
-    if (deflate_anon_monitor(current)) {
-      current->_wait_deflation++;
-      deflated = true;
-    }
-  }
-
   // Verify a few postconditions
-  assert(deflated || owner_raw() == current, "invariant");
+  assert(owner_raw() == current, "invariant");
   assert(_succ != current, "invariant");
   assert_mark_word_concistency();
 

--- a/src/hotspot/share/runtime/objectMonitor.hpp
+++ b/src/hotspot/share/runtime/objectMonitor.hpp
@@ -381,8 +381,6 @@ private:
 
   // Deflation support
   bool      deflate_monitor(Thread* current);
-public:
-  bool      deflate_anon_monitor(JavaThread* current);
 private:
   void      install_displaced_markword_in_object(const oop obj);
 };

--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -861,7 +861,6 @@ int ObjectSynchronizer::wait(Handle obj, jlong millis, TRAPS) {
 
   ObjectMonitor* monitor;
   if (LockingMode == LM_LIGHTWEIGHT) {
-    current->lock_stack().clear_wait_was_inflated();
     monitor = LightweightSynchronizer::inflate_locked_or_imse(obj(), inflate_cause_wait, CHECK_0);
   } else {
     // The ObjectMonitor* can't be async deflated because the _waiters


### PR DESCRIPTION
This removes the code that allows JavaThreads to deflate ObjectMonitors on self owned monitors on wait and exit. 

There currently is no good way to decide if a certain ObjectMonitor should be deflated. 

I propose removing the experimental code that relates to this feature, I will keep open a draft PR after this is integrated containing the JavaThread Sync Deflation Code in case it is something that is picked up at a later point.

This commit is currently based on ffc4c2fd5ba1c28432a5d5e84b8ada95fba7eeb8 without a merge. So GHA is not tested with lilliput. As long as this is mergable without conflicts (and no manual merge is performed) it will also be possible to move this commit down below lilliput on-top of OMWorld directly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput.git pull/153/head:pull/153` \
`$ git checkout pull/153`

Update a local copy of the PR: \
`$ git checkout pull/153` \
`$ git pull https://git.openjdk.org/lilliput.git pull/153/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 153`

View PR using the GUI difftool: \
`$ git pr show -t 153`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput/pull/153.diff">https://git.openjdk.org/lilliput/pull/153.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput/pull/153#issuecomment-2069231833)