### PR TITLE
OMWorld: Cleanup inflate

### DIFF
--- a/src/hotspot/share/runtime/synchronizer.hpp
+++ b/src/hotspot/share/runtime/synchronizer.hpp
@@ -127,7 +127,7 @@ public:
 
 private:
   // Shared implementation between the different LockingMode.
-  static ObjectMonitor* inflate_impl(JavaThread* thread, oop obj, const InflateCause cause);
+  static ObjectMonitor* inflate_impl(oop obj, const InflateCause cause);
 
 public:
   // This version is only for internal use


### PR DESCRIPTION
Cleanup of inflate code after `LM_LIGHTWEIGHT` and `LM_PLACEHOLDER` got merged.

This commit is currently based on ffc4c2fd5ba1c28432a5d5e84b8ada95fba7eeb8 without a merge. So GHA is not tested with lilliput. As long as this is mergable without conflicts (and no manual merge is performed) it will also be possible to move this commit down below lilliput on-top of OMWorld directly.