### PR TITLE
OMWorld: Cleanup quick_enter

### DIFF
--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -406,10 +406,6 @@ bool ObjectSynchronizer::quick_notify(oopDesc* obj, JavaThread* current, bool al
 
 bool ObjectSynchronizer::quick_enter(oop obj, JavaThread* current,
                                      BasicLock * lock) {
-  if (LockingMode == LM_LIGHTWEIGHT) {
-    // Not using quick_enter for now.
-    return false;
-  }
   assert(current->thread_state() == _thread_in_Java, "invariant");
   NoSafepointVerifier nsv;
   if (obj == nullptr) return false;       // Need to throw NPE
@@ -434,11 +430,11 @@ bool ObjectSynchronizer::quick_enter(oop obj, JavaThread* current,
   const markWord mark = obj->mark();
 
   if (mark.has_monitor()) {
-    ObjectMonitor* const m = mark.monitor();
+    ObjectMonitor* const m = ObjectSynchronizer::read_monitor(current, obj, mark);
     // An async deflation or GC can race us before we manage to make
     // the ObjectMonitor busy by setting the owner below. If we detect
     // that race we just bail out to the slow-path here.
-    if (m->object_peek() == nullptr) {
+    if (m == nullptr || m->object_peek() == nullptr) {
       return false;
     }
     JavaThread* const owner = static_cast<JavaThread*>(m->owner_raw());


### PR DESCRIPTION
Cleanup of `ObjectSynchronizer::quick_enter` after `LM_LIGHTWEIGHT` and `LM_PLACEHOLDER` got merged.

`LM_LIGHTWEIGHT` now makes use of `quick_enter`.  Doing a lookup in the hash table may be not be the best thing to do. Maybe just looking in thread local cache is enough. To avoid having to do multiple lookups.  Will add this change after I have tested it.

This commit is currently based on ffc4c2fd5ba1c28432a5d5e84b8ada95fba7eeb8 without a merge. So GHA is not tested with lilliput. As long as this is mergable without conflicts (and no manual merge is performed) it will also be possible to move this commit down below lilliput on-top of OMWorld directly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**) ⚠️ Review applies to [ecc164d8](https://git.openjdk.org/lilliput/pull/157/files/ecc164d86f7cf1cf4cc31ca429205ae5f27a4686)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput.git pull/157/head:pull/157` \
`$ git checkout pull/157`

Update a local copy of the PR: \
`$ git checkout pull/157` \
`$ git pull https://git.openjdk.org/lilliput.git pull/157/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 157`

View PR using the GUI difftool: \
`$ git pr show -t 157`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput/pull/157.diff">https://git.openjdk.org/lilliput/pull/157.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput/pull/157#issuecomment-2069265729)