### PR TITLE
OMWorld: Fix javaVFrame::print_lock_info_on

### DIFF
--- a/src/hotspot/share/runtime/vframe.cpp
+++ b/src/hotspot/share/runtime/vframe.cpp
@@ -247,9 +247,10 @@ void javaVFrame::print_lock_info_on(outputStream* st, int frame_count) {
           // The first stage of async deflation does not affect any field
           // used by this comparison so the ObjectMonitor* is usable here.
           if (mark.has_monitor()) {
-            // TODO[OMWorld]: Fix
             ObjectMonitor* mon = ObjectSynchronizer::read_monitor(current, monitor->owner(), mark);
-            if ( // we have marked ourself as pending on this monitor
+            if (// if the monitor is null we must be in the process of locking
+                mon == nullptr ||
+                // we have marked ourself as pending on this monitor
                 mon == thread()->current_pending_monitor() ||
                 // we are not the owner of this monitor
                 !mon->is_entered(thread())) {


### PR DESCRIPTION
OMWorld: `Fix javaVFrame::print_lock_info_on` printing. If the ObjectMonitor is `nullptr` and the header is `has_monitor` then we must be in the process of locking. (We cannot have locked, as that would have prevented deflation). 

This commit is currently based on ffc4c2fd5ba1c28432a5d5e84b8ada95fba7eeb8 without a merge. So GHA is not tested with lilliput. As long as this is mergable without conflicts (and no manual merge is performed) it will also be possible to move this commit down below lilliput on-top of OMWorld directly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput.git pull/158/head:pull/158` \
`$ git checkout pull/158`

Update a local copy of the PR: \
`$ git checkout pull/158` \
`$ git pull https://git.openjdk.org/lilliput.git pull/158/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 158`

View PR using the GUI difftool: \
`$ git pr show -t 158`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput/pull/158.diff">https://git.openjdk.org/lilliput/pull/158.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput/pull/158#issuecomment-2069281826)