### PR TITLE
OMWorld: ObjectMonitor:enter

### DIFF
--- a/src/hotspot/share/runtime/javaThread.inline.hpp
+++ b/src/hotspot/share/runtime/javaThread.inline.hpp
@@ -248,7 +248,8 @@ inline InstanceKlass* JavaThread::class_to_be_initialized() const {
 inline void JavaThread::om_set_monitor_cache(ObjectMonitor* monitor) {
   assert(LockingMode == LM_LIGHTWEIGHT, "must be");
   assert(monitor != nullptr, "use om_clear_monitor_cache to clear");
-  assert(this == current(), "only set own thread locals");
+  assert(this == current() || monitor->owner_raw() == this, "only add owned monitors for other threads");
+  assert(this == current() || is_obj_deopt_suspend(), "thread must not run concurrently");
 
   _om_cache.set_monitor(monitor);
 }

--- a/src/hotspot/share/runtime/lightweightSynchronizer.cpp
+++ b/src/hotspot/share/runtime/lightweightSynchronizer.cpp
@@ -940,7 +940,9 @@ bool LightweightSynchronizer::inflate_and_enter(oop object, BasicLock* lock, Jav
 
     // Update the thread-local cache
     locking_thread->om_set_monitor_cache(monitor);
-    lock->set_object_monitor_cache(monitor);
+    if (lock != nullptr) {
+      lock->set_displaced_header(monitor);
+    }
     locking_thread->_unlocked_inflation++;
 
     return true;
@@ -951,7 +953,9 @@ bool LightweightSynchronizer::inflate_and_enter(oop object, BasicLock* lock, Jav
     if (monitor->spin_enter(locking_thread)) {
       // Update the thread-local cache
       locking_thread->om_set_monitor_cache(monitor);
-      lock->set_object_monitor_cache(monitor);
+      if (lock != nullptr) {
+        lock->set_displaced_header(monitor);
+      }
 
       return true;
     }

--- a/src/hotspot/share/runtime/lightweightSynchronizer.hpp
+++ b/src/hotspot/share/runtime/lightweightSynchronizer.hpp
@@ -46,6 +46,8 @@ private:
 
   static void ensure_lock_stack_space(JavaThread* current);
 
+  class CacheSetter;
+
  public:
   static void initialize();
 
@@ -59,7 +61,7 @@ private:
 
   static ObjectMonitor* inflate_locked_or_imse(oop object, const ObjectSynchronizer::InflateCause cause, TRAPS);
   static ObjectMonitor* inflate_fast_locked_object(oop object, JavaThread* locking_thread, JavaThread* current, const ObjectSynchronizer::InflateCause cause);
-  static bool inflate_and_enter(oop object, BasicLock* lock, JavaThread* locking_thread, JavaThread* current, const ObjectSynchronizer::InflateCause cause);
+  static ObjectMonitor* inflate_and_enter(oop object, JavaThread* locking_thread, JavaThread* current, const ObjectSynchronizer::InflateCause cause);
 
   static void deflate_monitor(Thread* current, oop obj, ObjectMonitor* monitor);
   static void deflate_anon_monitor(Thread* current, oop obj, ObjectMonitor* monitor);

--- a/src/hotspot/share/runtime/lightweightSynchronizer.hpp
+++ b/src/hotspot/share/runtime/lightweightSynchronizer.hpp
@@ -54,7 +54,7 @@ private:
   static void set_table_max(JavaThread* current);
 
   static void enter_for(Handle obj, BasicLock* lock, JavaThread* locking_thread);
-  static void enter(Handle obj, BasicLock* lock, JavaThread* locking_thread);
+  static void enter(Handle obj, BasicLock* lock, JavaThread* current);
   static void exit(oop object, JavaThread* current);
 
   static ObjectMonitor* inflate_locked_or_imse(oop object, const ObjectSynchronizer::InflateCause cause, TRAPS);

--- a/src/hotspot/share/runtime/lightweightSynchronizer.hpp
+++ b/src/hotspot/share/runtime/lightweightSynchronizer.hpp
@@ -44,7 +44,7 @@ private:
 
   static void deflate_mark_word(oop object);
 
-  static void ensure_lock_stack_space(JavaThread* locking_thread, JavaThread* current);
+  static void ensure_lock_stack_space(JavaThread* current);
 
  public:
   static void initialize();
@@ -54,7 +54,7 @@ private:
   static void set_table_max(JavaThread* current);
 
   static void enter_for(Handle obj, BasicLock* lock, JavaThread* locking_thread);
-  static void enter(Handle obj, BasicLock* lock,  JavaThread* locking_thread, JavaThread* current);
+  static void enter(Handle obj, BasicLock* lock, JavaThread* locking_thread);
   static void exit(oop object, JavaThread* current);
 
   static ObjectMonitor* inflate_locked_or_imse(oop object, const ObjectSynchronizer::InflateCause cause, TRAPS);

--- a/src/hotspot/share/runtime/objectMonitor.cpp
+++ b/src/hotspot/share/runtime/objectMonitor.cpp
@@ -317,6 +317,83 @@ void ObjectMonitor::ClearSuccOnSuspend::operator()(JavaThread* current) {
 
 // -----------------------------------------------------------------------------
 // Enter support
+
+bool ObjectMonitor::enter_is_async_deflating() {
+  if (is_being_async_deflated()) {
+    if (LockingMode != LM_LIGHTWEIGHT) {
+      const oop l_object = object();
+      if (l_object != nullptr) {
+        // Attempt to restore the header/dmw to the object's header so that
+        // we only retry once if the deflater thread happens to be slow.
+        install_displaced_markword_in_object(l_object);
+      }
+    }
+    return true;
+  }
+
+  return false;
+}
+
+void ObjectMonitor::enter_for_with_contention_mark(JavaThread* locking_thread, ObjectMonitorContentionMark& contention_mark) {
+  // Used by ObjectSynchronizer::enter_for to enter for another thread.
+  // The monitor is private to or already owned by locking_thread which must be suspended.
+  // So this code may only contend with deflation.
+  assert(locking_thread == Thread::current() || locking_thread->is_obj_deopt_suspend(), "must be");
+  assert(contention_mark._monitor == this, "must be");
+  assert(!is_being_async_deflated(), "must be");
+
+
+  void* prev_owner = try_set_owner_from(nullptr, locking_thread);
+
+  bool success = false;
+
+  if (prev_owner == nullptr) {
+    assert(_recursions == 0, "invariant");
+    success = true;
+  } else if (prev_owner == locking_thread) {
+    _recursions++;
+    success = true;
+  } else if (prev_owner == DEFLATER_MARKER) {
+    // Racing with deflation.
+    prev_owner = try_set_owner_from(DEFLATER_MARKER, locking_thread);
+    if (prev_owner == DEFLATER_MARKER) {
+      // Cancelled deflation. Increment contentions as part of the deflation protocol.
+      add_to_contentions(1);
+      success = true;
+    } else if (prev_owner == nullptr) {
+      // At this point we cannot race with deflation as we have both incremented
+      // contentions, seen contention > 0 and seen a DEFLATER_MARKER.
+      // success will only be false if this races with something other than
+      // deflation.
+      prev_owner = try_set_owner_from(nullptr, locking_thread);
+      success = prev_owner == nullptr;
+    }
+  } else if (LockingMode == LM_LEGACY && locking_thread->is_lock_owned((address)prev_owner)) {
+    assert(_recursions == 0, "must be");
+    _recursions = 1;
+    set_owner_from_BasicLock(prev_owner, locking_thread);
+    success = true;
+  }
+  assert(success, "Failed to enter_for: locking_thread=" INTPTR_FORMAT
+          ", this=" INTPTR_FORMAT "{owner=" INTPTR_FORMAT "}, observed owner: " INTPTR_FORMAT,
+          p2i(locking_thread), p2i(this), p2i(owner_raw()), p2i(prev_owner));
+}
+
+bool ObjectMonitor::enter_for(JavaThread* locking_thread) {
+
+  // Block out deflation as soon as possible.
+  ObjectMonitorContentionMark contention_mark(this);
+
+  // Check for deflation.
+  if (enter_is_async_deflating()) {
+    return false;
+  }
+
+  enter_for_with_contention_mark(locking_thread, contention_mark);
+  assert(owner_raw() == locking_thread, "must be");
+  return true;
+}
+
 bool ObjectMonitor::try_enter(JavaThread* current) {
   void* cur = try_set_owner_from(nullptr, current);
   if (cur == nullptr) {
@@ -329,88 +406,6 @@ bool ObjectMonitor::try_enter(JavaThread* current) {
     return true;
   }
 
-  return false;
-}
-
-bool ObjectMonitor::enter_for(JavaThread* locking_thread) {
-  // Used by ObjectSynchronizer::enter_for to enter for another thread.
-  // The monitor is private to or already owned by locking_thread which must be suspended.
-  // So this code may only contend with deflation.
-  assert(locking_thread == Thread::current() || locking_thread->is_obj_deopt_suspend(), "must be");
-
-  // Block out deflation as soon as possible.
-  add_to_contentions(1);
-
-  bool success = false;
-  if (!is_being_async_deflated()) {
-    void* prev_owner = try_set_owner_from(nullptr, locking_thread);
-
-    if (prev_owner == nullptr) {
-      assert(_recursions == 0, "invariant");
-      success = true;
-    } else if (prev_owner == locking_thread) {
-      _recursions++;
-      success = true;
-    } else if (prev_owner == DEFLATER_MARKER) {
-      // Racing with deflation.
-      prev_owner = try_set_owner_from(DEFLATER_MARKER, locking_thread);
-      if (prev_owner == DEFLATER_MARKER) {
-        // Cancelled deflation. Increment contentions as part of the deflation protocol.
-        add_to_contentions(1);
-        success = true;
-      } else if (prev_owner == nullptr) {
-        // At this point we cannot race with deflation as we have both incremented
-        // contentions, seen contention > 0 and seen a DEFLATER_MARKER.
-        // success will only be false if this races with something other than
-        // deflation.
-        prev_owner = try_set_owner_from(nullptr, locking_thread);
-        success = prev_owner == nullptr;
-      }
-    } else if (LockingMode == LM_LEGACY && locking_thread->is_lock_owned((address)prev_owner)) {
-      assert(_recursions == 0, "must be");
-      _recursions = 1;
-      set_owner_from_BasicLock(prev_owner, locking_thread);
-      success = true;
-    }
-    assert(success, "Failed to enter_for: locking_thread=" INTPTR_FORMAT
-           ", this=" INTPTR_FORMAT "{owner=" INTPTR_FORMAT "}, observed owner: " INTPTR_FORMAT,
-           p2i(locking_thread), p2i(this), p2i(owner_raw()), p2i(prev_owner));
-  } else {
-    // Async deflation is in progress and our contentions increment
-    // above lost the race to async deflation. Undo the work and
-    // force the caller to retry.
-    const oop l_object = object();
-    if (l_object != nullptr) {
-      // Attempt to restore the header/dmw to the object's header so that
-      // we only retry once if the deflater thread happens to be slow.
-      install_displaced_markword_in_object(l_object);
-    }
-  }
-
-  add_to_contentions(-1);
-
-  assert(!success || owner_raw() == locking_thread, "must be");
-
-  return success;
-}
-
-bool ObjectMonitor::enter(JavaThread* current) {
-  assert(current == JavaThread::current(), "must be");
-  // The following code is ordered to check the most common cases first
-  // and to reduce RTS->RTO cache line upgrades on SPARC and IA32 processors.
-
-  void* cur = try_set_owner_from(nullptr, current);
-  if (cur == nullptr) {
-    assert(_recursions == 0, "invariant");
-    return true;
-  }
-
-  if (cur == current) {
-    // TODO-FIXME: check for integer overflow!  BUGID 6557169.
-    _recursions++;
-    return true;
-  }
-
   if (LockingMode != LM_LIGHTWEIGHT && current->is_lock_owned((address)cur)) {
     assert(_recursions == 0, "internal state error");
     _recursions = 1;
@@ -418,11 +413,25 @@ bool ObjectMonitor::enter(JavaThread* current) {
     return true;
   }
 
+  return false;
+}
+
+bool ObjectMonitor::spin_enter(JavaThread* current) {
+  assert(current == JavaThread::current(), "must be");
+
+  // Check for recursion.
+  if (try_enter(current)) {
+    return true;
+  }
+
+  // Check for deflation.
+  if (enter_is_async_deflating()) {
+    return false;
+  }
+
   // We've encountered genuine contention.
 
-  // Try one round of spinning *before* enqueueing current
-  // and before going through the awkward and expensive state
-  // transitions.  The following spin is strictly optional ...
+  // Do one round of spinning.
   // Note that if we acquire the monitor from an initial spin
   // we forgo posting JVMTI events and firing DTRACE probes.
   if (TrySpin(current) > 0) {
@@ -432,26 +441,39 @@ bool ObjectMonitor::enter(JavaThread* current) {
     return true;
   }
 
+  return false;
+}
+
+bool ObjectMonitor::enter(JavaThread* current) {
+  assert(current == JavaThread::current(), "must be");
+
+  if (spin_enter(current)) {
+    return true;
+  }
+
   assert(owner_raw() != current, "invariant");
   assert(_succ != current, "invariant");
   assert(!SafepointSynchronize::is_at_safepoint(), "invariant");
   assert(current->thread_state() != _thread_blocked, "invariant");
 
-  // Keep track of contention for JVM/TI and M&M queries.
-  add_to_contentions(1);
-  if (is_being_async_deflated()) {
-    // Async deflation is in progress and our contentions increment
-    // above lost the race to async deflation. Undo the work and
-    // force the caller to retry.
-    const oop l_object = object();
-    if (LockingMode != LM_LIGHTWEIGHT && l_object != nullptr) {
-      // Attempt to restore the header/dmw to the object's header so that
-      // we only retry once if the deflater thread happens to be slow.
-      install_displaced_markword_in_object(l_object);
-    }
-    add_to_contentions(-1);
+  // Keep is_being_async_deflated stable across the rest of enter
+  ObjectMonitorContentionMark contention_mark(this);
+
+  // Check for deflation.
+  if (enter_is_async_deflating()) {
     return false;
   }
+
+  // At this point this ObjectMonitor cannot be deflated, finish contended enter
+  enter_with_contention_mark(current, contention_mark);
+  return true;
+}
+
+void ObjectMonitor::enter_with_contention_mark(JavaThread *current, ObjectMonitorContentionMark &cm) {
+  assert(current == JavaThread::current(), "must be");
+  assert(owner_raw() != current, "must be");
+  assert(cm._monitor == this, "must be");
+  assert(!is_being_async_deflated(), "must be");
 
   JFR_ONLY(JfrConditionalFlush<EventJavaMonitorEnter> flush(current);)
   EventJavaMonitorEnter event;
@@ -509,7 +531,6 @@ bool ObjectMonitor::enter(JavaThread* current) {
     // the monitor free and clear.
   }
 
-  add_to_contentions(-1);
   assert(contentions() >= 0, "must not be negative: contentions=%d", contentions());
 
   // Must either set _recursions = 0 or ASSERT _recursions == 0.
@@ -545,7 +566,6 @@ bool ObjectMonitor::enter(JavaThread* current) {
     event.commit();
   }
   OM_PERFDATA_OP(ContendedLockAttempts, inc());
-  return true;
 }
 
 // Caveat: TryLock() is not necessarily serializing if it returns failure.

--- a/src/hotspot/share/runtime/objectMonitor.hpp
+++ b/src/hotspot/share/runtime/objectMonitor.hpp
@@ -33,6 +33,7 @@
 #include "utilities/checkedCast.hpp"
 
 class ObjectMonitor;
+class ObjectMonitorContentionMark;
 class ParkEvent;
 
 // ObjectWaiter serves as a "proxy" or surrogate thread.
@@ -349,10 +350,15 @@ private:
     ClearSuccOnSuspend(ObjectMonitor* om) : _om(om)  {}
     void operator()(JavaThread* current);
   };
+
+  bool      enter_is_async_deflating();
  public:
-  bool      try_enter(JavaThread* current);
+  void      enter_for_with_contention_mark(JavaThread* locking_thread, ObjectMonitorContentionMark& contention_mark);
   bool      enter_for(JavaThread* locking_thread);
   bool      enter(JavaThread* current);
+  bool      try_enter(JavaThread* current);
+  bool      spin_enter(JavaThread* current);
+  void      enter_with_contention_mark(JavaThread* current, ObjectMonitorContentionMark& contention_mark);
   void      exit(JavaThread* current, bool not_suspended = true);
   void      wait(jlong millis, bool interruptible, TRAPS);
   void      notify(TRAPS);
@@ -389,11 +395,15 @@ private:
 
 // RAII object to ensure that ObjectMonitor::is_being_async_deflated() is
 // stable within the context of this mark.
-class ObjectMonitorContentionMark {
+class ObjectMonitorContentionMark : StackObj {
+  DEBUG_ONLY(friend class ObjectMonitor;)
+
   ObjectMonitor* _monitor;
 
+  NONCOPYABLE(ObjectMonitorContentionMark);
+
 public:
-  ObjectMonitorContentionMark(ObjectMonitor* monitor);
+  explicit ObjectMonitorContentionMark(ObjectMonitor* monitor);
   ~ObjectMonitorContentionMark();
 };
 

--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -574,7 +574,7 @@ void ObjectSynchronizer::enter(Handle obj, BasicLock* lock, JavaThread* current)
   assert(current == Thread::current(), "must be");
 
   if (LockingMode == LM_LIGHTWEIGHT) {
-    return LightweightSynchronizer::enter(obj, lock, current, current);
+    return LightweightSynchronizer::enter(obj, lock, current);
   }
 
   if (!enter_fast_impl(obj, lock, current)) {

--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -794,7 +794,7 @@ void ObjectSynchronizer::jni_enter(Handle obj, JavaThread* current) {
     ObjectMonitor* monitor;
     bool entered;
     if (LockingMode == LM_LIGHTWEIGHT) {
-      entered = LightweightSynchronizer::inflate_and_enter(obj(), nullptr, current, current, inflate_cause_jni_enter);
+      entered = LightweightSynchronizer::inflate_and_enter(obj(), current, current, inflate_cause_jni_enter) != nullptr;
     } else {
       monitor = inflate(current, obj(), inflate_cause_jni_enter);
       entered = monitor->enter(current);


### PR DESCRIPTION
This restructures `ObjectMonitor:enter` to fit better with the `LightweightSynchronizer`. Some parts of this could be upstreamed separately. 

This effectively splits up `ObjectMonitor::enter` into three parts. Which LightweightSynchronizer can weave into its `inflate_and_enter`. 

```c++
bool ObjectMonitor::enter(JavaThread* current) {
  // 1. Spinning without blocking out deflation
  if (spin_enter(current)) {
    return true;
  }

  // 2. Try to block deflation
  ObjectMonitorContentionMark contention_mark(this);
  if (enter_is_async_deflating()) {
    return false;
  }

  // 3. Enter while blocking out deflation
  enter_with_contention_mark(current, contention_mark);
  return true;
}
```

It may be worth the effort to document these new methods, and also add better documentation to `inflate_and_enter` which describes the invariants and how `ObjectMonitorContentionMark`, markWord transitions and ObjectMonitor::_owner field (on newly inserted monitors) plays together to guarantee correctness and works. 

This commit is currently based on ffc4c2fd5ba1c28432a5d5e84b8ada95fba7eeb8 without a merge. So GHA is not tested with lilliput. As long as this is mergable without conflicts (and no manual merge is performed) it will also be possible to move this commit down below lilliput on-top of OMWorld directly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**) ⚠️ Review applies to [24ed7d73](https://git.openjdk.org/lilliput/pull/159/files/24ed7d7341881b8eae240fda999021bf5f2159a7)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput.git pull/159/head:pull/159` \
`$ git checkout pull/159`

Update a local copy of the PR: \
`$ git checkout pull/159` \
`$ git pull https://git.openjdk.org/lilliput.git pull/159/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 159`

View PR using the GUI difftool: \
`$ git pr show -t 159`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput/pull/159.diff">https://git.openjdk.org/lilliput/pull/159.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput/pull/159#issuecomment-2069313425)