### PR TITLE
OMWorld: Cleanup BasicLock header

### DIFF
--- a/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.cpp
@@ -237,7 +237,7 @@ void C2_MacroAssembler::fast_lock_lightweight(Register obj, Register box, Regist
   Label slow_path;
 
   // Clear box. TODO[OMWorld]: Is this necessary? May also defer this to not write twice.
-  str(zr, Address(box, BasicLock::displaced_header_offset_in_bytes()));
+  str(zr, Address(box, BasicLock::object_monitor_cache_offset_in_bytes()));
 
   if (DiagnoseSyncOnValueBasedClasses != 0) {
     load_klass(t1, obj);
@@ -379,7 +379,7 @@ void C2_MacroAssembler::fast_lock_lightweight(Register obj, Register box, Regist
       increment(Address(t1_monitor, ObjectMonitor::recursions_offset()), 1);
 
       bind(monitor_locked);
-      str(t1_monitor, Address(box, BasicLock::displaced_header_offset_in_bytes()));
+      str(t1_monitor, Address(box, BasicLock::object_monitor_cache_offset_in_bytes()));
     }
 
   }
@@ -497,7 +497,7 @@ void C2_MacroAssembler::fast_unlock_lightweight(Register obj, Register box, Regi
       const Register t1_monitor = t1;
 
       if (OMCacheHitRate) increment(Address(rthread, JavaThread::unlock_lookup_offset()));
-      ldr(t1_monitor, Address(box, BasicLock::displaced_header_offset_in_bytes()));
+      ldr(t1_monitor, Address(box, BasicLock::object_monitor_cache_offset_in_bytes()));
       // TODO: Cleanup these constants (with an enum and asserts)
       cmp(t1_monitor, (uint8_t)2);
       // Non symmetrical, take slow path monitor == 0 or 1, 0 and 1 < 2, both LS and NE

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -6438,7 +6438,7 @@ void MacroAssembler::lightweight_lock(Register basic_lock, Register obj, Registe
   // instruction emitted as it is part of C1's null check semantics.
   ldr(mark, Address(obj, oopDesc::mark_offset_in_bytes()));
 
-  str(zr, Address(basic_lock, BasicObjectLock::lock_offset() + in_ByteSize((BasicLock::displaced_header_offset_in_bytes()))));
+  str(zr, Address(basic_lock, BasicObjectLock::lock_offset() + in_ByteSize((BasicLock::object_monitor_cache_offset_in_bytes()))));
 
   // Check if the lock-stack is full.
   ldrw(top, Address(rthread, JavaThread::lock_stack_top_offset()));

--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
@@ -950,7 +950,7 @@ void C2_MacroAssembler::fast_lock_lightweight(Register obj, Register box, Regist
   Label slow_path;
 
   // Clear box. TODO[OMWorld]: Is this necessary? May also defer this to not write twice.
-  movptr(Address(box, BasicLock::displaced_header_offset_in_bytes()), 0);
+  movptr(Address(box, BasicLock::object_monitor_cache_offset_in_bytes()), 0);
 
   if (DiagnoseSyncOnValueBasedClasses != 0) {
     load_klass(rax_reg, obj, t);
@@ -1084,7 +1084,7 @@ void C2_MacroAssembler::fast_lock_lightweight(Register obj, Register box, Regist
 
       bind(monitor_locked);
       // Cache the monitor for unlock
-      movptr(Address(box, BasicLock::displaced_header_offset_in_bytes()), monitor);
+      movptr(Address(box, BasicLock::object_monitor_cache_offset_in_bytes()), monitor);
     }
   }
 
@@ -1200,7 +1200,7 @@ void C2_MacroAssembler::fast_unlock_lightweight(Register obj, Register reg_rax, 
       jmp(slow_path);
     } else {
       if (OMCacheHitRate) increment(Address(thread, JavaThread::unlock_lookup_offset()));
-      movptr(monitor, Address(box, BasicLock::displaced_header_offset_in_bytes()));
+      movptr(monitor, Address(box, BasicLock::object_monitor_cache_offset_in_bytes()));
       // TODO[OMWorld]: Figure out the correctness surrounding the owner field here. Obj is not on the lock stack
       //                but this means this thread must have locked on the inflated monitor at some point. So it
       //                should not be anonymous.

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -10007,7 +10007,7 @@ void MacroAssembler::lightweight_lock(Register basic_lock, Register obj, Registe
   // instruction emitted as it is part of C1's null check semantics.
   movptr(reg_rax, Address(obj, oopDesc::mark_offset_in_bytes()));
 
-  movptr(Address(basic_lock, BasicObjectLock::lock_offset() + in_ByteSize((BasicLock::displaced_header_offset_in_bytes()))), 0);
+  movptr(Address(basic_lock, BasicObjectLock::lock_offset() + in_ByteSize((BasicLock::object_monitor_cache_offset_in_bytes()))), 0);
 
 #ifndef _LP64
   if (thread == basic_lock) {

--- a/src/hotspot/share/interpreter/zero/bytecodeInterpreter.cpp
+++ b/src/hotspot/share/interpreter/zero/bytecodeInterpreter.cpp
@@ -53,7 +53,9 @@
 #include "prims/jvmtiExport.hpp"
 #include "prims/jvmtiThreadState.hpp"
 #include "runtime/atomic.hpp"
+#include "runtime/basicLock.inline.hpp"
 #include "runtime/frame.inline.hpp"
+#include "runtime/globals.hpp"
 #include "runtime/handles.inline.hpp"
 #include "runtime/interfaceSupport.inline.hpp"
 #include "runtime/orderAccess.hpp"
@@ -61,6 +63,7 @@
 #include "runtime/threadCritical.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/exceptions.hpp"
+#include "utilities/globalDefinitions.hpp"
 #include "utilities/macros.hpp"
 
 /*
@@ -624,23 +627,28 @@ void BytecodeInterpreter::run(interpreterState istate) {
         BasicObjectLock* mon = &istate->monitor_base()[-1];
         mon->set_obj(rcvr);
 
-        // Traditional lightweight locking.
-        markWord displaced = rcvr->mark().set_unlocked();
-        mon->lock()->set_displaced_header(displaced);
-        bool call_vm = (LockingMode == LM_MONITOR);
-        bool inc_monitor_count = true;
-        if (call_vm || rcvr->cas_set_mark(markWord::from_pointer(mon), displaced) != displaced) {
-          // Is it simple recursive case?
-          if (!call_vm && THREAD->is_lock_owned((address) displaced.clear_lock_bits().to_pointer())) {
-            mon->lock()->set_displaced_header(markWord::from_pointer(nullptr));
-          } else {
-            inc_monitor_count = false;
-            CALL_VM(InterpreterRuntime::monitorenter(THREAD, mon), handle_exception);
+        bool success = false;
+        if (LockingMode == LM_LEGACY) {
+           // Traditional lightweight locking.
+          markWord displaced = rcvr->mark().set_unlocked();
+          mon->lock()->set_displaced_header(displaced);
+          success = true;
+          if (rcvr->cas_set_mark(markWord::from_pointer(mon), displaced) != displaced) {
+            // Is it simple recursive case?
+            if (THREAD->is_lock_owned((address) displaced.clear_lock_bits().to_pointer())) {
+              mon->lock()->set_displaced_header(markWord::from_pointer(nullptr));
+            } else {
+              success = false;
+            }
+          }
+          if (success) {
+            THREAD->inc_held_monitor_count();
           }
         }
-        if (inc_monitor_count) {
-          THREAD->inc_held_monitor_count();
+        if (!success) {
+            CALL_VM(InterpreterRuntime::monitorenter(THREAD, mon), handle_exception);
         }
+
       }
       THREAD->set_do_not_unlock_if_synchronized(false);
 
@@ -723,23 +731,28 @@ void BytecodeInterpreter::run(interpreterState istate) {
       assert(entry->obj() == nullptr, "Frame manager didn't allocate the monitor");
       entry->set_obj(lockee);
 
-      // traditional lightweight locking
-      markWord displaced = lockee->mark().set_unlocked();
-      entry->lock()->set_displaced_header(displaced);
-      bool call_vm = (LockingMode == LM_MONITOR);
-      bool inc_monitor_count = true;
-      if (call_vm || lockee->cas_set_mark(markWord::from_pointer(entry), displaced) != displaced) {
-        // Is it simple recursive case?
-        if (!call_vm && THREAD->is_lock_owned((address) displaced.clear_lock_bits().to_pointer())) {
-          entry->lock()->set_displaced_header(markWord::from_pointer(nullptr));
-        } else {
-          inc_monitor_count = false;
-          CALL_VM(InterpreterRuntime::monitorenter(THREAD, entry), handle_exception);
+      bool success = false;
+      if (LockingMode == LM_LEGACY) {
+        // traditional lightweight locking
+        markWord displaced = lockee->mark().set_unlocked();
+        entry->lock()->set_displaced_header(displaced);
+        success = true;
+        if (lockee->cas_set_mark(markWord::from_pointer(entry), displaced) != displaced) {
+          // Is it simple recursive case?
+          if (THREAD->is_lock_owned((address) displaced.clear_lock_bits().to_pointer())) {
+            entry->lock()->set_displaced_header(markWord::from_pointer(nullptr));
+          } else {
+            success = false;
+          }
+        }
+        if (success) {
+          THREAD->inc_held_monitor_count();
         }
       }
-      if (inc_monitor_count) {
-        THREAD->inc_held_monitor_count();
+      if (!success) {
+        CALL_VM(InterpreterRuntime::monitorenter(THREAD, entry), handle_exception);
       }
+
       UPDATE_PC_AND_TOS(1, -1);
       goto run;
     }
@@ -1653,23 +1666,28 @@ run:
         if (entry != nullptr) {
           entry->set_obj(lockee);
 
-          // traditional lightweight locking
-          markWord displaced = lockee->mark().set_unlocked();
-          entry->lock()->set_displaced_header(displaced);
-          bool call_vm = (LockingMode == LM_MONITOR);
-          bool inc_monitor_count = true;
-          if (call_vm || lockee->cas_set_mark(markWord::from_pointer(entry), displaced) != displaced) {
-            // Is it simple recursive case?
-            if (!call_vm && THREAD->is_lock_owned((address) displaced.clear_lock_bits().to_pointer())) {
-              entry->lock()->set_displaced_header(markWord::from_pointer(nullptr));
-            } else {
-              inc_monitor_count = false;
-              CALL_VM(InterpreterRuntime::monitorenter(THREAD, entry), handle_exception);
+          bool success = false;
+          if (LockingMode == LM_LEGACY) {
+            // traditional lightweight locking
+            markWord displaced = lockee->mark().set_unlocked();
+            entry->lock()->set_displaced_header(displaced);
+            success = true;
+            if (lockee->cas_set_mark(markWord::from_pointer(entry), displaced) != displaced) {
+              // Is it simple recursive case?
+              if (THREAD->is_lock_owned((address) displaced.clear_lock_bits().to_pointer())) {
+                entry->lock()->set_displaced_header(markWord::from_pointer(nullptr));
+              } else {
+                success = false;
+              }
+            }
+            if (success) {
+              THREAD->inc_held_monitor_count();
             }
           }
-          if (inc_monitor_count) {
-            THREAD->inc_held_monitor_count();
+          if (!success) {
+            CALL_VM(InterpreterRuntime::monitorenter(THREAD, entry), handle_exception);
           }
+
           UPDATE_PC_AND_TOS_AND_CONTINUE(1, -1);
         } else {
           istate->set_msg(more_monitors);
@@ -1687,23 +1705,27 @@ run:
         while (most_recent != limit ) {
           if ((most_recent)->obj() == lockee) {
             BasicLock* lock = most_recent->lock();
-            markWord header = lock->displaced_header();
-            most_recent->set_obj(nullptr);
 
-            // If it isn't recursive we either must swap old header or call the runtime
-            bool dec_monitor_count = true;
-            bool call_vm = (LockingMode == LM_MONITOR);
-            if (header.to_pointer() != nullptr || call_vm) {
-              markWord old_header = markWord::encode(lock);
-              if (call_vm || lockee->cas_set_mark(header, old_header) != old_header) {
-                // restore object for the slow case
-                most_recent->set_obj(lockee);
-                dec_monitor_count = false;
-                InterpreterRuntime::monitorexit(most_recent);
+            bool success = false;
+            if (LockingMode == LM_LEGACY) {
+              // If it isn't recursive we either must swap old header or call the runtime
+              most_recent->set_obj(nullptr);
+              success = true;
+              markWord header = lock->displaced_header();
+              if (header.to_pointer() != nullptr) {
+                markWord old_header = markWord::encode(lock);
+                if (lockee->cas_set_mark(header, old_header) != old_header) {
+                  // restore object for the slow case
+                  most_recent->set_obj(lockee);
+                  success = false;
+                }
+              }
+              if (success) {
+                THREAD->dec_held_monitor_count();
               }
             }
-            if (dec_monitor_count) {
-              THREAD->dec_held_monitor_count();
+            if (!success) {
+              InterpreterRuntime::monitorexit(most_recent);
             }
             UPDATE_PC_AND_TOS_AND_CONTINUE(1, -1);
           }
@@ -3128,22 +3150,28 @@ run:
         oop lockee = end->obj();
         if (lockee != nullptr) {
           BasicLock* lock = end->lock();
-          markWord header = lock->displaced_header();
-          end->set_obj(nullptr);
 
-          // If it isn't recursive we either must swap old header or call the runtime
-          bool dec_monitor_count = true;
-          if (header.to_pointer() != nullptr) {
-            markWord old_header = markWord::encode(lock);
-            if (lockee->cas_set_mark(header, old_header) != old_header) {
-              // restore object for the slow case
-              end->set_obj(lockee);
-              dec_monitor_count = false;
-              InterpreterRuntime::monitorexit(end);
+          bool success = false;
+          if (LockingMode == LM_LEGACY) {
+            markWord header = lock->displaced_header();
+            end->set_obj(nullptr);
+
+            // If it isn't recursive we either must swap old header or call the runtime
+            success = true;
+            if (header.to_pointer() != nullptr) {
+              markWord old_header = markWord::encode(lock);
+              if (lockee->cas_set_mark(header, old_header) != old_header) {
+                // restore object for the slow case
+                end->set_obj(lockee);
+                success = false;
+              }
+            }
+            if (success) {
+              THREAD->dec_held_monitor_count();
             }
           }
-          if (dec_monitor_count) {
-            THREAD->dec_held_monitor_count();
+          if (!success) {
+            InterpreterRuntime::monitorexit(end);
           }
 
           // One error is plenty
@@ -3191,7 +3219,7 @@ run:
               illegal_state_oop = Handle(THREAD, THREAD->pending_exception());
               THREAD->clear_pending_exception();
             }
-          } else if (LockingMode == LM_MONITOR) {
+          } else if (LockingMode != LM_LEGACY) {
             InterpreterRuntime::monitorexit(base);
             if (THREAD->has_pending_exception()) {
               if (!suppress_error) illegal_state_oop = Handle(THREAD, THREAD->pending_exception());

--- a/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
+++ b/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
@@ -136,7 +136,7 @@
   nonstatic_field(Array<Klass*>,               _length,                                int)                                          \
   nonstatic_field(Array<Klass*>,               _data[0],                               Klass*)                                       \
                                                                                                                                      \
-  volatile_nonstatic_field(BasicLock,          _displaced_header,                      markWord)                                     \
+  volatile_nonstatic_field(BasicLock,          _metadata,                              uintptr_t)                                    \
                                                                                                                                      \
   static_field(CodeCache,                      _low_bound,                             address)                                      \
   static_field(CodeCache,                      _high_bound,                            address)                                      \

--- a/src/hotspot/share/oops/markWord.cpp
+++ b/src/hotspot/share/oops/markWord.cpp
@@ -24,6 +24,7 @@
 
 #include "precompiled.hpp"
 #include "oops/markWord.hpp"
+#include "runtime/basicLock.inline.hpp"
 #include "runtime/javaThread.hpp"
 #include "runtime/objectMonitor.inline.hpp"
 #include "utilities/ostream.hpp"

--- a/src/hotspot/share/runtime/basicLock.cpp
+++ b/src/hotspot/share/runtime/basicLock.cpp
@@ -24,16 +24,25 @@
 
 #include "precompiled.hpp"
 #include "oops/oop.inline.hpp"
-#include "runtime/basicLock.hpp"
+#include "runtime/basicLock.inline.hpp"
+#include "runtime/objectMonitor.hpp"
 #include "runtime/synchronizer.hpp"
+#include "utilities/globalDefinitions.hpp"
 
 void BasicLock::print_on(outputStream* st, oop owner) const {
   st->print("monitor");
-  markWord mark_word = displaced_header();
-  if (mark_word.value() != 0) {
-    // Print monitor info if there's an owning oop and it refers to this BasicLock.
-    bool print_monitor_info = (owner != nullptr) && (owner->mark() == markWord::from_pointer((void*)this));
-    mark_word.print_on(st, print_monitor_info);
+  if (LockingMode == LM_LIGHTWEIGHT) {
+    ObjectMonitor* mon = object_monitor_cache();
+    if (mon != nullptr) {
+      mon->print_on(st);
+    }
+  } else {
+    markWord mark_word = displaced_header();
+    if (mark_word.value() != 0) {
+      // Print monitor info if there's an owning oop and it refers to this BasicLock.
+      bool print_monitor_info = (owner != nullptr) && (owner->mark() == markWord::from_pointer((void*)this));
+      mark_word.print_on(st, print_monitor_info);
+    }
   }
 }
 
@@ -83,16 +92,14 @@ void BasicLock::move_to(oop obj, BasicLock* dest) {
     }
     dest->set_displaced_header(displaced_header());
   } else if (LockingMode == LM_LIGHTWEIGHT) {
-    // Lightweight locking uses the displace header to store a cache which
-    // must contain either an ObjectMonitor* associated with this lock or null.
     // Preserve the ObjectMonitor*, the cache is cleared when a box is reused
     // and only read while the lock is held, so no stale ObjectMonitor* is
     // encountered.
-    dest->set_displaced_header(displaced_header());
+    dest->set_object_monitor_cache(object_monitor_cache());
   }
 #ifdef ASSERT
   else {
-    dest->set_displaced_header(markWord(badDispHeaderDeopt));
+    dest->set_bad_metadata_deopt();
   }
 #endif
 }

--- a/src/hotspot/share/runtime/basicLock.hpp
+++ b/src/hotspot/share/runtime/basicLock.hpp
@@ -28,39 +28,46 @@
 #include "oops/markWord.hpp"
 #include "runtime/atomic.hpp"
 #include "runtime/handles.hpp"
+#include "utilities/globalDefinitions.hpp"
 #include "utilities/sizes.hpp"
 
 class BasicLock {
   friend class VMStructs;
   friend class JVMCIVMStructs;
  private:
+  // * For LM_MONITOR
+  // Unused.
+  // * For LM_LEGACY
   // This is either the actual displaced header from a locked object, or
   // a sentinel zero value indicating a recursive stack-lock.
-  volatile markWord _displaced_header;
+  // * For LM_LIGHTWEIGHT
+  // Used as a cache the ObjectMonitor* used when locking. Must either
+  // be nullptr or the ObjectMonitor* used when locking.
+  volatile uintptr_t _metadata;
+
+  uintptr_t get_metadata() const { return Atomic::load(&_metadata); }
+  void set_metadata(uintptr_t value) { Atomic::store(&_metadata, value); }
+  static int metadata_offset_in_bytes() { return (int)offset_of(BasicLock, _metadata); }
+
  public:
-  markWord displaced_header() const {
-    return Atomic::load(&_displaced_header);
-  }
+  // LM_MONITOR
+  void set_bad_metadata_deopt() { set_metadata(badDispHeaderDeopt); }
 
-  void set_displaced_header(markWord header) {
-    Atomic::store(&_displaced_header, header);
-  }
+  // LM_LEGACY
+  inline markWord displaced_header() const;
+  inline void set_displaced_header(markWord header);
+  static int displaced_header_offset_in_bytes() { return metadata_offset_in_bytes(); }
 
-  // TODO[OMWorld]: Cleanup these names, the storage `_displaced_header` usage depends on the locking mode.
-  void clear_displaced_header() {
-    Atomic::store(&_displaced_header, markWord(0));
-  }
-
-  void set_displaced_header(ObjectMonitor* mon) {
-    Atomic::store(&_displaced_header, markWord::from_pointer(mon));
-  }
+  // LM_LIGHTWEIGHT
+  inline ObjectMonitor* object_monitor_cache() const;
+  inline void clear_object_monitor_cache();
+  inline void set_object_monitor_cache(ObjectMonitor* mon);
+  static int object_monitor_cache_offset_in_bytes() { return metadata_offset_in_bytes(); }
 
   void print_on(outputStream* st, oop owner) const;
 
   // move a basic lock (used during deoptimization)
   void move_to(oop obj, BasicLock* dest);
-
-  static int displaced_header_offset_in_bytes() { return (int)offset_of(BasicLock, _displaced_header); }
 };
 
 // A BasicObjectLock associates a specific Java object with a BasicLock.

--- a/src/hotspot/share/runtime/basicLock.inline.hpp
+++ b/src/hotspot/share/runtime/basicLock.inline.hpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef SHARE_RUNTIME_BASICLOCK_INLINE_HPP
+#define SHARE_RUNTIME_BASICLOCK_INLINE_HPP
+
+#include "runtime/basicLock.hpp"
+
+inline markWord BasicLock::displaced_header() const {
+  assert(LockingMode == LM_LEGACY, "must be");
+  return markWord(get_metadata());
+}
+
+inline void BasicLock::set_displaced_header(markWord header) {
+  assert(LockingMode == LM_LEGACY, "must be");
+  Atomic::store(&_metadata, header.value());
+}
+
+inline ObjectMonitor* BasicLock::object_monitor_cache() const {
+  assert(LockingMode == LM_LIGHTWEIGHT, "must be");
+  return reinterpret_cast<ObjectMonitor*>(get_metadata());
+}
+
+inline void BasicLock::clear_object_monitor_cache() {
+  assert(LockingMode == LM_LIGHTWEIGHT, "must be");
+  set_metadata(0);
+}
+
+inline void BasicLock::set_object_monitor_cache(ObjectMonitor* mon) {
+  assert(LockingMode == LM_LIGHTWEIGHT, "must be");
+  set_metadata(reinterpret_cast<uintptr_t>(mon));
+}
+
+#endif // SHARE_RUNTIME_BASICLOCK_INLINE_HPP

--- a/src/hotspot/share/runtime/lightweightSynchronizer.cpp
+++ b/src/hotspot/share/runtime/lightweightSynchronizer.cpp
@@ -31,6 +31,7 @@
 #include "logging/logStream.hpp"
 #include "memory/resourceArea.hpp"
 #include "oops/oop.inline.hpp"
+#include "runtime/basicLock.inline.hpp"
 #include "runtime/globals_extension.hpp"
 #include "runtime/javaThread.hpp"
 #include "runtime/lightweightSynchronizer.hpp"
@@ -524,9 +525,9 @@ public:
   ~CacheSetter() {
     if (_monitor != nullptr) {
       _thread->om_set_monitor_cache(_monitor);
-      _lock->set_displaced_header(_monitor);
+      _lock->set_object_monitor_cache(_monitor);
     } else {
-      _lock->clear_displaced_header();
+      _lock->clear_object_monitor_cache();
     }
   }
 

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -56,6 +56,7 @@
 #include "prims/methodHandles.hpp"
 #include "prims/nativeLookup.hpp"
 #include "runtime/atomic.hpp"
+#include "runtime/basicLock.inline.hpp"
 #include "runtime/frame.inline.hpp"
 #include "runtime/globals.hpp"
 #include "runtime/handles.inline.hpp"
@@ -2937,7 +2938,7 @@ JRT_LEAF(intptr_t*, SharedRuntime::OSR_migration_begin( JavaThread *current) )
         // object's header no longer refers to it.
         buf[i] = (intptr_t)lock->displaced_header().value();
       } else if (LockingMode == LM_LIGHTWEIGHT) {
-        buf[i] = (intptr_t)lock->displaced_header().value();
+        buf[i] = (intptr_t)lock->object_monitor_cache();
       }
 #ifdef ASSERT
       else {

--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -35,6 +35,7 @@
 #include "oops/markWord.hpp"
 #include "oops/oop.inline.hpp"
 #include "runtime/atomic.hpp"
+#include "runtime/basicLock.inline.hpp"
 #include "runtime/frame.inline.hpp"
 #include "runtime/globals.hpp"
 #include "runtime/handles.inline.hpp"

--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -460,7 +460,7 @@ bool ObjectSynchronizer::quick_enter(oop obj, JavaThread* current,
       return true;
     }
 
-    if (LockingMode != LM_LIGHTWEIGHT) {
+    if (LockingMode == LM_LEGACY) {
       // This Java Monitor is inflated so obj's header will never be
       // displaced to this thread's BasicLock. Make the displaced header
       // non-null so this BasicLock is not seen as recursive nor as

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -782,7 +782,7 @@
   unchecked_nonstatic_field(ObjectMonitor,     _object,                                       sizeof(void *)) /* NOTE: no type */    \
   unchecked_nonstatic_field(ObjectMonitor,     _owner,                                        sizeof(void *)) /* NOTE: no type */    \
   volatile_nonstatic_field(ObjectMonitor,      _next_om,                                      ObjectMonitor*)                        \
-  volatile_nonstatic_field(BasicLock,          _displaced_header,                             markWord)                              \
+  volatile_nonstatic_field(BasicLock,          _metadata,                                     uintptr_t)                             \
   nonstatic_field(ObjectMonitor,               _contentions,                                  int)                                   \
   volatile_nonstatic_field(ObjectMonitor,      _waiters,                                      int)                                   \
   volatile_nonstatic_field(ObjectMonitor,      _recursions,                                   intx)                                  \

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/BasicLock.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/BasicLock.java
@@ -43,7 +43,7 @@ public class BasicLock extends VMObject {
 
   private static synchronized void initialize(TypeDataBase db) throws WrongTypeException {
     Type type  = db.lookupType("BasicLock");
-    displacedHeaderField = type.getCIntegerField("_displaced_header");
+    displacedHeaderField = type.getCIntegerField("_metadata");
   }
 
   private static CIntegerField displacedHeaderField;


### PR DESCRIPTION
Cleanup the usage of the header field in BasicLock. Because the asserts are stronger now I also cleanup the zero usage of the BasicLock. Because https://bugs.openjdk.org/browse/JDK-8307532 is not yet implemented I have not tested this interaction but as this now restricts the displaced header in the BasicLock to only LM_LEGACY something had to be done for LM_MONITOR support. 

This also changes symbols exposed through JVMCI so it may take extra effort to get this through. 

Similarly to #161 some changes could be upstreamed, and here there is already a distinction as neither `LM_LIGHTWEIGHT` nor `LM_MONITOR` uses the displaced header.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - Committer) ⚠️ Review applies to [b54babc1](https://git.openjdk.org/lilliput/pull/162/files/b54babc19f58fff198d1d4a9c7609382e243f59d)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput.git pull/162/head:pull/162` \
`$ git checkout pull/162`

Update a local copy of the PR: \
`$ git checkout pull/162` \
`$ git pull https://git.openjdk.org/lilliput.git pull/162/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 162`

View PR using the GUI difftool: \
`$ git pr show -t 162`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput/pull/162.diff">https://git.openjdk.org/lilliput/pull/162.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput/pull/162#issuecomment-2072882106)