### PR TITLE
Parallel: fix size_given_klass

### DIFF
--- a/src/hotspot/share/oops/oop.cpp
+++ b/src/hotspot/share/oops/oop.cpp
@@ -221,12 +221,12 @@ jdouble oopDesc::double_field_acquire(int offset) const               { return A
 void oopDesc::release_double_field_put(int offset, jdouble value)     { Atomic::release_store(field_addr<jdouble>(offset), value); }
 
 #ifdef ASSERT
-bool oopDesc::size_might_change() {
+bool oopDesc::size_might_change(Klass* klass) {
   // UseParallelGC and UseG1GC can change the length field
   // of an "old copy" of an object array in the young gen so it indicates
   // the grey portion of an already copied array. This will cause the first
   // disjunct below to fail if the two comparands are computed across such
   // a concurrent change.
-  return Universe::heap()->is_gc_active() && is_objArray() && is_forwarded() && (UseParallelGC || UseG1GC);
+  return Universe::heap()->is_gc_active() && klass->is_objArray_klass() && is_forwarded() && (UseParallelGC || UseG1GC);
 }
 #endif

--- a/src/hotspot/share/oops/oop.hpp
+++ b/src/hotspot/share/oops/oop.hpp
@@ -379,7 +379,7 @@ public:
   // for error reporting
   static void* load_oop_raw(oop obj, int offset);
 
-  DEBUG_ONLY(bool size_might_change();)
+  DEBUG_ONLY(bool size_might_change(Klass* klass);)
 };
 
 // An oopDesc is not initialized via a constructor.  Space is allocated in

--- a/src/hotspot/share/oops/oop.inline.hpp
+++ b/src/hotspot/share/oops/oop.inline.hpp
@@ -213,7 +213,7 @@ size_t oopDesc::size_given_klass(Klass* klass)  {
       // skipping the intermediate round to HeapWordSize.
       s = align_up(size_in_bytes, MinObjAlignmentInBytes) / HeapWordSize;
 
-      assert(s == klass->oop_size(this) || size_might_change(), "wrong array object size");
+      assert(s == klass->oop_size(this) || size_might_change(klass), "wrong array object size");
     } else {
       // Must be zero, so bite the bullet and take the virtual call.
       s = klass->oop_size(this);


### PR DESCRIPTION
The Parallel scavenge threads compete to copy and forward objects, and the winning object is the one that managed to update the the forwarding pointer. For Lilliput, this code needs to be extra carefully written because installing the forwarding pointer destroys the klass pointer. The threads need to read the object header once, and then use that information when figuring out the size of the object. The code has been changed to do this, but there's a place in an assert were the code tries to reread the klass pointer, and then crash because it has been racingly been overwritten by another thread.

I had an idea that we could fix this by simplifying the assert with #149, but that has a problem with self-forwarded objects. There are ways to fix the problem listed in that PR, but for now the suggestion is to just make sure that the asserting code doesn't reread the klass pointer.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - Committer)
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput.git pull/163/head:pull/163` \
`$ git checkout pull/163`

Update a local copy of the PR: \
`$ git checkout pull/163` \
`$ git pull https://git.openjdk.org/lilliput.git pull/163/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 163`

View PR using the GUI difftool: \
`$ git pr show -t 163`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput/pull/163.diff">https://git.openjdk.org/lilliput/pull/163.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput/pull/163#issuecomment-2072091929)