### PR TITLE
Fix CompressedClassPointersEncodingScheme for aarch64 with -UseCOH

### DIFF
--- a/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointersEncodingScheme.java
+++ b/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointersEncodingScheme.java
@@ -83,8 +83,10 @@ public class CompressedClassPointersEncodingScheme {
         // - non-aarch64: base=0, shift=3
         // - aarch64: base to start of class range, shift 0
         if (Platform.isAArch64()) {
-            long forceAddress = 0x70000000; // make sure we have a valid EOR immediate
-            test(forceAddress, false, G, forceAddress, 0);
+            // The best we can do on aarch64 is to be *near* the end of the 32g range, since a valid encoding base
+            // on aarch64 must be 4G aligned, and the max. class space size is 3G.
+            long forceAddress = 0x7_0000_0000L; // 28g, and also a valid EOR immediate
+            test(forceAddress, false, 3 * G, forceAddress, 0);
         } else {
             test(32 * G - 128 * M, false, 128 * M, 0, 3);
         }
@@ -92,7 +94,7 @@ public class CompressedClassPointersEncodingScheme {
         // Test ccs starting *below* 4G, but extending upwards beyond 4G. All platforms except aarch64 should pick
         // zero based encoding.
         if (Platform.isAArch64()) {
-            long forceAddress = 0xc0000000; // make sure we have a valid EOR immediate
+            long forceAddress = 0xC000_0000L; // make sure we have a valid EOR immediate
             test(forceAddress, false, G + (128 * M), forceAddress, 0);
         } else {
             test(4 * G - 128 * M, false, 2 * 128 * M, 0, 3);


### PR DESCRIPTION
There had been two errors.

- the literal was missing the L to make it long
- the first test that tests mapping below the 32g boundary was using a far too low address.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - Committer)
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput.git pull/164/head:pull/164` \
`$ git checkout pull/164`

Update a local copy of the PR: \
`$ git checkout pull/164` \
`$ git pull https://git.openjdk.org/lilliput.git pull/164/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 164`

View PR using the GUI difftool: \
`$ git pr show -t 164`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput/pull/164.diff">https://git.openjdk.org/lilliput/pull/164.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput/pull/164#issuecomment-2073059256)