### PR TITLE
Disable UseCompressedOops tests for 32-bits JVMs

### DIFF
--- a/test/hotspot/jtreg/runtime/FieldLayout/BaseOffsets.java
+++ b/test/hotspot/jtreg/runtime/FieldLayout/BaseOffsets.java
@@ -24,6 +24,7 @@
 /*
  * @test id=with-coops-with-ccp
  * @library /test/lib /
+ * @requires vm.bits == "64"
  * @modules java.base/jdk.internal.misc
  *          java.management
  * @build jdk.test.whitebox.WhiteBox
@@ -33,6 +34,7 @@
 /*
  * @test id=no-coops-with-ccp
  * @library /test/lib /
+ * @requires vm.bits == "64"
  * @modules java.base/jdk.internal.misc
  *          java.management
  * @build jdk.test.whitebox.WhiteBox
@@ -42,6 +44,7 @@
 /*
  * @test id=with-coops-no-ccp
  * @library /test/lib /
+ * @requires vm.bits == "64"
  * @modules java.base/jdk.internal.misc
  *          java.management
  * @build jdk.test.whitebox.WhiteBox
@@ -51,6 +54,7 @@
 /*
  * @test id=no-coops-no-ccp
  * @library /test/lib /
+ * @requires vm.bits == "64"
  * @modules java.base/jdk.internal.misc
  *          java.management
  * @build jdk.test.whitebox.WhiteBox
@@ -60,6 +64,7 @@
 /*
  * @test id=with-coop--with-coh
  * @library /test/lib /
+ * @requires vm.bits == "64"
  * @modules java.base/jdk.internal.misc
  *          java.management
  * @build jdk.test.whitebox.WhiteBox
@@ -69,6 +74,7 @@
 /*
  * @test id=no-coops-with-coh
  * @library /test/lib /
+ * @requires vm.bits == "64"
  * @modules java.base/jdk.internal.misc
  *          java.management
  * @build jdk.test.whitebox.WhiteBox


### PR DESCRIPTION
Fix failures in GHA. Stop running tests using UseCompressedOops on 32-bit JVMs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput.git pull/166/head:pull/166` \
`$ git checkout pull/166`

Update a local copy of the PR: \
`$ git checkout pull/166` \
`$ git pull https://git.openjdk.org/lilliput.git pull/166/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 166`

View PR using the GUI difftool: \
`$ git pr show -t 166`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput/pull/166.diff">https://git.openjdk.org/lilliput/pull/166.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput/pull/166#issuecomment-2074114292)