### PR TITLE
8330631: Lilliput: Modify runtime/CompressedOops/CompressedClassPointers for tinycp

### DIFF
--- a/src/hotspot/share/oops/compressedKlass.cpp
+++ b/src/hotspot/share/oops/compressedKlass.cpp
@@ -186,17 +186,11 @@ char* CompressedKlassPointers::reserve_address_space_X(uintptr_t from, uintptr_t
 }
 
 char* CompressedKlassPointers::reserve_address_space_for_unscaled_encoding(size_t size, bool aslr) {
-  if (tiny_classpointer_mode()) {
-    return nullptr;
-  }
   const size_t unscaled_max = nth_bit(narrow_klass_pointer_bits());
   return reserve_address_space_X(0, unscaled_max, size, Metaspace::reserve_alignment(), aslr);
 }
 
 char* CompressedKlassPointers::reserve_address_space_for_zerobased_encoding(size_t size, bool aslr) {
-  if (tiny_classpointer_mode()) {
-    return nullptr;
-  }
   const size_t unscaled_max = nth_bit(narrow_klass_pointer_bits());
   const size_t zerobased_max = nth_bit(narrow_klass_pointer_bits() + max_shift());
   return reserve_address_space_X(unscaled_max, zerobased_max, size, Metaspace::reserve_alignment(), aslr);

--- a/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointers.java
+++ b/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointers.java
@@ -46,6 +46,7 @@ public class CompressedClassPointers {
 
     static final String logging_option = "-Xlog:gc+metaspace=trace,metaspace=info,cds=trace";
     static final String reserveCCSAnywhere = "Reserving compressed class space anywhere";
+    static final String usesCompactObjectHeadersPat = "UseCompactObjectHeaders 1";
 
     // Returns true if we are to test the narrow klass base; we only do this on
     // platforms where we can be reasonably shure that we get reproducable placement).
@@ -55,6 +56,15 @@ public class CompressedClassPointers {
         }
         return true;
 
+    }
+
+    // Returns true if the output indicates that the VM uses compact object headers
+    static boolean usesCompactObjectHeaders(OutputAnalyzer output) {
+        if (output.getOutput().contains(usesCompactObjectHeadersPat)) {
+            return true;
+        } else {
+            return false;
+        }
     }
 
     // Returns true if the output indicates that the ccs is reserved anywhere.
@@ -221,7 +231,7 @@ public class CompressedClassPointers {
             "-Xlog:cds=trace",
             "-XX:+VerifyBeforeGC", "-version");
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
-        if (!isCCSReservedAnywhere(output)) {
+        if (!isCCSReservedAnywhere(output) && !usesCompactObjectHeaders(output)) {
             output.shouldContain("Narrow klass base: 0x0000000000000000");
         }
         output.shouldHaveExitValue(0);
@@ -239,10 +249,10 @@ public class CompressedClassPointers {
             "-Xlog:cds=trace",
             "-XX:+VerifyBeforeGC", "-version");
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
-        if (!isCCSReservedAnywhere(output)) {
+        if (!isCCSReservedAnywhere(output) && !usesCompactObjectHeaders(output)) {
             output.shouldContain("Narrow klass base: 0x0000000000000000");
         }
-        if (!Platform.isAArch64() && !Platform.isPPC()) {
+        if (!Platform.isAArch64()  && !usesCompactObjectHeaders(output) && !Platform.isPPC()) {
             // Currently relax this test for Aarch64 and ppc.
             output.shouldContain("Narrow klass shift: 0");
         }
@@ -261,10 +271,10 @@ public class CompressedClassPointers {
             "-Xlog:cds=trace",
             "-XX:+VerifyBeforeGC", "-version");
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
-        if (!isCCSReservedAnywhere(output)) {
+        if (!isCCSReservedAnywhere(output) && !usesCompactObjectHeaders(output)) {
             output.shouldContain("Narrow klass base: 0x0000000000000000");
         }
-        if (!Platform.isAArch64() && !Platform.isPPC()) {
+        if (!Platform.isAArch64()  && !usesCompactObjectHeaders(output) && !Platform.isPPC()) {
             // Currently relax this test for Aarch64 and ppc.
             output.shouldContain("Narrow klass shift: 0");
         }

--- a/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointers.java
+++ b/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointers.java
@@ -60,11 +60,7 @@ public class CompressedClassPointers {
 
     // Returns true if the output indicates that the VM uses compact object headers
     static boolean usesCompactObjectHeaders(OutputAnalyzer output) {
-        if (output.getOutput().contains(usesCompactObjectHeadersPat)) {
-            return true;
-        } else {
-            return false;
-        }
+        return output.getOutput().contains(usesCompactObjectHeadersPat);
     }
 
     // Returns true if the output indicates that the ccs is reserved anywhere.


### PR DESCRIPTION
A patch that got lost in the Great Reset. Fixes test failure in runtime/CompressedOops/CompressedClassPointers.java. Originally done by @tstuefe .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8330631](https://bugs.openjdk.org/browse/JDK-8330631): Lilliput: Modify runtime/CompressedOops/CompressedClassPointers for tinycp (**Bug** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - Committer) ⚠️ Review applies to [84860699](https://git.openjdk.org/lilliput/pull/167/files/84860699afa1ad428703246725fe12682fb6359a)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput.git pull/167/head:pull/167` \
`$ git checkout pull/167`

Update a local copy of the PR: \
`$ git checkout pull/167` \
`$ git pull https://git.openjdk.org/lilliput.git pull/167/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 167`

View PR using the GUI difftool: \
`$ git pr show -t 167`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput/pull/167.diff">https://git.openjdk.org/lilliput/pull/167.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput/pull/167#issuecomment-2074152645)