### PR TITLE
OMWorld: Fix enter_for is_value_based bug

### DIFF
--- a/src/hotspot/share/runtime/lightweightSynchronizer.cpp
+++ b/src/hotspot/share/runtime/lightweightSynchronizer.cpp
@@ -566,7 +566,7 @@ void LightweightSynchronizer::enter_for(Handle obj, BasicLock* lock, JavaThread*
 
   // TODO[OMWorld]: Is this necessary?
   if (obj->klass()->is_value_based()) {
-    ObjectSynchronizer::handle_sync_on_value_based_class(obj, current);
+    ObjectSynchronizer::handle_sync_on_value_based_class(obj, locking_thread);
   }
 
   locking_thread->inc_held_monitor_count();


### PR DESCRIPTION
There was a copy-n-paste error in one of the previous OMWorld patches. `handle_sync_on_value_based_class` expects the `locking_thread` and not the `current` thread.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput.git pull/168/head:pull/168` \
`$ git checkout pull/168`

Update a local copy of the PR: \
`$ git checkout pull/168` \
`$ git pull https://git.openjdk.org/lilliput.git pull/168/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 168`

View PR using the GUI difftool: \
`$ git pr show -t 168`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput/pull/168.diff">https://git.openjdk.org/lilliput/pull/168.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput/pull/168#issuecomment-2074167320)