### PR TITLE
OMWorld: Add LightweightSynchronizer::quick_enter - fix incorrectly setup cache

### DIFF
--- a/src/hotspot/share/runtime/lightweightSynchronizer.cpp
+++ b/src/hotspot/share/runtime/lightweightSynchronizer.cpp
@@ -1019,7 +1019,7 @@ intptr_t LightweightSynchronizer::FastHashCode(Thread* current, oop obj) {
   }
 }
 
-bool LightweightSynchronizer::quick_enter(oop obj, JavaThread* current, BasicLock * lock) {
+bool LightweightSynchronizer::quick_enter(oop obj, JavaThread* current, BasicLock* lock) {
   assert(LockingMode == LM_LIGHTWEIGHT, "must be");
   assert(current->thread_state() == _thread_in_Java, "must be");
   assert(obj != nullptr, "must be");

--- a/src/hotspot/share/runtime/lightweightSynchronizer.cpp
+++ b/src/hotspot/share/runtime/lightweightSynchronizer.cpp
@@ -1018,3 +1018,45 @@ intptr_t LightweightSynchronizer::FastHashCode(Thread* current, oop obj) {
     }
   }
 }
+
+bool LightweightSynchronizer::quick_enter(oop obj, JavaThread* current, BasicLock * lock) {
+  assert(LockingMode == LM_LIGHTWEIGHT, "must be");
+  assert(current->thread_state() == _thread_in_Java, "must be");
+  assert(obj != nullptr, "must be");
+  NoSafepointVerifier nsv;
+
+  CacheSetter cache_setter(current, lock);
+
+  LockStack& lock_stack = current->lock_stack();
+  if (lock_stack.is_full()) {
+    // Always go into runtime if the lock stack is full.
+    return false;
+  }
+
+  if (lock_stack.try_recursive_enter(obj)) {
+    // Recursive lock successful.
+    current->inc_held_monitor_count();
+    return true;
+  }
+
+  const markWord mark = obj->mark();
+
+  if (mark.has_monitor()) {
+    ObjectMonitor* const monitor = current->om_get_from_monitor_cache(obj);
+
+    if (monitor == nullptr) {
+      // Take the slow-path on a cache miss.
+      return false;
+    }
+
+    if (monitor->try_enter(current)) {
+      // ObjectMonitor enter successful.
+      cache_setter.set_monitor(monitor);
+      current->inc_held_monitor_count();
+      return true;
+    }
+  }
+
+  // Slow-path.
+  return false;
+}

--- a/src/hotspot/share/runtime/lightweightSynchronizer.hpp
+++ b/src/hotspot/share/runtime/lightweightSynchronizer.hpp
@@ -72,6 +72,8 @@ private:
 
   // NOTE: May not cause monitor inflation
   static intptr_t FastHashCode(Thread* current, oop obj);
+
+  static bool quick_enter(oop obj, JavaThread* current, BasicLock* Lock);
 };
 
 #endif // SHARE_RUNTIME_LIGHTWEIGHTSYNCHRONIZER_HPP

--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -408,6 +408,7 @@ bool ObjectSynchronizer::quick_enter(oop obj, JavaThread* current,
                                      BasicLock * lock) {
   assert(current->thread_state() == _thread_in_Java, "invariant");
   NoSafepointVerifier nsv;
+
   if (obj == nullptr) return false;       // Need to throw NPE
 
   if (obj->klass()->is_value_based()) {
@@ -415,31 +416,13 @@ bool ObjectSynchronizer::quick_enter(oop obj, JavaThread* current,
   }
 
   if (LockingMode == LM_LIGHTWEIGHT) {
-    LockStack& lock_stack = current->lock_stack();
-    if (lock_stack.is_full()) {
-      // Always go into runtime if the lock stack is full.
-      return false;
-    }
-    if (lock_stack.try_recursive_enter(obj)) {
-      // Recursive lock successful.
-      current->inc_held_monitor_count();
-      return true;
-    }
+    return LightweightSynchronizer::quick_enter(obj, current, lock);
   }
 
   const markWord mark = obj->mark();
 
   if (mark.has_monitor()) {
-    ObjectMonitor* m = nullptr;
-    if (LockingMode == LM_LIGHTWEIGHT) {
-      m = current->om_get_from_monitor_cache(obj);
-      if (m == nullptr) {
-        // Take the slow-path on a cache miss.
-        return false;
-      }
-    } else {
-      m = ObjectSynchronizer::read_monitor(mark);
-    }
+    ObjectMonitor* const m = ObjectSynchronizer::read_monitor(mark);
     // An async deflation or GC can race us before we manage to make
     // the ObjectMonitor busy by setting the owner below. If we detect
     // that race we just bail out to the slow-path here.
@@ -459,18 +442,16 @@ bool ObjectSynchronizer::quick_enter(oop obj, JavaThread* current,
       return true;
     }
 
-    if (LockingMode != LM_LIGHTWEIGHT) {
-      // This Java Monitor is inflated so obj's header will never be
-      // displaced to this thread's BasicLock. Make the displaced header
-      // non-null so this BasicLock is not seen as recursive nor as
-      // being locked. We do this unconditionally so that this thread's
-      // BasicLock cannot be mis-interpreted by any stack walkers. For
-      // performance reasons, stack walkers generally first check for
-      // stack-locking in the object's header, the second check is for
-      // recursive stack-locking in the displaced header in the BasicLock,
-      // and last are the inflated Java Monitor (ObjectMonitor) checks.
-      lock->set_displaced_header(markWord::unused_mark());
-    }
+    // This Java Monitor is inflated so obj's header will never be
+    // displaced to this thread's BasicLock. Make the displaced header
+    // non-null so this BasicLock is not seen as recursive nor as
+    // being locked. We do this unconditionally so that this thread's
+    // BasicLock cannot be mis-interpreted by any stack walkers. For
+    // performance reasons, stack walkers generally first check for
+    // stack-locking in the object's header, the second check is for
+    // recursive stack-locking in the displaced header in the BasicLock,
+    // and last are the inflated Java Monitor (ObjectMonitor) checks.
+    lock->set_displaced_header(markWord::unused_mark());
 
     if (owner == nullptr && m->try_set_owner_from(nullptr, current) == nullptr) {
       assert(m->_recursions == 0, "invariant");

--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -408,7 +408,6 @@ bool ObjectSynchronizer::quick_enter(oop obj, JavaThread* current,
                                      BasicLock * lock) {
   assert(current->thread_state() == _thread_in_Java, "invariant");
   NoSafepointVerifier nsv;
-
   if (obj == nullptr) return false;       // Need to throw NPE
 
   if (obj->klass()->is_value_based()) {


### PR DESCRIPTION
`ObjectSynchronizer::quick_enter` did not setup the BasicLock cache correctly when successful. When x86_32 started calling directly into the VM there are paths which never cleared the cache. Add `LightweightSynchronizer::quick_enter` which correctly clears or sets the cache in all paths.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - Committer) ⚠️ Review applies to [3201e2be](https://git.openjdk.org/lilliput/pull/169/files/3201e2be2a777b5ec8979b94b73ca298d9cc3670)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput.git pull/169/head:pull/169` \
`$ git checkout pull/169`

Update a local copy of the PR: \
`$ git checkout pull/169` \
`$ git pull https://git.openjdk.org/lilliput.git pull/169/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 169`

View PR using the GUI difftool: \
`$ git pr show -t 169`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput/pull/169.diff">https://git.openjdk.org/lilliput/pull/169.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput/pull/169#issuecomment-2074415588)