### PR TITLE
Fix arrays-equals intrinsic on AArch64

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -5242,6 +5242,14 @@ address MacroAssembler::arrays_equals(Register a1, Register a2, Register tmp3,
   int length_offset = arrayOopDesc::length_offset_in_bytes();
   int base_offset
     = arrayOopDesc::base_offset_in_bytes(elem_size == 2 ? T_CHAR : T_BYTE);
+  // When the base is not aligned to 8 bytes, then we let
+  // the compare loop include the array length, and skip
+  // the explicit comparison of length.
+  bool is_8aligned = is_aligned(base_offset, BytesPerWord);
+  assert(is_aligned(base_offset, BytesPerWord) || is_aligned(length_offset, BytesPerWord),
+         "base_offset or length_offset must be 8-byte aligned");
+  int start_offset = is_8aligned ? base_offset : length_offset;
+  int extra_length = is_8aligned ? 0 : BytesPerInt / elem_size;
   int stubBytesThreshold = 3 * 64 + (UseSIMDForArrayEquals ? 0 : 16);
 
   assert(elem_size == 1 || elem_size == 2, "must be char or byte");
@@ -5276,10 +5284,15 @@ address MacroAssembler::arrays_equals(Register a1, Register a2, Register tmp3,
     bind(A_IS_NOT_NULL);
     ldrw(cnt1, Address(a1, length_offset));
     ldrw(cnt2, Address(a2, length_offset));
+    if (extra_length != 0) {
+      // Increase loop counter by size of length field.
+      addw(cnt1, cnt1, extra_length);
+      addw(cnt2, cnt2, extra_length);
+    }
     eorw(tmp5, cnt1, cnt2);
     cbnzw(tmp5, DONE);
-    lea(a1, Address(a1, base_offset));
-    lea(a2, Address(a2, base_offset));
+    lea(a1, Address(a1, start_offset));
+    lea(a2, Address(a2, start_offset));
     // Check for short strings, i.e. smaller than wordSize.
     subs(cnt1, cnt1, elem_per_word);
     br(Assembler::LT, SHORT);
@@ -5338,41 +5351,27 @@ address MacroAssembler::arrays_equals(Register a1, Register a2, Register tmp3,
   } else {
     Label NEXT_DWORD, SHORT, TAIL, TAIL2, STUB,
         CSET_EQ, LAST_CHECK;
-    // When the base is not aligned to 8 bytes, then we let
-    // the compare loop include the array length, and skip
-    // the explicit comparison of length.
-    bool is_8aligned = is_aligned(base_offset, BytesPerWord);
     mov(result, false);
     cbz(a1, DONE);
     ldrw(cnt1, Address(a1, length_offset));
     cbz(a2, DONE);
     ldrw(cnt2, Address(a2, length_offset));
-    if (!is_8aligned) {
+    if (extra_length != 0) {
       // Increase loop counter by size of length field.
-      addw(cnt1, cnt1, BytesPerInt / elem_size);
-      addw(cnt2, cnt2, BytesPerInt / elem_size);
+      addw(cnt1, cnt1, extra_length);
+      addw(cnt2, cnt2, extra_length);
     }
     // on most CPUs a2 is still "locked"(surprisingly) in ldrw and it's
     // faster to perform another branch before comparing a1 and a2
     cmp(cnt1, (u1)elem_per_word);
     br(LE, SHORT); // short or same
-    if (is_8aligned) {
-      ldr(tmp3, Address(pre(a1, base_offset)));
-    } else {
-      ldr(tmp3, Address(pre(a1, length_offset)));
-    }
+    ldr(tmp3, Address(pre(a1, start_offset)));
     subs(zr, cnt1, stubBytesThreshold);
     br(GE, STUB);
-    if (is_8aligned) {
-      ldr(tmp4, Address(pre(a2, base_offset)));
-    } else {
-      ldr(tmp4, Address(pre(a2, length_offset)));
-    }
+    ldr(tmp4, Address(pre(a2, start_offset)));
     sub(tmp5, zr, cnt1, LSL, 3 + log_elem_size);
-    if (is_8aligned) {
-      cmp(cnt2, cnt1);
-      br(NE, DONE);
-    }
+    cmp(cnt2, cnt1);
+    br(NE, DONE);
 
     // Main 16 byte comparison loop with 2 exits
     bind(NEXT_DWORD); {
@@ -5404,11 +5403,7 @@ address MacroAssembler::arrays_equals(Register a1, Register a2, Register tmp3,
     b(LAST_CHECK);
 
     bind(STUB);
-    if (is_8aligned) {
-      ldr(tmp4, Address(pre(a2, base_offset)));
-    } else {
-      ldr(tmp4, Address(pre(a2, length_offset)));
-    }
+    ldr(tmp4, Address(pre(a2, start_offset)));
     cmp(cnt2, cnt1);
     br(NE, DONE);
     if (elem_size == 2) { // convert to byte counter
@@ -5431,22 +5426,12 @@ address MacroAssembler::arrays_equals(Register a1, Register a2, Register tmp3,
     mov(result, a2);
     b(DONE);
     bind(SHORT);
-    if (is_8aligned) {
-      cmp(cnt2, cnt1);
-      br(NE, DONE);
-    }
+    cmp(cnt2, cnt1);
+    br(NE, DONE);
     cbz(cnt1, SAME);
     sub(tmp5, zr, cnt1, LSL, 3 + log_elem_size);
-    if (is_8aligned) {
-      ldr(tmp3, Address(pre(a1, base_offset)));
-    } else {
-      ldr(tmp3, Address(pre(a1, length_offset)));
-    }
-    if (is_8aligned) {
-      ldr(tmp4, Address(pre(a2, base_offset)));
-    } else {
-      ldr(tmp4, Address(pre(a2, length_offset)));
-    }
+    ldr(tmp3, Address(pre(a1, start_offset)));
+    ldr(tmp4, Address(pre(a2, start_offset)));
     bind(LAST_CHECK);
     eor(tmp4, tmp3, tmp4);
     lslv(tmp5, tmp4, tmp5);


### PR DESCRIPTION
The arrays-equals intrinsic on AArch64 assumes that array elements start at 8-byte-aligned boundary. There are several problems with that:
- I believe it may give wrong results when comparing some junk after the end of the array.
- We may crash when loading beyond the heap boundary.

The proposed fix is to start the comparison at the array-length field. When the array base is unaligned (that is really 4-byte-aligned), then the array-length is at 8-byte-aligned location. And since we want to compare the lengths anyway, we can just as well use word-sized loads to compare the length and first elements in a single step, and elide the separate cmp+branch for the length.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput.git pull/170/head:pull/170` \
`$ git checkout pull/170`

Update a local copy of the PR: \
`$ git checkout pull/170` \
`$ git pull https://git.openjdk.org/lilliput.git pull/170/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 170`

View PR using the GUI difftool: \
`$ git pr show -t 170`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput/pull/170.diff">https://git.openjdk.org/lilliput/pull/170.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput/pull/170#issuecomment-2075116835)