### PR TITLE
Prepare for smaller-than-22-bit class pointers

### DIFF
--- a/src/hotspot/share/oops/compressedKlass.hpp
+++ b/src/hotspot/share/oops/compressedKlass.hpp
@@ -133,6 +133,10 @@ public:
   // The maximum possible shift; the actual shift employed later can be smaller (see initialize())
   static int max_shift()                 { check_init(_max_shift); return _max_shift; }
 
+  // Returns the maximum encoding range that can be covered with the currently
+  // choosen nKlassID geometry (nKlass bit size, max shift)
+  static size_t max_encoding_range_size();
+
   // Reserve a range of memory that is to contain Klass strucutures which are referenced by narrow Klass IDs.
   // If optimize_for_zero_base is true, the implementation will attempt to reserve optimized for zero-based encoding.
   static char* reserve_address_space_for_compressed_classes(size_t size, bool aslr, bool optimize_for_zero_base);

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -131,8 +131,6 @@ const size_t minimumSymbolTableSize = 1024;
   product(bool, UseCompactObjectHeaders, false, EXPERIMENTAL,               \
           "Use compact 64-bit object headers in 64-bit VM")                 \
                                                                             \
-  develop(int, TinyClassPointerShift, 0, "")                                \
-                                                                            \
   product(int, ObjectAlignmentInBytes, 8,                                   \
           "Default object alignment in bytes, 8 is minimum")                \
           range(8, 256)                                                     \


### PR DESCRIPTION
This PR prepares using arbitrary klass pointer sizes (e.g. 16). It cleans up a few places and corrects comments.

The changes in detail:

- exposes a new function `CompressedKlassPointers::max_encoding_range_size()` that returns the maximum possible size of the encoding range given the current nKlass geometry (e.g. 16 bit klass pointers with a max. shift of 10 bits can encode 64MB of class space). 

- In Metaspace::ergo_initialize(), where we ergo-adjust the CompressedClassSpaceSize, the maximum possible encoding range size flows into this adjustment now. We also print clearer warnings in case the user specifies CCS size explicitly, and we override that decision.

- removed any hard-wiredness of a "max class space size/encoding range size of 4GB" since with smaller geometries that does not hold true anymore. Instead, we now use `CompressedKlassPointers::max_encoding_range_size()`.

- made the requirements on klass_alignment_in_bytes clearer when setting up class space

- removed remnant code (TinyClassPointerShift) left over from development


Note: One still unsolved problem—unsolved in Lilliput as well as upstream—is to correctly limit the compressed class space size in the presence of CDS. Upstream "solves" this by capping CCS size at 3GB, which leaves 1GB for CDS archives. There is no solution if CDS would ever exceed this limit,  and it's a waste of space for CCS. 

In Lilliput, if we limit the class pointer size such that we drastically reduce the klass encoding range size, we need to be better at splitting that klass encoding range between CDS and class space. For example, we could map CDS and then use the remaining space completely for class space. But that would require more serious reshuffling for initialization code, and CDS setup is horrendously complex.

For this patch, if one wants to reduce class pointer size, one may have to disable CDS to run.

Tested: Mac m1, fastdebug, with 32, 22 and 16 bit class pointers. GHAs in process.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput.git pull/172/head:pull/172` \
`$ git checkout pull/172`

Update a local copy of the PR: \
`$ git checkout pull/172` \
`$ git pull https://git.openjdk.org/lilliput.git pull/172/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 172`

View PR using the GUI difftool: \
`$ git pr show -t 172`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput/pull/172.diff">https://git.openjdk.org/lilliput/pull/172.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput/pull/172#issuecomment-2080405199)