### PR TITLE
Exclude some tests from Lilliput which rely on array alignment

### DIFF
--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestMulAddS2I.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestMulAddS2I.java
@@ -153,11 +153,13 @@ public class TestMulAddS2I {
     @Test
     @IR(applyIfCPUFeature = {"sse2", "true"},
         applyIfPlatform = {"64-bit", "true"},
+        applyIf = { "UseCompactObjectHeaders", "false" },
         counts = {IRNode.MUL_ADD_S2I, "> 0", IRNode.MUL_ADD_VS2VI, "> 0"})
     @IR(applyIfCPUFeature = {"asimd", "true"},
-        applyIf = {"MaxVectorSize", "16"}, // AD file requires vector_length = 16
+        applyIfAnd = {"MaxVectorSize", "16", "UseCompactObjectHeaders", "false" }, // AD file requires vector_length = 16
         counts = {IRNode.MUL_ADD_S2I, "> 0", IRNode.MUL_ADD_VS2VI, "> 0"})
     @IR(applyIfCPUFeature = {"avx512_vnni", "true"},
+        applyIf = { "UseCompactObjectHeaders", "false" },
         counts = {IRNode.MUL_ADD_S2I, "> 0", IRNode.MUL_ADD_VS2VI_VNNI, "> 0"})
     public static int[] testd() {
         int[] out = ioutArr;
@@ -172,11 +174,13 @@ public class TestMulAddS2I {
     @Test
     @IR(applyIfCPUFeature = {"sse2", "true"},
         applyIfPlatform = {"64-bit", "true"},
+        applyIf = { "UseCompactObjectHeaders", "false" },
         counts = {IRNode.MUL_ADD_S2I, "> 0", IRNode.MUL_ADD_VS2VI, "> 0"})
     @IR(applyIfCPUFeature = {"asimd", "true"},
-        applyIf = {"MaxVectorSize", "16"}, // AD file requires vector_length = 16
+        applyIfAnd = {"MaxVectorSize", "16", "UseCompactObjectHeaders", "false" }, // AD file requires vector_length = 16
         counts = {IRNode.MUL_ADD_S2I, "> 0", IRNode.MUL_ADD_VS2VI, "> 0"})
     @IR(applyIfCPUFeature = {"avx512_vnni", "true"},
+        applyIf = { "UseCompactObjectHeaders", "false" },
         counts = {IRNode.MUL_ADD_S2I, "> 0", IRNode.MUL_ADD_VS2VI_VNNI, "> 0"})
     public static int[] teste() {
         int[] out = ioutArr;
@@ -191,11 +195,13 @@ public class TestMulAddS2I {
     @Test
     @IR(applyIfCPUFeature = {"sse2", "true"},
         applyIfPlatform = {"64-bit", "true"},
+        applyIf = { "UseCompactObjectHeaders", "false" },
         counts = {IRNode.MUL_ADD_S2I, "> 0", IRNode.MUL_ADD_VS2VI, "> 0"})
     @IR(applyIfCPUFeature = {"asimd", "true"},
-        applyIf = {"MaxVectorSize", "16"}, // AD file requires vector_length = 16
+        applyIfAnd = {"MaxVectorSize", "16", "UseCompactObjectHeaders", "false" }, // AD file requires vector_length = 16
         counts = {IRNode.MUL_ADD_S2I, "> 0", IRNode.MUL_ADD_VS2VI, "> 0"})
     @IR(applyIfCPUFeature = {"avx512_vnni", "true"},
+        applyIf = { "UseCompactObjectHeaders", "false" },
         counts = {IRNode.MUL_ADD_S2I, "> 0", IRNode.MUL_ADD_VS2VI_VNNI, "> 0"})
     public static int[] testf() {
         int[] out = ioutArr;
@@ -210,11 +216,13 @@ public class TestMulAddS2I {
     @Test
     @IR(applyIfCPUFeature = {"sse2", "true"},
         applyIfPlatform = {"64-bit", "true"},
+        applyIf = { "UseCompactObjectHeaders", "false" },
         counts = {IRNode.MUL_ADD_S2I, "> 0", IRNode.MUL_ADD_VS2VI, "> 0"})
     @IR(applyIfCPUFeature = {"asimd", "true"},
-        applyIf = {"MaxVectorSize", "16"}, // AD file requires vector_length = 16
+        applyIfAnd = {"MaxVectorSize", "16", "UseCompactObjectHeaders", "false" }, // AD file requires vector_length = 16
         counts = {IRNode.MUL_ADD_S2I, "> 0", IRNode.MUL_ADD_VS2VI, "> 0"})
     @IR(applyIfCPUFeature = {"avx512_vnni", "true"},
+        applyIf = { "UseCompactObjectHeaders", "false" },
         counts = {IRNode.MUL_ADD_S2I, "> 0", IRNode.MUL_ADD_VS2VI_VNNI, "> 0"})
     public static int[] testg() {
         int[] out = ioutArr;
@@ -229,11 +237,13 @@ public class TestMulAddS2I {
     @Test
     @IR(applyIfCPUFeature = {"sse2", "true"},
         applyIfPlatform = {"64-bit", "true"},
+        applyIf = { "UseCompactObjectHeaders", "false" },
         counts = {IRNode.MUL_ADD_S2I, "> 0", IRNode.MUL_ADD_VS2VI, "> 0"})
     @IR(applyIfCPUFeature = {"asimd", "true"},
-        applyIf = {"MaxVectorSize", "16"}, // AD file requires vector_length = 16
+        applyIfAnd = {"MaxVectorSize", "16", "UseCompactObjectHeaders", "false" }, // AD file requires vector_length = 16
         counts = {IRNode.MUL_ADD_S2I, "> 0", IRNode.MUL_ADD_VS2VI, "> 0"})
     @IR(applyIfCPUFeature = {"avx512_vnni", "true"},
+        applyIf = { "UseCompactObjectHeaders", "false" },
         counts = {IRNode.MUL_ADD_S2I, "> 0", IRNode.MUL_ADD_VS2VI_VNNI, "> 0"})
     public static int[] testh() {
         int[] out = ioutArr;


### PR DESCRIPTION
On x86_64, some IR tests are failing with +UCOH, because they expect a certain array alignment. Let's not run those tests with +UCOH, just like we do with other similar tests.

Testing:
 - [x] compiler/loopopts/superword/TestMulAddS2I.java
 - [x] compiler/loopopts/superword/TestMulAddS2I.java (-UCOH)
 - [x] compiler/loopopts/superword/TestMulAddS2I.java (+UCOH)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput.git pull/173/head:pull/173` \
`$ git checkout pull/173`

Update a local copy of the PR: \
`$ git checkout pull/173` \
`$ git pull https://git.openjdk.org/lilliput.git pull/173/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 173`

View PR using the GUI difftool: \
`$ git pr show -t 173`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput/pull/173.diff">https://git.openjdk.org/lilliput/pull/173.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput/pull/173#issuecomment-2109901264)