### PR TITLE
OMWorld: reenable all platforms

### DIFF
--- a/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
@@ -2515,32 +2515,11 @@ void MacroAssembler::compiler_fast_lock_lightweight_object(ConditionRegister fla
   { // Handle inflated monitor.
     bind(inflated);
 
-    // mark contains the tagged ObjectMonitor*.
-    const Register tagged_monitor = mark;
-    const uintptr_t monitor_tag = markWord::monitor_value;
-    const Register owner_addr = tmp2;
+    // OMCache lookup not supported yet. Take slowpath.
 
-    // Compute owner address.
-    addi(owner_addr, tagged_monitor, in_bytes(ObjectMonitor::owner_offset()) - monitor_tag);
-
-    // CAS owner (null => current thread).
-    cmpxchgd(/*flag=*/flag,
-            /*current_value=*/t,
-            /*compare_value=*/(intptr_t)0,
-            /*exchange_value=*/R16_thread,
-            /*where=*/owner_addr,
-            MacroAssembler::MemBarRel | MacroAssembler::MemBarAcq,
-            MacroAssembler::cmpxchgx_hint_acquire_lock());
-    beq(flag, locked);
-
-    // Check if recursive.
-    cmpd(flag, t, R16_thread);
-    bne(flag, slow_path);
-
-    // Recursive.
-    ld(tmp1, in_bytes(ObjectMonitor::recursions_offset() - ObjectMonitor::owner_offset()), owner_addr);
-    addi(tmp1, tmp1, 1);
-    std(tmp1, in_bytes(ObjectMonitor::recursions_offset() - ObjectMonitor::owner_offset()), owner_addr);
+    // Set flag to NE.
+    crxor(flag, Assembler::equal, flag, Assembler::equal);
+    b(slow_path);
   }
 
   bind(locked);
@@ -2654,49 +2633,11 @@ void MacroAssembler::compiler_fast_unlock_lightweight_object(ConditionRegister f
     bind(check_done);
 #endif
 
-    // mark contains the tagged ObjectMonitor*.
-    const Register monitor = mark;
-    const uintptr_t monitor_tag = markWord::monitor_value;
+    // OMCache lookup not supported yet. Take slowpath.
 
-    // Untag the monitor.
-    subi(monitor, mark, monitor_tag);
-
-    const Register recursions = tmp2;
-    Label not_recursive;
-
-    // Check if recursive.
-    ld(recursions, in_bytes(ObjectMonitor::recursions_offset()), monitor);
-    addic_(recursions, recursions, -1);
-    blt(CCR0, not_recursive);
-
-    // Recursive unlock.
-    std(recursions, in_bytes(ObjectMonitor::recursions_offset()), monitor);
-    crorc(CCR0, Assembler::equal, CCR0, Assembler::equal);
-    b(unlocked);
-
-    bind(not_recursive);
-
-    Label release_;
-    const Register t2 = tmp2;
-
-    // Check if the entry lists are empty.
-    ld(t, in_bytes(ObjectMonitor::EntryList_offset()), monitor);
-    ld(t2, in_bytes(ObjectMonitor::cxq_offset()), monitor);
-    orr(t, t, t2);
-    cmpdi(flag, t, 0);
-    beq(flag, release_);
-
-    // The owner may be anonymous and we removed the last obj entry in
-    // the lock-stack. This loses the information about the owner.
-    // Write the thread to the owner field so the runtime knows the owner.
-    std(R16_thread, in_bytes(ObjectMonitor::owner_offset()), monitor);
+    // Set flag to NE.
+    crxor(flag, Assembler::equal, flag, Assembler::equal);
     b(slow_path);
-
-    bind(release_);
-    // Set owner to null.
-    release();
-    // t contains 0
-    std(t, in_bytes(ObjectMonitor::owner_offset()), monitor);
   }
 
   bind(unlocked);

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -322,26 +322,8 @@ void C2_MacroAssembler::fast_lock_lightweight(Register obj, Register tmp1, Regis
 
   { // Handle inflated monitor.
     bind(inflated);
-
-    // mark contains the tagged ObjectMonitor*.
-    const Register tmp1_tagged_monitor = tmp1_mark;
-    const uintptr_t monitor_tag = markWord::monitor_value;
-    const Register tmp2_owner_addr = tmp2;
-    const Register tmp3_owner = tmp3;
-
-    // Compute owner address.
-    la(tmp2_owner_addr, Address(tmp1_tagged_monitor, (in_bytes(ObjectMonitor::owner_offset()) - monitor_tag)));
-
-    // CAS owner (null => current thread).
-    cmpxchg(/*addr*/ tmp2_owner_addr, /*expected*/ zr, /*new*/ xthread, Assembler::int64,
-            /*acquire*/ Assembler::aq, /*release*/ Assembler::relaxed, /*result*/ tmp3_owner);
-    beqz(tmp3_owner, locked);
-
-    // Check if recursive.
-    bne(tmp3_owner, xthread, slow_path);
-
-    // Recursive.
-    increment(Address(tmp1_tagged_monitor, in_bytes(ObjectMonitor::recursions_offset()) - monitor_tag), 1, tmp2, tmp3);
+    // OMCache lookup not supported yet. Take slowpath.
+    j(slow_path);
   }
 
   bind(locked);
@@ -453,49 +435,8 @@ void C2_MacroAssembler::fast_unlock_lightweight(Register obj, Register tmp1, Reg
     bind(check_done);
 #endif
 
-    // mark contains the tagged ObjectMonitor*.
-    const Register tmp1_monitor = tmp1_mark;
-    const uintptr_t monitor_tag = markWord::monitor_value;
-
-    // Untag the monitor.
-    sub(tmp1_monitor, tmp1_mark, monitor_tag);
-
-    const Register tmp2_recursions = tmp2;
-    Label not_recursive;
-
-    // Check if recursive.
-    ld(tmp2_recursions, Address(tmp1_monitor, ObjectMonitor::recursions_offset()));
-    beqz(tmp2_recursions, not_recursive);
-
-    // Recursive unlock.
-    addi(tmp2_recursions, tmp2_recursions, -1);
-    sd(tmp2_recursions, Address(tmp1_monitor, ObjectMonitor::recursions_offset()));
-    j(unlocked);
-
-    bind(not_recursive);
-
-    Label release;
-    const Register tmp2_owner_addr = tmp2;
-
-    // Compute owner address.
-    la(tmp2_owner_addr, Address(tmp1_monitor, ObjectMonitor::owner_offset()));
-
-    // Check if the entry lists are empty.
-    ld(t0, Address(tmp1_monitor, ObjectMonitor::EntryList_offset()));
-    ld(tmp3_t, Address(tmp1_monitor, ObjectMonitor::cxq_offset()));
-    orr(t0, t0, tmp3_t);
-    beqz(t0, release);
-
-    // The owner may be anonymous and we removed the last obj entry in
-    // the lock-stack. This loses the information about the owner.
-    // Write the thread to the owner field so the runtime knows the owner.
-    sd(xthread, Address(tmp2_owner_addr));
+    // OMCache lookup not supported yet. Take slowpath.
     j(slow_path);
-
-    bind(release);
-    // Set owner to null.
-    membar(MacroAssembler::LoadStore | MacroAssembler::StoreStore);
-    sd(zr, Address(tmp2_owner_addr));
   }
 
   bind(unlocked);

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -1824,7 +1824,7 @@ bool Arguments::check_vm_args_consistency() {
   }
 #endif
 
-#if !defined(X86) && !defined(AARCH64)
+#if !defined(X86) && !defined(AARCH64) && !defined(RISCV64) && !defined(ARM) && !defined(PPC64) && !defined(S390)
   if (LockingMode == LM_LIGHTWEIGHT) {
     FLAG_SET_CMDLINE(LockingMode, LM_LEGACY);
     warning("New lightweight locking not supported on this platform");


### PR DESCRIPTION
This reenables all platforms to use OMWorld, and by extension UseCompactObjectHeaders. 

This change simply calls the runtime if a lock is inflated, until port support for OMWorld cache lookup is added.

ARM (32-bit) required no changes as it already always called the runtime when a monitor is inflated.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput.git pull/174/head:pull/174` \
`$ git checkout pull/174`

Update a local copy of the PR: \
`$ git checkout pull/174` \
`$ git pull https://git.openjdk.org/lilliput.git pull/174/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 174`

View PR using the GUI difftool: \
`$ git pr show -t 174`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput/pull/174.diff">https://git.openjdk.org/lilliput/pull/174.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput/pull/174#issuecomment-2126333174)