### PR TITLE
OMWorld: Remove OMRecursiveFastPath

### DIFF
--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
@@ -1057,29 +1057,17 @@ void C2_MacroAssembler::fast_lock_lightweight(Register obj, Register box, Regist
 
       Label monitor_locked;
       // Lock the monitor.
-      Label recursion;
-      if (OMRecursiveFastPath) {
-        // Check owner for recursion first.
-        cmpptr(thread, Address(monitor, ObjectMonitor::owner_offset()));
-        jccb(Assembler::equal, recursion);
-      }
 
       // CAS owner (null => current thread).
       xorptr(rax, rax);
       lock(); cmpxchgptr(thread, Address(monitor, ObjectMonitor::owner_offset()));
       jccb(Assembler::equal, monitor_locked);
 
-      if (OMRecursiveFastPath) {
-        // Recursion already checked.
-        jmpb(slow_path);
-      } else {
-        // Check if recursive.
-        cmpptr(thread, rax);
-        jccb(Assembler::notEqual, slow_path);
-      }
+      // Check if recursive.
+      cmpptr(thread, rax);
+      jccb(Assembler::notEqual, slow_path);
 
       // Recursive.
-      bind(recursion);
       increment(Address(monitor, ObjectMonitor::recursions_offset()));
 
       bind(monitor_locked);

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -2004,8 +2004,6 @@ const int ObjectAlignmentInBytes = 8;
                                                                             \
   product(bool, OMCacheHitRate, false, "")                                  \
                                                                             \
-  product(bool, OMRecursiveFastPath, true, "Inflated recursion check first")\
-                                                                            \
   product(uint, TrimNativeHeapInterval, 0,                                  \
           "Interval, in ms, at which the JVM will trim the native heap if " \
           "the platform supports that. Lower values will reclaim memory "   \


### PR DESCRIPTION
The `OMRecursiveFastPath` was an experiment that was introduced when recursive lightweight was developed. It could show some gains in some scenarios on specific hardware, but remove it for now. Checking for recursion via a failed CAS that reads out the owner is good enough.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput.git pull/176/head:pull/176` \
`$ git checkout pull/176`

Update a local copy of the PR: \
`$ git checkout pull/176` \
`$ git pull https://git.openjdk.org/lilliput.git pull/176/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 176`

View PR using the GUI difftool: \
`$ git pr show -t 176`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput/pull/176.diff">https://git.openjdk.org/lilliput/pull/176.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput/pull/176#issuecomment-2126346693)