### PR TITLE
OMWorld: Spin Changes

### DIFF
--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1998,7 +1998,11 @@ const int ObjectAlignmentInBytes = 8;
                                                                             \
   product(bool, OMShrinkCHT, false, "")                                     \
                                                                             \
-  product(int, OMSpins, 13, "")                                             \
+  product(int, OMSpins, 13,                                                 \
+          "Specifies the number of time lightweight fast locking will "     \
+          "attempt to CAS the markWord before inflating. Between each "     \
+          "CAS it will spin for exponentially more time, resulting in "     \
+          "a total number of spins on the order of O(2^OMSpins)")           \
           range(1, 30)                                                      \
                                                                             \
   product(bool, OMCacheHitRate, false, "")                                  \

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1998,9 +1998,8 @@ const int ObjectAlignmentInBytes = 8;
                                                                             \
   product(bool, OMShrinkCHT, false, "")                                     \
                                                                             \
-  product(int, OMSpins, 20, "")                                             \
-                                                                            \
-  product(int, OMYields, 5, "")                                             \
+  product(int, OMSpins, 13, "")                                             \
+          range(1, 30)                                                      \
                                                                             \
   product(bool, OMCacheHitRate, false, "")                                  \
                                                                             \

--- a/src/hotspot/share/runtime/lightweightSynchronizer.cpp
+++ b/src/hotspot/share/runtime/lightweightSynchronizer.cpp
@@ -570,10 +570,10 @@ bool LightweightSynchronizer::fast_lock_spin_enter(oop obj, JavaThread* current,
   LockStack& lock_stack = current->lock_stack();
 
   markWord mark = obj->mark();
-  const bool try_spin = observed_deflation || !mark.has_monitor();
+  const auto try_spin = [&]() { return observed_deflation || !mark.has_monitor(); };
   // Always attempt to lock once even when safepoint synchronizing.
   bool should_process = false;
-  for (int i = 0; try_spin && !should_process && i < log_spin_limit; i++) {
+  for (int i = 0; try_spin() && !should_process && i < log_spin_limit; i++) {
     // Spin with exponential backoff.
     const int total_spin_count = 1 << i;
     const int inner_spin_count = MIN2(1 << log_min_safepoint_check_interval, total_spin_count);

--- a/src/hotspot/share/runtime/lightweightSynchronizer.cpp
+++ b/src/hotspot/share/runtime/lightweightSynchronizer.cpp
@@ -634,7 +634,7 @@ void LightweightSynchronizer::enter(Handle obj, BasicLock* lock, JavaThread* cur
   }
 
   // Will spin with exponential backoff with an accumulative O(2^spin_limit) spins.
-  const int log_spin_limit = OMSpins;
+  const int log_spin_limit = os::is_MP() ? OMSpins : 1;
   const int log_min_safepoint_check_interval = 10;
 
   while (true) {

--- a/src/hotspot/share/runtime/lightweightSynchronizer.cpp
+++ b/src/hotspot/share/runtime/lightweightSynchronizer.cpp
@@ -707,7 +707,7 @@ void LightweightSynchronizer::enter(Handle obj, BasicLock* lock, JavaThread* cur
     }
 
     // If inflate_and_enter returns nullptr it is because a deflated monitor
-    // was encountered. Fallback to fast locking. The deflater is responisble
+    // was encountered. Fallback to fast locking. The deflater is responsible
     // for clearing out the monitor and transitioning the markWord back to
     // fast locking.
     observed_deflation = true;

--- a/src/hotspot/share/runtime/lightweightSynchronizer.cpp
+++ b/src/hotspot/share/runtime/lightweightSynchronizer.cpp
@@ -692,6 +692,10 @@ void LightweightSynchronizer::enter(Handle obj, BasicLock* lock, JavaThread* cur
 
   while (true) {
     // Fast-locking does not use the 'lock' argument.
+    // Fast-lock spinning to avoid inflating for short critical sections.
+    // The goal is to only inflate when the extra cost of using ObjectMonitors
+    // is worth it.
+    // If deflation has been observed we also spin while deflation is onging.
     if (fast_lock_spin_enter(obj(), current, observed_deflation)) {
       return;
     }

--- a/src/hotspot/share/runtime/lightweightSynchronizer.cpp
+++ b/src/hotspot/share/runtime/lightweightSynchronizer.cpp
@@ -570,7 +570,7 @@ bool LightweightSynchronizer::fast_lock_spin_enter(oop obj, JavaThread* current,
   LockStack& lock_stack = current->lock_stack();
 
   markWord mark = obj->mark();
-  const auto try_spin = [&]() {
+  const auto should_spin = [&]() {
     if (!mark.has_monitor()) {
       // Spin while not inflated.
       return true;
@@ -584,7 +584,7 @@ bool LightweightSynchronizer::fast_lock_spin_enter(oop obj, JavaThread* current,
   };
   // Always attempt to lock once even when safepoint synchronizing.
   bool should_process = false;
-  for (int i = 0; try_spin() && !should_process && i < log_spin_limit; i++) {
+  for (int i = 0; should_spin() && !should_process && i < log_spin_limit; i++) {
     // Spin with exponential backoff.
     const int total_spin_count = 1 << i;
     const int inner_spin_count = MIN2(1 << log_min_safepoint_check_interval, total_spin_count);

--- a/src/hotspot/share/runtime/lightweightSynchronizer.hpp
+++ b/src/hotspot/share/runtime/lightweightSynchronizer.hpp
@@ -56,7 +56,7 @@ private:
   static void set_table_max(JavaThread* current);
 
 private:
-  static bool fast_lock_spin_enter(oop obj, JavaThread* current, bool first_time);
+  static bool fast_lock_spin_enter(oop obj, JavaThread* current, bool observed_deflation);
 
 public:
   static void enter_for(Handle obj, BasicLock* lock, JavaThread* locking_thread);

--- a/src/hotspot/share/runtime/lightweightSynchronizer.hpp
+++ b/src/hotspot/share/runtime/lightweightSynchronizer.hpp
@@ -55,6 +55,10 @@ private:
   static bool resize_table(JavaThread* current);
   static void set_table_max(JavaThread* current);
 
+private:
+  static bool fast_lock_spin_enter(oop obj, JavaThread* current, bool first_time);
+
+public:
   static void enter_for(Handle obj, BasicLock* lock, JavaThread* locking_thread);
   static void enter(Handle obj, BasicLock* lock, JavaThread* current);
   static void exit(oop object, JavaThread* current);


### PR DESCRIPTION
The fast lock spinning uses `sched_yield` which tends to be discouraged for spin locking code. Instead only use `SpinPause` with exponential backoff. Where after each failed CAS wait for exponentially more time until trying again in an attempt to reduce cache contention. 

This change also makes the spinning aware of safepoints, and tries to fast track the execution to next poll, which is either when successfully locked (VM backedge transition) or when going into blocked to enter the ObjectMonitor.

Have not removed `OMSpins` yet, as the exact value is not determined yet. It may have to be platform specific as `SpinPause` have different characteristics on different hardware. OMSpins is the number of fast lock, with each attempt spinning for twice as much as the last, so the total number of spins are on the order of O(2^OMSpins). It will probably land somewhere on the range of 7-14 (128 -16384 spins)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput.git pull/177/head:pull/177` \
`$ git checkout pull/177`

Update a local copy of the PR: \
`$ git checkout pull/177` \
`$ git pull https://git.openjdk.org/lilliput.git pull/177/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 177`

View PR using the GUI difftool: \
`$ git pr show -t 177`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput/pull/177.diff">https://git.openjdk.org/lilliput/pull/177.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput/pull/177#issuecomment-2126369051)