### PR TITLE
OMWorld: Cleanups

### DIFF
--- a/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
@@ -799,7 +799,6 @@ void InterpreterMacroAssembler::unlock_object(Register lock_reg)
     save_bcp(); // Save in case of exception
 
     if (LockingMode != LM_LIGHTWEIGHT) {
-      // TODO[OMWorld]: Cleanup lock_reg usage for placeholder
       // Convert from BasicObjectLock structure to object and BasicLock
       // structure Store the BasicLock address into %r0
       lea(swap_reg, Address(lock_reg, BasicObjectLock::lock_offset()));

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -6456,6 +6456,7 @@ void MacroAssembler::lightweight_lock(Register basic_lock, Register obj, Registe
   // instruction emitted as it is part of C1's null check semantics.
   ldr(mark, Address(obj, oopDesc::mark_offset_in_bytes()));
 
+  // Clear cache in case fast locking succeeds.
   str(zr, Address(basic_lock, BasicObjectLock::lock_offset() + in_ByteSize((BasicLock::object_monitor_cache_offset_in_bytes()))));
 
   // Check if the lock-stack is full.

--- a/src/hotspot/cpu/x86/c1_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_MacroAssembler_x86.cpp
@@ -142,10 +142,8 @@ void C1_MacroAssembler::unlock_object(Register hdr, Register obj, Register disp_
 #ifdef _LP64
     lightweight_unlock(obj, disp_hdr, r15_thread, hdr, slow_case);
 #else
-    // This relies on the implementation of lightweight_unlock being able to handle
-    // that the reg_rax and thread Register parameters may alias each other.
-    get_thread(disp_hdr);
-    lightweight_unlock(obj, disp_hdr, disp_hdr, hdr, slow_case);
+    // Lacking registers and thread on x86_32. Always take slow path.
+    jmp(slow_case);
 #endif
   } else if (LockingMode == LM_LEGACY) {
     // test if object header is pointing to the displaced header, and if so, restore

--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
@@ -949,7 +949,7 @@ void C2_MacroAssembler::fast_lock_lightweight(Register obj, Register box, Regist
   // Finish fast lock unsuccessfully. MUST jump with ZF == 0
   Label slow_path;
 
-  // Clear box. TODO[OMWorld]: Is this necessary? May also defer this to not write twice.
+  // Clear cache in case fast locking succeeds.
   movptr(Address(box, BasicLock::object_monitor_cache_offset_in_bytes()), 0);
 
   if (DiagnoseSyncOnValueBasedClasses != 0) {
@@ -994,7 +994,6 @@ void C2_MacroAssembler::fast_lock_lightweight(Register obj, Register box, Regist
 
     bind(push);
     // After successful lock, push object on lock-stack.
-    // TODO[OMWorld]: Was prepush better?
     movl(top, Address(thread, JavaThread::lock_stack_top_offset()));
     movptr(Address(thread, top), obj);
     addl(Address(thread, JavaThread::lock_stack_top_offset()), oopSize);
@@ -1201,10 +1200,8 @@ void C2_MacroAssembler::fast_unlock_lightweight(Register obj, Register reg_rax, 
     } else {
       if (OMCacheHitRate) increment(Address(thread, JavaThread::unlock_lookup_offset()));
       movptr(monitor, Address(box, BasicLock::object_monitor_cache_offset_in_bytes()));
-      // TODO[OMWorld]: Figure out the correctness surrounding the owner field here. Obj is not on the lock stack
-      //                but this means this thread must have locked on the inflated monitor at some point. So it
-      //                should not be anonymous.
-      cmpptr(monitor, 2);
+      // null check with ZF == 0, no valid pointer below alignof(ObjectMonitor*)
+      cmpptr(monitor, alignof(ObjectMonitor*));
       jcc(Assembler::below, slow_path);
 
       if (OMCacheHitRate) increment(Address(thread, JavaThread::unlock_hit_offset()));

--- a/src/hotspot/cpu/x86/interp_masm_x86.cpp
+++ b/src/hotspot/cpu/x86/interp_masm_x86.cpp
@@ -1305,10 +1305,8 @@ void InterpreterMacroAssembler::unlock_object(Register lock_reg) {
 #ifdef _LP64
       lightweight_unlock(obj_reg, swap_reg, r15_thread, header_reg, slow_case);
 #else
-      // This relies on the implementation of lightweight_unlock being able to handle
-      // that the reg_rax and thread Register parameters may alias each other.
-      get_thread(swap_reg);
-      lightweight_unlock(obj_reg, swap_reg, swap_reg, header_reg, slow_case);
+      // Lacking registers and thread on x86_32. Always take slow path.
+      jmp(slow_case);
 #endif
     } else if (LockingMode == LM_LEGACY) {
       // Load the old header from BasicLock structure

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -9993,12 +9993,9 @@ void MacroAssembler::check_stack_alignment(Register sp, const char* msg, unsigne
 // reg_rax: rax
 // thread: the thread which attempts to lock obj
 // tmp: a temporary register
-//
-// x86_32 Note: basic_lock and thread may alias each other due to limited register
-//              availiability.
 void MacroAssembler::lightweight_lock(Register basic_lock, Register obj, Register reg_rax, Register thread, Register tmp, Label& slow) {
   assert(reg_rax == rax, "");
-  assert_different_registers(obj, reg_rax, thread, tmp);
+  assert_different_registers(basic_lock, obj, reg_rax, thread, tmp);
 
   Label push;
   const Register top = tmp;
@@ -10007,13 +10004,9 @@ void MacroAssembler::lightweight_lock(Register basic_lock, Register obj, Registe
   // instruction emitted as it is part of C1's null check semantics.
   movptr(reg_rax, Address(obj, oopDesc::mark_offset_in_bytes()));
 
+  // Clear cache in case fast locking succeeds.
   movptr(Address(basic_lock, BasicObjectLock::lock_offset() + in_ByteSize((BasicLock::object_monitor_cache_offset_in_bytes()))), 0);
 
-#ifndef _LP64
-  if (thread == basic_lock) {
-    get_thread(thread);
-  }
-#endif // !_LP64
   // Load top.
   movl(top, Address(thread, JavaThread::lock_stack_top_offset()));
 
@@ -10057,8 +10050,7 @@ void MacroAssembler::lightweight_lock(Register basic_lock, Register obj, Registe
 //              availiability.
 void MacroAssembler::lightweight_unlock(Register obj, Register reg_rax, Register thread, Register tmp, Label& slow) {
   assert(reg_rax == rax, "");
-  assert_different_registers(obj, reg_rax, tmp);
-  LP64_ONLY(assert_different_registers(obj, reg_rax, thread, tmp);)
+  assert_different_registers(obj, reg_rax, thread, tmp);
 
   Label unlocked, push_and_slow;
   const Register top = tmp;
@@ -10098,10 +10090,6 @@ void MacroAssembler::lightweight_unlock(Register obj, Register reg_rax, Register
 
   bind(push_and_slow);
   // Restore lock-stack and handle the unlock in runtime.
-  if (thread == reg_rax) {
-    // On x86_32 we may lose the thread.
-    get_thread(thread);
-  }
 #ifdef ASSERT
   movl(top, Address(thread, JavaThread::lock_stack_top_offset()));
   movptr(Address(thread, top), obj);

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp
@@ -1695,7 +1695,8 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
       __ jcc(Assembler::notEqual, slow_path_lock);
     } else {
       assert(LockingMode == LM_LIGHTWEIGHT, "must be");
-      __ lightweight_lock(lock_reg, obj_reg, swap_reg, thread, lock_reg, slow_path_lock);
+      // Lacking registers and thread on x86_32. Always take slow path.
+      __ jmp(slow_path_lock);
     }
     __ bind(count_mon);
     __ inc_held_monitor_count();
@@ -1933,11 +1934,6 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
     // BEGIN Slow path lock
 
     __ bind(slow_path_lock);
-
-    if (LockingMode == LM_LIGHTWEIGHT) {
-      // Reload the lock addr. Clobbered by lightweight_lock.
-      __ lea(lock_reg, Address(rbp, lock_slot_rbp_offset));
-    }
 
     // has last_Java_frame setup. No exceptions so do vanilla call not call_VM
     // args are (oop obj, BasicLock* lock, JavaThread* thread)

--- a/src/hotspot/share/oops/markWord.cpp
+++ b/src/hotspot/share/oops/markWord.cpp
@@ -77,7 +77,6 @@ void markWord::print_on(outputStream* st, bool print_monitor_info) const {
     // have to check has_monitor() before is_locked()
     st->print(" monitor(" INTPTR_FORMAT ")=", value());
     if (print_monitor_info && LockingMode != LM_LIGHTWEIGHT) {
-      // TODO[OMWorld]: Cleanup, even if the monitor read is racy, something should be printed.
       ObjectMonitor* mon = monitor();
       if (mon == nullptr) {
         st->print("null (this should never be seen!)");

--- a/src/hotspot/share/runtime/lightweightSynchronizer.cpp
+++ b/src/hotspot/share/runtime/lightweightSynchronizer.cpp
@@ -349,7 +349,7 @@ ObjectMonitor* LightweightSynchronizer::get_or_insert_monitor_from_table(oop obj
 static void log_inflate(Thread* current, oop object, const ObjectSynchronizer::InflateCause cause) {
   if (log_is_enabled(Trace, monitorinflation)) {
     ResourceMark rm(current);
-    log_info(monitorinflation)("inflate(has_locker): object=" INTPTR_FORMAT ", mark="
+    log_info(monitorinflation)("inflate: object=" INTPTR_FORMAT ", mark="
                                INTPTR_FORMAT ", type='%s' cause %s", p2i(object),
                                object->mark().value(), object->klass()->external_name(),
                                ObjectSynchronizer::inflate_cause_name(cause));

--- a/src/hotspot/share/runtime/lightweightSynchronizer.hpp
+++ b/src/hotspot/share/runtime/lightweightSynchronizer.hpp
@@ -47,6 +47,8 @@ private:
   static void ensure_lock_stack_space(JavaThread* current);
 
   class CacheSetter;
+  class LockStackInflateContendedLocks;
+  class VerifyThreadState;
 
  public:
   static void initialize();
@@ -64,7 +66,6 @@ private:
   static ObjectMonitor* inflate_and_enter(oop object, JavaThread* locking_thread, JavaThread* current, const ObjectSynchronizer::InflateCause cause);
 
   static void deflate_monitor(Thread* current, oop obj, ObjectMonitor* monitor);
-  static void deflate_anon_monitor(Thread* current, oop obj, ObjectMonitor* monitor);
 
   static ObjectMonitor* read_monitor(Thread* current, oop obj);
 

--- a/src/hotspot/share/runtime/objectMonitor.hpp
+++ b/src/hotspot/share/runtime/objectMonitor.hpp
@@ -159,7 +159,6 @@ class ObjectMonitor : public CHeapObj<mtObjectMonitor> {
 public:
   // NOTE: Typed as uintptr_t so that we can pick it up in SA, via vmStructs.
   static const uintptr_t ANONYMOUS_OWNER = 1;
-  static const uintptr_t ANONYMOUS_OWNER_OR_DEFLATER_MARKER = ANONYMOUS_OWNER | DEFLATER_MARKER_VALUE;
 
 private:
   static void* anon_owner_ptr() { return reinterpret_cast<void*>(ANONYMOUS_OWNER); }
@@ -263,14 +262,6 @@ private:
     }
     if (!owner_is_DEFLATER_MARKER()) {
       ret_code |= intptr_t(owner_raw());
-    }
-    return ret_code != 0;
-  }
-  bool is_contended() const {
-    intptr_t ret_code = intptr_t(_waiters) | intptr_t(_cxq) | intptr_t(_EntryList);
-    int cnts = contentions();
-    if (cnts > 0) {
-      ret_code |= intptr_t(cnts);
     }
     return ret_code != 0;
   }

--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -939,7 +939,7 @@ static markWord read_stable_mark(oop obj) {
 //   There are simple ways to "diffuse" the middle address bits over the
 //   generated hashCode values:
 
-static inline intptr_t get_next_hash(Thread* current, oop obj) {
+intptr_t ObjectSynchronizer::get_next_hash(Thread* current, oop obj) {
   intptr_t value = 0;
   if (hashCode == 0) {
     // This form uses global Park-Miller RNG.
@@ -977,11 +977,6 @@ static inline intptr_t get_next_hash(Thread* current, oop obj) {
   if (value == 0) value = 0xBAD;
   assert(value != markWord::no_hash, "invariant");
   return value;
-}
-
-intptr_t ObjectSynchronizer::get_next_hash(Thread* current, oop obj) {
-  // CLEANUP[Axel]: hack for LightweightSynchronizer being in different translation unit
-  return ::get_next_hash(current, obj);
 }
 
 intptr_t ObjectSynchronizer::FastHashCode(Thread* current, oop obj) {

--- a/test/hotspot/jtreg/runtime/logging/MonitorInflationTest.java
+++ b/test/hotspot/jtreg/runtime/logging/MonitorInflationTest.java
@@ -38,7 +38,7 @@ import jdk.test.lib.process.ProcessTools;
 public class MonitorInflationTest {
     static void analyzeOutputOn(ProcessBuilder pb) throws Exception {
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
-        output.shouldContain("inflate(has_locker):");
+        output.shouldContain("inflate:");
         output.shouldContain("type='MonitorInflationTest$Waiter'");
         output.shouldContain("I've been waiting.");
         output.shouldHaveExitValue(0);


### PR DESCRIPTION
This contains a handful of miscellaneous cleanups. Removing dead code, fixes/cleanups todos, cleanup logging and removing all special handling of `x86_32` not having a thread register / lacking registers.