### PR TITLE
Fix BasicLock to test for UseObjectMonitorTable rather than LM_LIGHTWEIGHT

### DIFF
--- a/src/hotspot/share/runtime/basicLock.cpp
+++ b/src/hotspot/share/runtime/basicLock.cpp
@@ -31,7 +31,7 @@
 
 void BasicLock::print_on(outputStream* st, oop owner) const {
   st->print("monitor");
-  if (LockingMode == LM_LIGHTWEIGHT) {
+  if (UseObjectMonitorTable) {
     ObjectMonitor* mon = object_monitor_cache();
     if (mon != nullptr) {
       mon->print_on(st);
@@ -91,7 +91,7 @@ void BasicLock::move_to(oop obj, BasicLock* dest) {
       // we can find any flavor mark in the displaced mark.
     }
     dest->set_displaced_header(displaced_header());
-  } else if (LockingMode == LM_LIGHTWEIGHT) {
+  } else if (UseObjectMonitorTable) {
     // Preserve the ObjectMonitor*, the cache is cleared when a box is reused
     // and only read while the lock is held, so no stale ObjectMonitor* is
     // encountered.

--- a/src/hotspot/share/runtime/basicLock.inline.hpp
+++ b/src/hotspot/share/runtime/basicLock.inline.hpp
@@ -28,27 +28,27 @@
 #include "runtime/basicLock.hpp"
 
 inline markWord BasicLock::displaced_header() const {
-  assert(LockingMode == LM_LEGACY, "must be");
+  assert(!UseObjectMonitorTable, "must be");
   return markWord(get_metadata());
 }
 
 inline void BasicLock::set_displaced_header(markWord header) {
-  assert(LockingMode == LM_LEGACY, "must be");
+  assert(!UseObjectMonitorTable, "must be");
   Atomic::store(&_metadata, header.value());
 }
 
 inline ObjectMonitor* BasicLock::object_monitor_cache() const {
-  assert(LockingMode == LM_LIGHTWEIGHT, "must be");
+  assert(UseObjectMonitorTable, "must be");
   return reinterpret_cast<ObjectMonitor*>(get_metadata());
 }
 
 inline void BasicLock::clear_object_monitor_cache() {
-  assert(LockingMode == LM_LIGHTWEIGHT, "must be");
+  assert(UseObjectMonitorTable, "must be");
   set_metadata(0);
 }
 
 inline void BasicLock::set_object_monitor_cache(ObjectMonitor* mon) {
-  assert(LockingMode == LM_LIGHTWEIGHT, "must be");
+  assert(UseObjectMonitorTable, "must be");
   set_metadata(reinterpret_cast<uintptr_t>(mon));
 }
 


### PR DESCRIPTION
The test compiler/uncommontrap/TestDeoptOOM.java was failing with -Xcomp because it was looking for the object monitor in the basicLock which is only the case for -XX:+UseObjectMonitorTable.

Testing locally with table on and off.