### PR TITLE
OMWorld: Removal of flags, general cleanups

### DIFF
--- a/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c2_MacroAssembler_aarch64.cpp
@@ -299,14 +299,14 @@ void C2_MacroAssembler::fast_lock_lightweight(Register obj, Register box, Regist
     if (!UseObjectMonitorTable) {
       assert(t1_monitor == t1_mark, "should be the same here");
     } else {
-      if (OMCacheHitRate) increment(Address(rthread, JavaThread::lock_lookup_offset()));
+      if (false) increment(Address(rthread, JavaThread::lock_lookup_offset()));
 
       Label monitor_found;
 
       // Load cache address
       lea(t3_t, Address(rthread, JavaThread::om_cache_oops_offset()));
 
-      const int num_unrolled = MIN2(OMC2UnrollCacheEntries, OMCacheSize);
+      const int num_unrolled = MIN2(2, OMCache::CAPACITY);
       for (int i = 0; i < num_unrolled; i++) {
         ldr(t1, Address(t3_t));
         cmp(obj, t1);
@@ -316,7 +316,7 @@ void C2_MacroAssembler::fast_lock_lightweight(Register obj, Register box, Regist
         }
       }
 
-      if (num_unrolled == 0 || (OMC2UnrollCacheLookupLoopTail && num_unrolled != OMCacheSize)) {
+      if (num_unrolled == 0 || (true && num_unrolled != OMCache::CAPACITY)) {
         if (num_unrolled != 0) {
           // Loop after unrolling, advance iterator.
           increment(t3_t, in_bytes(OMCache::oop_to_oop_difference()));
@@ -343,7 +343,7 @@ void C2_MacroAssembler::fast_lock_lightweight(Register obj, Register box, Regist
 
       bind(monitor_found);
       ldr(t1_monitor, Address(t3_t, OMCache::oop_to_monitor_difference()));
-      if (OMCacheHitRate) increment(Address(rthread, JavaThread::lock_hit_offset()));
+      if (false) increment(Address(rthread, JavaThread::lock_hit_offset()));
     }
 
     const Register t2_owner_addr = t2;
@@ -490,12 +490,12 @@ void C2_MacroAssembler::fast_unlock_lightweight(Register obj, Register box, Regi
       // Untag the monitor.
       add(t1_monitor, t1_mark, -(int)markWord::monitor_value);
     } else {
-      if (OMCacheHitRate) increment(Address(rthread, JavaThread::unlock_lookup_offset()));
+      if (false) increment(Address(rthread, JavaThread::unlock_lookup_offset()));
       ldr(t1_monitor, Address(box, BasicLock::object_monitor_cache_offset_in_bytes()));
       // null check with Flags == NE, no valid pointer below alignof(ObjectMonitor*)
       cmp(t1_monitor, checked_cast<uint8_t>(alignof(ObjectMonitor*)));
       br(Assembler::LO, slow_path);
-      if (OMCacheHitRate) increment(Address(rthread, JavaThread::unlock_hit_offset()));
+      if (false) increment(Address(rthread, JavaThread::unlock_hit_offset()));
     }
 
     const Register t2_recursions = t2;

--- a/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
@@ -46,7 +46,6 @@
 #include "runtime/javaThread.hpp"
 #include "runtime/safepointMechanism.hpp"
 #include "runtime/sharedRuntime.hpp"
-#include "utilities/globalDefinitions.hpp"
 #include "utilities/powerOfTwo.hpp"
 
 void InterpreterMacroAssembler::narrow(Register result) {

--- a/src/hotspot/cpu/x86/c1_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_MacroAssembler_x86.cpp
@@ -41,7 +41,6 @@
 #include "runtime/stubRoutines.hpp"
 #include "utilities/checkedCast.hpp"
 #include "utilities/globalDefinitions.hpp"
-#include "utilities/macros.hpp"
 
 int C1_MacroAssembler::lock_object(Register hdr, Register obj, Register disp_hdr, Register tmp, Label& slow_case) {
   const int aligned_mask = BytesPerWord -1;

--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
@@ -1014,15 +1014,13 @@ void C2_MacroAssembler::fast_lock_lightweight(Register obj, Register box, Regist
       assert(mark == monitor, "should be the same here");
     } else {
       // Uses ObjectMonitorTable.  Look for the monitor in the om_cache.
-      if (false) increment(Address(thread, JavaThread::lock_lookup_offset()));
-
       // Fetch ObjectMonitor* from the cache or take the slow-path.
       Label monitor_found;
 
       // Load cache address
       lea(t, Address(thread, JavaThread::om_cache_oops_offset()));
 
-      const int num_unrolled = MIN2(2, OMCache::CAPACITY);
+      const int num_unrolled = 2;
       for (int i = 0; i < num_unrolled; i++) {
         cmpptr(obj, Address(t));
         jccb(Assembler::equal, monitor_found);
@@ -1031,34 +1029,27 @@ void C2_MacroAssembler::fast_lock_lightweight(Register obj, Register box, Regist
         }
       }
 
-      if (num_unrolled == 0 || (true && num_unrolled != OMCache::CAPACITY)) {
-        if (num_unrolled != 0) {
-          // Loop after unrolling, advance iterator.
-          increment(t, in_bytes(OMCache::oop_to_oop_difference()));
-        }
+      // Loop after unrolling, advance iterator.
+      increment(t, in_bytes(OMCache::oop_to_oop_difference()));
 
-        Label loop;
+      Label loop;
 
-        // Search for obj in cache.
-        bind(loop);
+      // Search for obj in cache.
+      bind(loop);
 
-        // Check for match.
-        cmpptr(obj, Address(t));
-        jccb(Assembler::equal, monitor_found);
+      // Check for match.
+      cmpptr(obj, Address(t));
+      jccb(Assembler::equal, monitor_found);
 
-        // Search until null encountered, guaranteed _null_sentinel at end.
-        cmpptr(Address(t), 1);
-        jcc(Assembler::below, slow_path); // 0 check, but with ZF=0 when *t == 0
-        increment(t, in_bytes(OMCache::oop_to_oop_difference()));
-        jmpb(loop);
-      } else {
-        jmp(slow_path);
-      }
+      // Search until null encountered, guaranteed _null_sentinel at end.
+      cmpptr(Address(t), 1);
+      jcc(Assembler::below, slow_path); // 0 check, but with ZF=0 when *t == 0
+      increment(t, in_bytes(OMCache::oop_to_oop_difference()));
+      jmpb(loop);
 
       // Cache hit.
       bind(monitor_found);
       movptr(monitor, Address(t, OMCache::oop_to_monitor_difference()));
-      if (false) increment(Address(thread, JavaThread::lock_hit_offset()));
     }
     const ByteSize monitor_tag = in_ByteSize(UseObjectMonitorTable ? 0 : checked_cast<int>(markWord::monitor_value));
     const Address recursions_address{monitor, ObjectMonitor::recursions_offset() - monitor_tag};
@@ -1206,13 +1197,10 @@ void C2_MacroAssembler::fast_unlock_lightweight(Register obj, Register reg_rax, 
       assert(mark == monitor, "should be the same here");
     } else {
       // Uses ObjectMonitorTable.  Look for the monitor in our BasicLock on the stack.
-      if (false) increment(Address(thread, JavaThread::unlock_lookup_offset()));
       movptr(monitor, Address(box, BasicLock::object_monitor_cache_offset_in_bytes()));
       // null check with ZF == 0, no valid pointer below alignof(ObjectMonitor*)
       cmpptr(monitor, alignof(ObjectMonitor*));
       jcc(Assembler::below, slow_path);
-
-      if (false) increment(Address(thread, JavaThread::unlock_hit_offset()));
     }
     const ByteSize monitor_tag = in_ByteSize(UseObjectMonitorTable ? 0 : checked_cast<int>(markWord::monitor_value));
     const Address recursions_address{monitor, ObjectMonitor::recursions_offset() - monitor_tag};

--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
@@ -1014,7 +1014,7 @@ void C2_MacroAssembler::fast_lock_lightweight(Register obj, Register box, Regist
       assert(mark == monitor, "should be the same here");
     } else {
       // Uses ObjectMonitorTable.  Look for the monitor in the om_cache.
-      if (OMCacheHitRate) increment(Address(thread, JavaThread::lock_lookup_offset()));
+      if (false) increment(Address(thread, JavaThread::lock_lookup_offset()));
 
       // Fetch ObjectMonitor* from the cache or take the slow-path.
       Label monitor_found;
@@ -1022,7 +1022,7 @@ void C2_MacroAssembler::fast_lock_lightweight(Register obj, Register box, Regist
       // Load cache address
       lea(t, Address(thread, JavaThread::om_cache_oops_offset()));
 
-      const int num_unrolled = MIN2(OMC2UnrollCacheEntries, OMCacheSize);
+      const int num_unrolled = MIN2(2, OMCache::CAPACITY);
       for (int i = 0; i < num_unrolled; i++) {
         cmpptr(obj, Address(t));
         jccb(Assembler::equal, monitor_found);
@@ -1031,7 +1031,7 @@ void C2_MacroAssembler::fast_lock_lightweight(Register obj, Register box, Regist
         }
       }
 
-      if (num_unrolled == 0 || (OMC2UnrollCacheLookupLoopTail && num_unrolled != OMCacheSize)) {
+      if (num_unrolled == 0 || (true && num_unrolled != OMCache::CAPACITY)) {
         if (num_unrolled != 0) {
           // Loop after unrolling, advance iterator.
           increment(t, in_bytes(OMCache::oop_to_oop_difference()));
@@ -1058,7 +1058,7 @@ void C2_MacroAssembler::fast_lock_lightweight(Register obj, Register box, Regist
       // Cache hit.
       bind(monitor_found);
       movptr(monitor, Address(t, OMCache::oop_to_monitor_difference()));
-      if (OMCacheHitRate) increment(Address(thread, JavaThread::lock_hit_offset()));
+      if (false) increment(Address(thread, JavaThread::lock_hit_offset()));
     }
     const ByteSize monitor_tag = in_ByteSize(UseObjectMonitorTable ? 0 : checked_cast<int>(markWord::monitor_value));
     const Address recursions_address{monitor, ObjectMonitor::recursions_offset() - monitor_tag};
@@ -1206,13 +1206,13 @@ void C2_MacroAssembler::fast_unlock_lightweight(Register obj, Register reg_rax, 
       assert(mark == monitor, "should be the same here");
     } else {
       // Uses ObjectMonitorTable.  Look for the monitor in our BasicLock on the stack.
-      if (OMCacheHitRate) increment(Address(thread, JavaThread::unlock_lookup_offset()));
+      if (false) increment(Address(thread, JavaThread::unlock_lookup_offset()));
       movptr(monitor, Address(box, BasicLock::object_monitor_cache_offset_in_bytes()));
       // null check with ZF == 0, no valid pointer below alignof(ObjectMonitor*)
       cmpptr(monitor, alignof(ObjectMonitor*));
       jcc(Assembler::below, slow_path);
 
-      if (OMCacheHitRate) increment(Address(thread, JavaThread::unlock_hit_offset()));
+      if (false) increment(Address(thread, JavaThread::unlock_hit_offset()));
     }
     const ByteSize monitor_tag = in_ByteSize(UseObjectMonitorTable ? 0 : checked_cast<int>(markWord::monitor_value));
     const Address recursions_address{monitor, ObjectMonitor::recursions_offset() - monitor_tag};

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -10391,9 +10391,6 @@ void MacroAssembler::lightweight_lock(Register basic_lock, Register obj, Registe
 // reg_rax: rax
 // thread: the thread
 // tmp: a temporary register
-//
-// x86_32 Note: reg_rax and thread may alias each other due to limited register
-//              availiability.
 void MacroAssembler::lightweight_unlock(Register obj, Register reg_rax, Register thread, Register tmp, Label& slow) {
   assert(reg_rax == rax, "");
   assert_different_registers(obj, reg_rax, thread, tmp);

--- a/src/hotspot/cpu/x86/sharedRuntime_x86.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86.cpp
@@ -62,9 +62,11 @@ void SharedRuntime::inline_check_hashcode_from_object_header(MacroAssembler* mas
 
 
   if (LockingMode == LM_LIGHTWEIGHT) {
-    // check if monitor
-    __ testptr(result, markWord::monitor_value);
-    __ jcc(Assembler::notZero, slowCase);
+    if (!UseObjectMonitorTable) {
+      // check if monitor
+      __ testptr(result, markWord::monitor_value);
+      __ jcc(Assembler::notZero, slowCase);
+    }
   } else {
     // check if locked
     __ testptr(result, markWord::unlocked_value);

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp
@@ -46,7 +46,6 @@
 #include "runtime/vframeArray.hpp"
 #include "runtime/vm_version.hpp"
 #include "utilities/align.hpp"
-#include "utilities/globalDefinitions.hpp"
 #include "vmreg_x86.inline.hpp"
 #ifdef COMPILER1
 #include "c1/c1_Runtime1.hpp"

--- a/src/hotspot/share/c1/c1_Runtime1.cpp
+++ b/src/hotspot/share/c1/c1_Runtime1.cpp
@@ -73,7 +73,6 @@
 #include "runtime/vm_version.hpp"
 #include "utilities/copy.hpp"
 #include "utilities/events.hpp"
-#include "utilities/macros.hpp"
 
 
 // Implementation of StubAssembler
@@ -758,7 +757,7 @@ JRT_BLOCK_ENTRY(void, Runtime1::monitorenter(JavaThread* current, oopDesc* obj, 
   if (LockingMode == LM_MONITOR) {
     lock->set_obj(obj);
   }
-  assert(obj == lock->obj(), "must match: " PTR_FORMAT, p2i(lock));
+  assert(obj == lock->obj(), "must match");
   SharedRuntime::monitor_enter_helper(obj, lock->lock(), current);
 JRT_END
 

--- a/src/hotspot/share/logging/logTag.hpp
+++ b/src/hotspot/share/logging/logTag.hpp
@@ -129,6 +129,7 @@ class outputStream;
   LOG_TAG(module) \
   LOG_TAG(monitorinflation) \
   LOG_TAG(monitormismatch) \
+  LOG_TAG(monitortable) \
   LOG_TAG(native) \
   LOG_TAG(nestmates) \
   LOG_TAG(nmethod) \
@@ -138,7 +139,6 @@ class outputStream;
   LOG_TAG(objecttagging) \
   LOG_TAG(obsolete) \
   LOG_TAG(oldobject) \
-  LOG_TAG(omworld) \
   LOG_TAG(oom) \
   LOG_TAG(oopmap) \
   LOG_TAG(oops) \

--- a/src/hotspot/share/nmt/memflags.hpp
+++ b/src/hotspot/share/nmt/memflags.hpp
@@ -58,7 +58,6 @@
   f(mtMetaspace,      "Metaspace")                                                   \
   f(mtStringDedup,    "String Deduplication")                                        \
   f(mtObjectMonitor,  "Object Monitors")                                             \
-  f(mtOMWorld,        "OM World")                                                    \
   f(mtNone,           "Unknown")                                                     \
   //end
 

--- a/src/hotspot/share/oops/markWord.hpp
+++ b/src/hotspot/share/oops/markWord.hpp
@@ -29,7 +29,6 @@
 #include "oops/compressedKlass.hpp"
 #include "oops/oopsHierarchy.hpp"
 #include "runtime/globals.hpp"
-#include "utilities/globalDefinitions.hpp"
 
 #include <type_traits>
 

--- a/src/hotspot/share/runtime/basicLock.cpp
+++ b/src/hotspot/share/runtime/basicLock.cpp
@@ -27,7 +27,6 @@
 #include "runtime/basicLock.inline.hpp"
 #include "runtime/objectMonitor.hpp"
 #include "runtime/synchronizer.hpp"
-#include "utilities/globalDefinitions.hpp"
 
 void BasicLock::print_on(outputStream* st, oop owner) const {
   st->print("monitor");

--- a/src/hotspot/share/runtime/basicLock.cpp
+++ b/src/hotspot/share/runtime/basicLock.cpp
@@ -30,12 +30,12 @@
 
 void BasicLock::print_on(outputStream* st, oop owner) const {
   st->print("monitor");
-  if (LockingMode == LM_LIGHTWEIGHT) {
+  if (UseObjectMonitorTable) {
     ObjectMonitor* mon = object_monitor_cache();
     if (mon != nullptr) {
       mon->print_on(st);
     }
-  } else {
+  } else if (LockingMode == LM_LEGACY) {
     markWord mark_word = displaced_header();
     if (mark_word.value() != 0) {
       // Print monitor info if there's an owning oop and it refers to this BasicLock.
@@ -90,7 +90,7 @@ void BasicLock::move_to(oop obj, BasicLock* dest) {
       // we can find any flavor mark in the displaced mark.
     }
     dest->set_displaced_header(displaced_header());
-  } else if (LockingMode == LM_LIGHTWEIGHT) {
+  } else if (UseObjectMonitorTable) {
     // Preserve the ObjectMonitor*, the cache is cleared when a box is reused
     // and only read while the lock is held, so no stale ObjectMonitor* is
     // encountered.

--- a/src/hotspot/share/runtime/basicLock.inline.hpp
+++ b/src/hotspot/share/runtime/basicLock.inline.hpp
@@ -38,17 +38,17 @@ inline void BasicLock::set_displaced_header(markWord header) {
 }
 
 inline ObjectMonitor* BasicLock::object_monitor_cache() const {
-  assert(LockingMode == LM_LIGHTWEIGHT, "must be");
+  assert(UseObjectMonitorTable, "must be");
   return reinterpret_cast<ObjectMonitor*>(get_metadata());
 }
 
 inline void BasicLock::clear_object_monitor_cache() {
-  assert(LockingMode == LM_LIGHTWEIGHT, "must be");
+  assert(UseObjectMonitorTable, "must be");
   set_metadata(0);
 }
 
 inline void BasicLock::set_object_monitor_cache(ObjectMonitor* mon) {
-  assert(LockingMode == LM_LIGHTWEIGHT, "must be");
+  assert(UseObjectMonitorTable, "must be");
   set_metadata(reinterpret_cast<uintptr_t>(mon));
 }
 

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -96,7 +96,6 @@
 #include "runtime/vmOperations.hpp"
 #include "utilities/checkedCast.hpp"
 #include "utilities/events.hpp"
-#include "utilities/globalDefinitions.hpp"
 #include "utilities/growableArray.hpp"
 #include "utilities/macros.hpp"
 #include "utilities/preserveException.hpp"

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -1645,12 +1645,12 @@ bool Deoptimization::relock_objects(JavaThread* thread, GrowableArray<MonitorInf
               assert(fr.is_deoptimized_frame(), "frame must be scheduled for deoptimization");
               if (LockingMode == LM_LEGACY) {
                 mon_info->lock()->set_displaced_header(markWord::unused_mark());
-              } else if (LockingMode == LM_LIGHTWEIGHT) {
+              } else if (UseObjectMonitorTable) {
                 mon_info->lock()->clear_object_monitor_cache();
               }
 #ifdef ASSERT
               else {
-                assert(LockingMode == LM_MONITOR, "must be");
+                assert(LockingMode == LM_MONITOR || !UseObjectMonitorTable, "must be");
                 mon_info->lock()->set_bad_metadata_deopt();
               }
 #endif

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1977,22 +1977,12 @@ const int ObjectAlignmentInBytes = 8;
           "With Lightweight Locking mode, use a table to record inflated "  \
           "monitors rather than the first word of the object.")             \
                                                                             \
-  product(bool, OMC2UnrollCacheLookupLoopTail, true, "")                    \
-                                                                            \
-  product(int, OMC2UnrollCacheEntries, 0, "")                               \
-          range(0, OMCache::CAPACITY)                                       \
-                                                                            \
-  product(int, OMCacheSize, 8, "")                                          \
-          range(0, OMCache::CAPACITY)                                       \
-                                                                            \
-  product(int, OMSpins, 13,                                                 \
+  product(int, LightweightFastLockingSpins, 13, DIAGNOSTIC,                 \
           "Specifies the number of time lightweight fast locking will "     \
           "attempt to CAS the markWord before inflating. Between each "     \
           "CAS it will spin for exponentially more time, resulting in "     \
-          "a total number of spins on the order of O(2^OMSpins)")           \
+          "a total number of spins on the order of O(2^value)")             \
           range(1, 30)                                                      \
-                                                                            \
-  product(bool, OMCacheHitRate, false, "")                                  \
                                                                             \
   product(uint, TrimNativeHeapInterval, 0,                                  \
           "Interval, in ms, at which the JVM will trim the native heap if " \

--- a/src/hotspot/share/runtime/javaThread.cpp
+++ b/src/hotspot/share/runtime/javaThread.cpp
@@ -98,7 +98,6 @@
 #include "utilities/defaultStream.hpp"
 #include "utilities/dtrace.hpp"
 #include "utilities/events.hpp"
-#include "utilities/globalDefinitions.hpp"
 #include "utilities/macros.hpp"
 #include "utilities/preserveException.hpp"
 #include "utilities/spinYield.hpp"

--- a/src/hotspot/share/runtime/javaThread.hpp
+++ b/src/hotspot/share/runtime/javaThread.hpp
@@ -1175,16 +1175,6 @@ public:
   size_t _wait_inflation = 0;
   size_t _lock_stack_inflation = 0;
 
-  size_t _lock_lookup = 0;
-  size_t _lock_hit = 0;
-  size_t _unlock_lookup = 0;
-  size_t _unlock_hit = 0;
-
-  static ByteSize lock_lookup_offset() { return byte_offset_of(JavaThread, _lock_lookup); }
-  static ByteSize lock_hit_offset() { return byte_offset_of(JavaThread, _lock_hit); }
-  static ByteSize unlock_lookup_offset() { return byte_offset_of(JavaThread, _unlock_lookup); }
-  static ByteSize unlock_hit_offset() { return byte_offset_of(JavaThread, _unlock_hit); }
-
   static ByteSize lock_stack_offset()      { return byte_offset_of(JavaThread, _lock_stack); }
   // Those offsets are used in code generators to access the LockStack that is embedded in this
   // JavaThread structure. Those accesses are relative to the current thread, which

--- a/src/hotspot/share/runtime/javaThread.hpp
+++ b/src/hotspot/share/runtime/javaThread.hpp
@@ -1168,12 +1168,6 @@ private:
 
 public:
   LockStack& lock_stack() { return _lock_stack; }
-  size_t _unlocked_inflation = 0;
-  size_t _recursive_inflation = 0;
-  size_t _contended_recursive_inflation = 0;
-  size_t _contended_inflation = 0;
-  size_t _wait_inflation = 0;
-  size_t _lock_stack_inflation = 0;
 
   static ByteSize lock_stack_offset()      { return byte_offset_of(JavaThread, _lock_stack); }
   // Those offsets are used in code generators to access the LockStack that is embedded in this

--- a/src/hotspot/share/runtime/javaThread.hpp
+++ b/src/hotspot/share/runtime/javaThread.hpp
@@ -1178,7 +1178,7 @@ public:
 
 
   static ByteSize om_cache_offset()        { return byte_offset_of(JavaThread, _om_cache); }
-  static ByteSize om_cache_oops_offset()   { return om_cache_offset() + OMCache::entries(); }
+  static ByteSize om_cache_oops_offset()   { return om_cache_offset() + OMCache::entries_offset(); }
 
   void om_set_monitor_cache(ObjectMonitor* monitor);
   void om_clear_monitor_cache();

--- a/src/hotspot/share/runtime/javaThread.inline.hpp
+++ b/src/hotspot/share/runtime/javaThread.inline.hpp
@@ -289,20 +289,6 @@ inline void JavaThread::om_clear_monitor_cache() {
   _contended_inflation           = 0;
   _wait_inflation                = 0;
   _lock_stack_inflation          = 0;
-
-  if (_lock_lookup != 0 ||
-      _unlock_lookup != 0) {
-    const double lock_hit_rate = (double)_lock_hit / (double)_lock_lookup * 100;
-    const double unlock_hit_rate = (double)_unlock_hit / (double)_unlock_lookup * 100;
-    lt.print("Lock: %3.2lf %% [%6zu / %6zu] Unlock: %3.2lf %% [%6zu / %6zu] Thread: %s",
-             lock_hit_rate, _lock_hit, _lock_lookup,
-             unlock_hit_rate, _unlock_hit, _unlock_lookup,
-             name());
-  }
-  _lock_hit = 0;
-  _lock_lookup = 0;
-  _unlock_hit = 0;
-  _unlock_lookup = 0;
 }
 
 inline ObjectMonitor* JavaThread::om_get_from_monitor_cache(oop obj) {

--- a/src/hotspot/share/runtime/javaThread.inline.hpp
+++ b/src/hotspot/share/runtime/javaThread.inline.hpp
@@ -30,21 +30,17 @@
 
 #include "classfile/javaClasses.hpp"
 #include "gc/shared/tlab_globals.hpp"
-#include "logging/log.hpp"
-#include "memory/resourceArea.hpp"
 #include "memory/universe.hpp"
 #include "oops/instanceKlass.hpp"
 #include "oops/oopHandle.inline.hpp"
 #include "runtime/atomic.hpp"
 #include "runtime/continuation.hpp"
 #include "runtime/continuationEntry.inline.hpp"
+#include "runtime/lockStack.inline.hpp"
 #include "runtime/nonJavaThread.hpp"
 #include "runtime/objectMonitor.inline.hpp"
 #include "runtime/orderAccess.hpp"
 #include "runtime/safepoint.hpp"
-#include "runtime/synchronizer.hpp"
-#include "utilities/globalDefinitions.hpp"
-#include "utilities/sizes.hpp"
 
 inline void JavaThread::set_suspend_flag(SuspendFlags f) {
   uint32_t flags;

--- a/src/hotspot/share/runtime/javaThread.inline.hpp
+++ b/src/hotspot/share/runtime/javaThread.inline.hpp
@@ -260,35 +260,6 @@ inline void JavaThread::om_clear_monitor_cache() {
   }
 
   _om_cache.clear();
-
-  LogTarget(Info, monitorinflation, thread) lt;
-  if (!lt.is_enabled()) {
-    return;
-  }
-
-  ResourceMark rm;
-
-  if (_unlocked_inflation != 0 ||
-      _recursive_inflation != 0 ||
-      _contended_recursive_inflation != 0 ||
-      _contended_inflation != 0 ||
-      _wait_inflation != 0 ||
-      _lock_stack_inflation != 0) {
-    lt.print("Mon: %8zu Rec: %8zu CRec: %8zu Cont: %8zu Wait: %8zu Stack: %8zu Thread: %s",
-             _unlocked_inflation,
-             _recursive_inflation,
-             _contended_recursive_inflation,
-             _contended_inflation,
-             _wait_inflation,
-             _lock_stack_inflation,
-             name());
-  }
-  _unlocked_inflation            = 0;
-  _recursive_inflation           = 0;
-  _contended_recursive_inflation = 0;
-  _contended_inflation           = 0;
-  _wait_inflation                = 0;
-  _lock_stack_inflation          = 0;
 }
 
 inline ObjectMonitor* JavaThread::om_get_from_monitor_cache(oop obj) {

--- a/src/hotspot/share/runtime/javaThread.inline.hpp
+++ b/src/hotspot/share/runtime/javaThread.inline.hpp
@@ -246,7 +246,7 @@ inline InstanceKlass* JavaThread::class_to_be_initialized() const {
 }
 
 inline void JavaThread::om_set_monitor_cache(ObjectMonitor* monitor) {
-  assert(LockingMode == LM_LIGHTWEIGHT, "must be");
+  assert(UseObjectMonitorTable, "must be");
   assert(monitor != nullptr, "use om_clear_monitor_cache to clear");
   assert(this == current() || monitor->owner_raw() == this, "only add owned monitors for other threads");
   assert(this == current() || is_obj_deopt_suspend(), "thread must not run concurrently");
@@ -255,7 +255,7 @@ inline void JavaThread::om_set_monitor_cache(ObjectMonitor* monitor) {
 }
 
 inline void JavaThread::om_clear_monitor_cache() {
-  if (LockingMode != LM_LIGHTWEIGHT) {
+  if (!UseObjectMonitorTable) {
     return;
   }
 

--- a/src/hotspot/share/runtime/lightweightSynchronizer.cpp
+++ b/src/hotspot/share/runtime/lightweightSynchronizer.cpp
@@ -576,7 +576,7 @@ public:
 
 bool LightweightSynchronizer::fast_lock_spin_enter(oop obj, JavaThread* current, bool observed_deflation) {
   // Will spin with exponential backoff with an accumulative O(2^spin_limit) spins.
-  const int log_spin_limit = os::is_MP() || !UseObjectMonitorTable ? OMSpins : 1;
+  const int log_spin_limit = os::is_MP() || !UseObjectMonitorTable ? LightweightFastLockingSpins : 1;
   const int log_min_safepoint_check_interval = 10;
 
   LockStack& lock_stack = current->lock_stack();

--- a/src/hotspot/share/runtime/lockStack.hpp
+++ b/src/hotspot/share/runtime/lockStack.hpp
@@ -85,9 +85,6 @@ public:
   static uint32_t start_offset();
   static uint32_t end_offset();
 
-  // Return true if we have room to push n oops onto this lock-stack, false otherwise.
-  inline bool can_push(int n = 1) const;
-
   // Returns true if the lock-stack is full. False otherwise.
   inline bool is_full() const;
 
@@ -100,9 +97,6 @@ public:
 
   // Is the lock-stack empty.
   inline bool is_empty() const;
-
-  // Get the oldest oop in the stack
-  inline oop top();
 
   // Check if object is recursive.
   // Precondition: This lock-stack must contain the oop.
@@ -144,7 +138,7 @@ private:
   const oop _null_sentinel = nullptr;
 
 public:
-  static ByteSize entries() { return byte_offset_of(OMCache, _entries); }
+  static ByteSize entries_offset() { return byte_offset_of(OMCache, _entries); }
   static constexpr ByteSize oop_to_oop_difference() { return in_ByteSize(sizeof(OMCacheEntry)); }
   static constexpr ByteSize oop_to_monitor_difference() { return in_ByteSize(sizeof(oop)); }
 

--- a/src/hotspot/share/runtime/lockStack.inline.hpp
+++ b/src/hotspot/share/runtime/lockStack.inline.hpp
@@ -237,7 +237,7 @@ inline void LockStack::oops_do(OopClosure* cl) {
 }
 
 inline void OMCache::set_monitor(ObjectMonitor *monitor) {
-  const int end = OMCacheSize - 1;
+  const int end = OMCache::CAPACITY - 1;
   if (end < 0) {
     return;
   }
@@ -263,13 +263,13 @@ inline void OMCache::set_monitor(ObjectMonitor *monitor) {
 }
 
 inline ObjectMonitor* OMCache::get_monitor(oop o) {
-  for (int i = 0; i < OMCacheSize; ++i) {
+  for (int i = 0; i < OMCache::CAPACITY; ++i) {
     if (_entries[i]._oop == o) {
       assert(_entries[i]._monitor != nullptr, "monitor must exist");
       if (_entries[i]._monitor->is_being_async_deflated()) {
         // Bad monitor
         // Shift down rest
-        for (; i < OMCacheSize - 1; ++i) {
+        for (; i < OMCache::CAPACITY - 1; ++i) {
           _entries[i] = _entries[i + 1];
         }
         // Clear end

--- a/src/hotspot/share/runtime/objectMonitor.cpp
+++ b/src/hotspot/share/runtime/objectMonitor.cpp
@@ -296,10 +296,10 @@ void ObjectMonitor::ClearSuccOnSuspend::operator()(JavaThread* current) {
   }
 }
 
-#define assert_mark_word_concistency()                                                 \
+#define assert_mark_word_concistency()                                         \
   assert(UseObjectMonitorTable || object()->mark() == markWord::encode(this),  \
-         "object mark must match encoded this: mark=" INTPTR_FORMAT                    \
-         ", encoded this=" INTPTR_FORMAT, object()->mark().value(),                    \
+         "object mark must match encoded this: mark=" INTPTR_FORMAT            \
+         ", encoded this=" INTPTR_FORMAT, object()->mark().value(),            \
          markWord::encode(this).value());
 
 // -----------------------------------------------------------------------------

--- a/src/hotspot/share/runtime/objectMonitor.cpp
+++ b/src/hotspot/share/runtime/objectMonitor.cpp
@@ -296,7 +296,7 @@ void ObjectMonitor::ClearSuccOnSuspend::operator()(JavaThread* current) {
   }
 }
 
-#define assert_mark_word_concistency()                                         \
+#define assert_mark_word_consistency()                                         \
   assert(UseObjectMonitorTable || object()->mark() == markWord::encode(this),  \
          "object mark must match encoded this: mark=" INTPTR_FORMAT            \
          ", encoded this=" INTPTR_FORMAT, object()->mark().value(),            \
@@ -424,7 +424,7 @@ bool ObjectMonitor::spin_enter(JavaThread* current) {
   if (TrySpin(current)) {
     assert(owner_raw() == current, "must be current: owner=" INTPTR_FORMAT, p2i(owner_raw()));
     assert(_recursions == 0, "must be 0: recursions=" INTX_FORMAT, _recursions);
-    assert_mark_word_concistency();
+    assert_mark_word_consistency();
     return true;
   }
 
@@ -524,7 +524,7 @@ void ObjectMonitor::enter_with_contention_mark(JavaThread *current, ObjectMonito
   assert(_recursions == 0, "invariant");
   assert(owner_raw() == current, "invariant");
   assert(_succ != current, "invariant");
-  assert_mark_word_concistency();
+  assert_mark_word_consistency();
 
   // The thread -- now the owner -- is back in vm mode.
   // Report the glorious news via TI,DTrace and jvmstat.
@@ -1019,7 +1019,7 @@ void ObjectMonitor::ReenterI(JavaThread* current, ObjectWaiter* currentNode) {
   assert(currentNode != nullptr, "invariant");
   assert(currentNode->_thread == current, "invariant");
   assert(_waiters > 0, "invariant");
-  assert_mark_word_concistency();
+  assert_mark_word_consistency();
 
   for (;;) {
     ObjectWaiter::TStates v = currentNode->TState;
@@ -1084,7 +1084,7 @@ void ObjectMonitor::ReenterI(JavaThread* current, ObjectWaiter* currentNode) {
   // In addition, current.TState is stable.
 
   assert(owner_raw() == current, "invariant");
-  assert_mark_word_concistency();
+  assert_mark_word_consistency();
   UnlinkAfterAcquire(current, currentNode);
   if (_succ == current) _succ = nullptr;
   assert(_succ != current, "invariant");
@@ -1710,7 +1710,7 @@ void ObjectMonitor::wait(jlong millis, bool interruptible, TRAPS) {
   // Verify a few postconditions
   assert(owner_raw() == current, "invariant");
   assert(_succ != current, "invariant");
-  assert_mark_word_concistency();
+  assert_mark_word_consistency();
 
   // check if the notification happened
   if (!WasNotified) {

--- a/src/hotspot/share/runtime/objectMonitor.hpp
+++ b/src/hotspot/share/runtime/objectMonitor.hpp
@@ -136,7 +136,7 @@ class ObjectMonitor : public CHeapObj<mtObjectMonitor> {
   // Enforced by the assert() in metadata_addr().
   // * LM_LIGHTWEIGHT with UseObjectMonitorTable:
   // Contains the _object's hashCode.
-  // * LM_LEGACY, LM_MONITOR:
+  // * LM_LEGACY, LM_MONITOR, LM_LIGHTWEIGHT without UseObjectMonitorTable:
   // Contains the displaced object header word - mark
   volatile uintptr_t _metadata;     // metadata
   WeakHandle _object;               // backward object pointer

--- a/src/hotspot/share/runtime/safepoint.cpp
+++ b/src/hotspot/share/runtime/safepoint.cpp
@@ -732,7 +732,7 @@ void ThreadSafepointState::account_safe_thread() {
   assert(!_safepoint_safe, "Must be unsafe before safe");
   _safepoint_safe = true;
 
-  // The oops in the monitor cache is cleared to prevent stale cache entries
+  // The oops in the monitor cache are cleared to prevent stale cache entries
   // from keeping dead objects alive. Because these oops are always cleared
   // before safepoint operations they are not visited in JavaThread::oops_do.
   _thread->om_clear_monitor_cache();

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -58,7 +58,6 @@
 #include "runtime/atomic.hpp"
 #include "runtime/basicLock.inline.hpp"
 #include "runtime/frame.inline.hpp"
-#include "runtime/globals.hpp"
 #include "runtime/handles.inline.hpp"
 #include "runtime/init.hpp"
 #include "runtime/interfaceSupport.inline.hpp"

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -2949,7 +2949,7 @@ JRT_LEAF(intptr_t*, SharedRuntime::OSR_migration_begin( JavaThread *current) )
         // Now the displaced header is free to move because the
         // object's header no longer refers to it.
         buf[i] = (intptr_t)lock->displaced_header().value();
-      } else if (LockingMode == LM_LIGHTWEIGHT) {
+      } else if (UseObjectMonitorTable) {
         buf[i] = (intptr_t)lock->object_monitor_cache();
       }
 #ifdef ASSERT

--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -994,7 +994,7 @@ static intptr_t install_hash_code(Thread* current, oop obj) {
 
 intptr_t ObjectSynchronizer::FastHashCode(Thread* current, oop obj) {
   // Since the monitor isn't in the object header, it can simply be installed.
-  if (UseObjectMonitorTable && LockingMode == LM_LIGHTWEIGHT) {
+  if (UseObjectMonitorTable) {
     return install_hash_code(current, obj);
   }
 

--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -1405,9 +1405,7 @@ static void post_monitor_inflate_event(EventJavaMonitorInflate* event,
 
 // Fast path code shared by multiple functions
 void ObjectSynchronizer::inflate_helper(oop obj) {
-  if (LockingMode == LM_LIGHTWEIGHT) {
-    return;
-  }
+  assert(LockingMode != LM_LIGHTWEIGHT, "only inflate through enter");
   markWord mark = obj->mark_acquire();
   if (mark.has_monitor()) {
     ObjectMonitor* monitor = read_monitor(mark);
@@ -1420,11 +1418,8 @@ void ObjectSynchronizer::inflate_helper(oop obj) {
 
 ObjectMonitor* ObjectSynchronizer::inflate(Thread* current, oop obj, const InflateCause cause) {
   assert(current == Thread::current(), "must be");
-  if (LockingMode == LM_LIGHTWEIGHT) {
-    return LightweightSynchronizer::inflate_into_object_header(current, nullptr, obj, cause);
-  } else {
-    return inflate_impl(obj, cause);
-  }
+  assert(LockingMode != LM_LIGHTWEIGHT, "only inflate through enter");
+  return inflate_impl(obj, cause);
 }
 
 ObjectMonitor* ObjectSynchronizer::inflate_for(JavaThread* thread, oop obj, const InflateCause cause) {

--- a/src/hotspot/share/runtime/synchronizer.inline.hpp
+++ b/src/hotspot/share/runtime/synchronizer.inline.hpp
@@ -24,6 +24,8 @@
 
 #include "runtime/synchronizer.hpp"
 
+#include "runtime/lightweightSynchronizer.hpp"
+
 ObjectMonitor* ObjectSynchronizer::read_monitor(markWord mark) {
   return mark.monitor();
 }

--- a/src/hotspot/share/utilities/globalDefinitions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions.hpp
@@ -1023,7 +1023,7 @@ enum LockingMode {
   // Legacy stack-locking, with monitors as 2nd tier
   LM_LEGACY      = 1,
   // New lightweight locking, with monitors as 2nd tier
-  LM_LIGHTWEIGHT = 2,
+  LM_LIGHTWEIGHT = 2
 };
 
 //----------------------------------------------------------------------------------------------------

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -575,7 +575,7 @@ static void report_vm_version(outputStream* st, char* buf, int buflen) {
                 buf, jdk_debug_level, runtime_version);
 
    // This is the long version with some default settings added
-   st->print_cr("# Java VM: %s%s%s (%s%s, %s%s%s%s%s%s%s, %s, %s)",
+   st->print_cr("# Java VM: %s%s%s (%s%s, %s%s%s%s%s%s, %s, %s)",
                  VM_Version::vm_name(),
                 (*vendor_version != '\0') ? " " : "", vendor_version,
                  jdk_debug_level,
@@ -590,9 +590,6 @@ static void report_vm_version(outputStream* st, char* buf, int buflen) {
 #endif
                  UseCompressedOops ? ", compressed oops" : "",
                  UseCompressedClassPointers ? ", compressed class ptrs" : "",
-                 LockingMode == LM_MONITOR ? ", lm_monitors" :
-                 LockingMode == LM_LEGACY ? ", lm_legacy" :
-                 LockingMode == LM_LIGHTWEIGHT ? ", lm_lightweight" : "",
                  GCConfig::hs_err_name(),
                  VM_Version::vm_platform_string()
                );

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -1116,7 +1116,7 @@ void VMError::report(outputStream* st, bool _verbose) {
     print_stack_location(st, _context, continuation);
     st->cr();
 
-  STEP_IF("printing lock stack", _verbose && _thread != nullptr && _thread->is_Java_thread() && (LockingMode == LM_LIGHTWEIGHT));
+  STEP_IF("printing lock stack", _verbose && _thread != nullptr && _thread->is_Java_thread() && LockingMode == LM_LIGHTWEIGHT);
     st->print_cr("Lock stack of current Java thread (top to bottom):");
     JavaThread::cast(_thread)->lock_stack().print_on(st);
     st->cr();


### PR DESCRIPTION
Cleanups in preparation for opening up a PR to mainline for [JDK-8315884](https://bugs.openjdk.org/browse/JDK-8315884).

@coleenp I incorporated #182 into this.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput.git pull/183/head:pull/183` \
`$ git checkout pull/183`

Update a local copy of the PR: \
`$ git checkout pull/183` \
`$ git pull https://git.openjdk.org/lilliput.git pull/183/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 183`

View PR using the GUI difftool: \
`$ git pr show -t 183`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput/pull/183.diff">https://git.openjdk.org/lilliput/pull/183.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput/pull/183#issuecomment-2180503447)