### PR TITLE
8335251: [Lilliput] Fix TestRecursiveMonitorChurn failure

### DIFF
--- a/test/hotspot/jtreg/runtime/locking/TestRecursiveMonitorChurn.java
+++ b/test/hotspot/jtreg/runtime/locking/TestRecursiveMonitorChurn.java
@@ -83,7 +83,7 @@ public class TestRecursiveMonitorChurn {
                     long reserved = Long.parseLong(m.group(1));
                     long committed = Long.parseLong(m.group(2));
                     System.out.println(">>>>> " + line + ": " + reserved + " - " + committed);
-                    if (committed > 1000) {
+                    if (committed > 100000) {
                         throw new RuntimeException("Allocated too many monitors");
                     }
                     return;


### PR DESCRIPTION
The test TestRecursiveMonitorChurn currrently fails with Lilliput or UseObjectMonitorTable, because the monitor table is also allocated with mtObjectMonitor tag, and the threshold in the test is too low.

The fix is to increase the threshold so that it covers the table, but not so much that we'd get false positives. 100,000 seems to hit that spot nicely. (The memory usage with table is about 70,000, the failure case is over the 1,000,000 mark.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8335251](https://bugs.openjdk.org/browse/JDK-8335251): [Lilliput] Fix TestRecursiveMonitorChurn failure (**Bug** - P4)


### Reviewers
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput.git pull/186/head:pull/186` \
`$ git checkout pull/186`

Update a local copy of the PR: \
`$ git checkout pull/186` \
`$ git pull https://git.openjdk.org/lilliput.git pull/186/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 186`

View PR using the GUI difftool: \
`$ git pr show -t 186`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput/pull/186.diff">https://git.openjdk.org/lilliput/pull/186.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput/pull/186#issuecomment-2194432265)