### PR TITLE
Add some inlining and avoid CAS for quick_enter for lightweight locking.

### DIFF
--- a/src/hotspot/share/interpreter/interpreterRuntime.cpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.cpp
@@ -71,7 +71,7 @@
 #include "runtime/sharedRuntime.hpp"
 #include "runtime/stackWatermarkSet.hpp"
 #include "runtime/stubRoutines.hpp"
-#include "runtime/synchronizer.hpp"
+#include "runtime/synchronizer.inline.hpp"
 #include "runtime/threadCritical.hpp"
 #include "utilities/align.hpp"
 #include "utilities/checkedCast.hpp"

--- a/src/hotspot/share/runtime/lightweightSynchronizer.cpp
+++ b/src/hotspot/share/runtime/lightweightSynchronizer.cpp
@@ -575,7 +575,7 @@ public:
   }
 };
 
-inline bool LightweightSynchronizer::check_unlocked(oop obj, LockStack& lock_stack, JavaThread* current) {
+inline bool LightweightSynchronizer::fast_lock_try_enter(oop obj, LockStack& lock_stack, JavaThread* current) {
   markWord mark = obj->mark();
   while (mark.is_unlocked()) {
     ensure_lock_stack_space(current);
@@ -632,7 +632,7 @@ bool LightweightSynchronizer::fast_lock_spin_enter(oop obj, LockStack& lock_stac
       }
     }
 
-    if (check_unlocked(obj, lock_stack, current)) return true;
+    if (fast_lock_try_enter(obj, lock_stack, current)) return true;
   }
   return false;
 }
@@ -705,7 +705,7 @@ void LightweightSynchronizer::enter(Handle obj, BasicLock* lock, JavaThread* cur
     // The goal is to only inflate when the extra cost of using ObjectMonitors
     // is worth it.
     // If deflation has been observed we also spin while deflation is onging.
-    if (check_unlocked(obj(), lock_stack, current)) {
+    if (fast_lock_try_enter(obj(), lock_stack, current)) {
       return;
     } else if (UseObjectMonitorTable && fast_lock_spin_enter(obj(), lock_stack, current, observed_deflation)) {
       return;

--- a/src/hotspot/share/runtime/lightweightSynchronizer.hpp
+++ b/src/hotspot/share/runtime/lightweightSynchronizer.hpp
@@ -57,7 +57,8 @@ private:
   static bool resize_table(JavaThread* current);
 
 private:
-  static bool fast_lock_spin_enter(oop obj, JavaThread* current, bool observed_deflation);
+  static inline bool check_unlocked(oop obj, LockStack& lock_stack, JavaThread* current);
+  static bool fast_lock_spin_enter(oop obj, LockStack& lock_stack, JavaThread* current, bool observed_deflation);
 
 public:
   static void enter_for(Handle obj, BasicLock* lock, JavaThread* locking_thread);

--- a/src/hotspot/share/runtime/lightweightSynchronizer.hpp
+++ b/src/hotspot/share/runtime/lightweightSynchronizer.hpp
@@ -57,7 +57,7 @@ private:
   static bool resize_table(JavaThread* current);
 
 private:
-  static inline bool check_unlocked(oop obj, LockStack& lock_stack, JavaThread* current);
+  static inline bool fast_lock_try_enter(oop obj, LockStack& lock_stack, JavaThread* current);
   static bool fast_lock_spin_enter(oop obj, LockStack& lock_stack, JavaThread* current, bool observed_deflation);
 
 public:

--- a/src/hotspot/share/runtime/lockStack.cpp
+++ b/src/hotspot/share/runtime/lockStack.cpp
@@ -29,6 +29,7 @@
 #include "oops/markWord.hpp"
 #include "oops/oop.inline.hpp"
 #include "runtime/globals.hpp"
+#include "runtime/javaThread.inline.hpp"
 #include "runtime/lockStack.inline.hpp"
 #include "runtime/objectMonitor.inline.hpp"
 #include "runtime/safepoint.hpp"

--- a/src/hotspot/share/runtime/objectMonitor.cpp
+++ b/src/hotspot/share/runtime/objectMonitor.cpp
@@ -382,22 +382,38 @@ bool ObjectMonitor::enter_for(JavaThread* locking_thread) {
 }
 
 bool ObjectMonitor::try_enter(JavaThread* current) {
-  void* cur = try_set_owner_from(nullptr, current);
-  if (cur == nullptr) {
-    assert(_recursions == 0, "invariant");
-    return true;
-  }
+  if (LockingMode == LM_LIGHTWEIGHT) {
+    // TryLock avoids the CAS
+    TryLockResult r = TryLock(current);
+    if (r == TryLockResult::Success) {
+      assert(_recursions == 0, "invariant");
+      return true;
+    }
 
-  if (cur == current) {
-    _recursions++;
-    return true;
-  }
+    if (r == TryLockResult::HasOwner && owner() == current) {
+      _recursions++;
+      return true;
+    }
+    return false;
 
-  if (LockingMode != LM_LIGHTWEIGHT && current->is_lock_owned((address)cur)) {
-    assert(_recursions == 0, "internal state error");
-    _recursions = 1;
-    set_owner_from_BasicLock(cur, current);  // Convert from BasicLock* to Thread*.
-    return true;
+  } else {
+    void* cur = try_set_owner_from(nullptr, current);
+    if (cur == nullptr) {
+      assert(_recursions == 0, "invariant");
+      return true;
+    }
+
+    if (cur == current) {
+      _recursions++;
+      return true;
+    }
+
+    if (LockingMode == LM_LEGACY && current->is_lock_owned((address)cur)) {
+      assert(_recursions == 0, "internal state error");
+      _recursions = 1;
+      set_owner_from_BasicLock(cur, current);  // Convert from BasicLock* to Thread*.
+      return true;
+    }
   }
 
   return false;

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -70,7 +70,7 @@
 #include "runtime/sharedRuntime.hpp"
 #include "runtime/stackWatermarkSet.hpp"
 #include "runtime/stubRoutines.hpp"
-#include "runtime/synchronizer.hpp"
+#include "runtime/synchronizer.inline.hpp"
 #include "runtime/vframe.inline.hpp"
 #include "runtime/vframeArray.hpp"
 #include "runtime/vm_version.hpp"

--- a/src/hotspot/share/runtime/synchronizer.hpp
+++ b/src/hotspot/share/runtime/synchronizer.hpp
@@ -93,8 +93,9 @@ class ObjectSynchronizer : AllStatic {
   // deoptimization at monitor exit. Hence, it does not take a Handle argument.
 
   // This is the "slow path" version of monitor enter and exit.
-  static void enter(Handle obj, BasicLock* lock, JavaThread* current);
-  static void exit(oop obj, BasicLock* lock, JavaThread* current);
+  static inline void enter(Handle obj, BasicLock* lock, JavaThread* current);
+  static inline void exit(oop obj, BasicLock* lock, JavaThread* current);
+
   // Used to enter a monitor for another thread. This requires that the
   // locking_thread is suspended, and that entering on a potential
   // inflated monitor may only contend with deflation. That is the obj being
@@ -106,6 +107,9 @@ private:
   // inflated monitor enter.
   static bool enter_fast_impl(Handle obj, BasicLock* lock, JavaThread* locking_thread);
 
+  static bool quick_enter_legacy(oop obj, JavaThread* current, BasicLock* Lock);
+  static void enter_legacy(Handle obj, BasicLock* Lock, JavaThread* current);
+  static void exit_legacy(oop obj, BasicLock* lock, JavaThread* current);
 public:
   // Used only to handle jni locks or other unmatched monitor enter/exit
   // Internally they will use heavy weight monitor.
@@ -118,7 +122,7 @@ public:
   static void notifyall(Handle obj, TRAPS);
 
   static bool quick_notify(oopDesc* obj, JavaThread* current, bool All);
-  static bool quick_enter(oop obj, JavaThread* current, BasicLock* Lock);
+  static inline bool quick_enter(oop obj, JavaThread* current, BasicLock* Lock);
 
   // Inflate light weight monitor to heavy weight monitor
   static ObjectMonitor* inflate(Thread* current, oop obj, const InflateCause cause);


### PR DESCRIPTION
This is sort of a simple change to inline the code that decides to go to LightweightSynchronizer in case the call has some negative effects for performance sensitive code.  Avoiding the CAS in try_enter was the most helpful.  With perf, I found that the CAS had a longer stall than with the code without the OM world refactoring.  The OM world table is off for this comparison.
Tested with tier1-4, including some local changes to run tier1 tests with -XX:+UseObjectMonitorTable.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewers
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - Committer) ⚠️ Review applies to [fb00e8dd](https://git.openjdk.org/lilliput/pull/187/files/fb00e8ddfe223082abb1e260aff3cbbb4de9ffd0)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput.git pull/187/head:pull/187` \
`$ git checkout pull/187`

Update a local copy of the PR: \
`$ git checkout pull/187` \
`$ git pull https://git.openjdk.org/lilliput.git pull/187/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 187`

View PR using the GUI difftool: \
`$ git pr show -t 187`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput/pull/187.diff">https://git.openjdk.org/lilliput/pull/187.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/lilliput/pull/187#issuecomment-2200957721)