### PR TITLE
8353849: [Lilliput] Avoid race in compact identity hashcode

### DIFF
--- a/src/hotspot/share/cds/heapShared.cpp
+++ b/src/hotspot/share/cds/heapShared.cpp
@@ -589,7 +589,7 @@ static void copy_java_mirror_hashcode(oop orig_mirror, oop scratch_m) {
         scratch_m->initialize_hash_if_necessary(orig_mirror, orig_klass, mark);
       } else {
         assert(mark.is_hashed_expanded(), "must be hashed & moved");
-        int offset = orig_klass->hash_offset_in_bytes(orig_mirror);
+        int offset = orig_klass->hash_offset_in_bytes(orig_mirror, mark);
         assert(offset >= 8, "hash offset must not be in header");
         scratch_m->int_field_put(offset, (jint) src_hash);
         scratch_m->set_mark(mark);

--- a/src/hotspot/share/ci/ciInstanceKlass.hpp
+++ b/src/hotspot/share/ci/ciInstanceKlass.hpp
@@ -297,7 +297,7 @@ public:
   GrowableArray<ciInstanceKlass*>* transitive_interfaces() const;
 
   int hash_offset_in_bytes() const {
-    return get_instanceKlass()->hash_offset_in_bytes(nullptr);
+    return get_instanceKlass()->hash_offset_in_bytes(nullptr, markWord(0));
   }
 
   // Replay support

--- a/src/hotspot/share/gc/shenandoah/shenandoahForwarding.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahForwarding.inline.hpp
@@ -123,7 +123,7 @@ inline size_t ShenandoahForwarding::size(oop obj) {
     size_t size = fwd->base_size_given_klass(fwd_mark, klass);
     if (UseCompactObjectHeaders) {
       if ((mark.value() & FWDED_HASH_TRANSITION) != FWDED_HASH_TRANSITION) {
-        if (fwd_mark.is_expanded() && klass->expand_for_hash(fwd)) {
+        if (fwd_mark.is_expanded() && klass->expand_for_hash(fwd, fwd_mark)) {
           size = align_object_size(size + 1);
         }
       }

--- a/src/hotspot/share/oops/arrayKlass.cpp
+++ b/src/hotspot/share/oops/arrayKlass.cpp
@@ -305,5 +305,6 @@ int ArrayKlass::hash_offset_in_bytes(oop obj, markWord m) const {
   assert(UseCompactObjectHeaders, "only with compact i-hash");
   arrayOop ary = arrayOop(obj);
   BasicType type = element_type();
-  return ary->base_offset_in_bytes(type) + (m.array_length() << log2_element_size());
+  int length = LP64_ONLY(m.array_length()) NOT_LP64(ary.length());
+  return ary->base_offset_in_bytes(type) + (length << log2_element_size());
 }

--- a/src/hotspot/share/oops/arrayKlass.cpp
+++ b/src/hotspot/share/oops/arrayKlass.cpp
@@ -301,9 +301,9 @@ void ArrayKlass::oop_verify_on(oop obj, outputStream* st) {
   guarantee(a->length() >= 0, "array with negative length?");
 }
 
-int ArrayKlass::hash_offset_in_bytes(oop obj) const {
+int ArrayKlass::hash_offset_in_bytes(oop obj, markWord m) const {
   assert(UseCompactObjectHeaders, "only with compact i-hash");
   arrayOop ary = arrayOop(obj);
   BasicType type = element_type();
-  return ary->base_offset_in_bytes(type) + (ary->length() << log2_element_size());
+  return ary->base_offset_in_bytes(type) + (m.array_length() << log2_element_size());
 }

--- a/src/hotspot/share/oops/arrayKlass.cpp
+++ b/src/hotspot/share/oops/arrayKlass.cpp
@@ -305,6 +305,6 @@ int ArrayKlass::hash_offset_in_bytes(oop obj, markWord m) const {
   assert(UseCompactObjectHeaders, "only with compact i-hash");
   arrayOop ary = arrayOop(obj);
   BasicType type = element_type();
-  int length = LP64_ONLY(m.array_length()) NOT_LP64(ary.length());
+  int length = LP64_ONLY(m.array_length()) NOT_LP64(ary->length());
   return ary->base_offset_in_bytes(type) + (length << log2_element_size());
 }

--- a/src/hotspot/share/oops/arrayKlass.hpp
+++ b/src/hotspot/share/oops/arrayKlass.hpp
@@ -118,7 +118,7 @@ class ArrayKlass: public Klass {
   // Return a handle.
   static void     complete_create_array_klass(ArrayKlass* k, Klass* super_klass, ModuleEntry* module, TRAPS);
 
-  int hash_offset_in_bytes(oop obj) const;
+  int hash_offset_in_bytes(oop obj, markWord m) const;
 
   // JVMTI support
   jint jvmti_class_status() const;

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -949,7 +949,7 @@ public:
     return layout_helper_to_size_helper(layout_helper());
   }
 
-  virtual int hash_offset_in_bytes(oop obj) const {
+  virtual int hash_offset_in_bytes(oop obj, markWord m) const {
     assert(UseCompactObjectHeaders, "only with compact i-hash");
     return _hash_offset;
   }

--- a/src/hotspot/share/oops/instanceMirrorKlass.cpp
+++ b/src/hotspot/share/oops/instanceMirrorKlass.cpp
@@ -80,14 +80,14 @@ int InstanceMirrorKlass::compute_static_oop_field_count(oop obj) {
   return 0;
 }
 
-int InstanceMirrorKlass::hash_offset_in_bytes(oop obj) const {
+int InstanceMirrorKlass::hash_offset_in_bytes(oop obj, markWord m) const {
   assert(UseCompactObjectHeaders, "only with compact i-hash");
   // TODO: There may be gaps that we could use, e.g. in the fields of Class,
   // between the fields of Class and the static fields or in or at the end of
   // the static fields block.
   // When implementing any change here, make sure that allocate_instance()
   // and corresponding code in InstanceMirrorKlass.java are in sync.
-  return checked_cast<int>(obj->base_size_given_klass(obj->mark(), this) * BytesPerWord);
+  return checked_cast<int>(obj->base_size_given_klass(m, this) * BytesPerWord);
 }
 
 #if INCLUDE_CDS

--- a/src/hotspot/share/oops/instanceMirrorKlass.hpp
+++ b/src/hotspot/share/oops/instanceMirrorKlass.hpp
@@ -66,7 +66,7 @@ class InstanceMirrorKlass: public InstanceKlass {
 
   // Returns the size of the instance including the extra static fields.
   size_t oop_size(oop obj, markWord mark) const;
-  int hash_offset_in_bytes(oop obj) const;
+  int hash_offset_in_bytes(oop obj, markWord m) const;
 
   // Static field offset is an offset into the Heap, should be converted by
   // based on UseCompressedOop for traversal

--- a/src/hotspot/share/oops/klass.cpp
+++ b/src/hotspot/share/oops/klass.cpp
@@ -1336,8 +1336,8 @@ static int expanded = 0;
 static int not_expanded = 0;
 static NumberSeq seq = NumberSeq();
 
-bool Klass::expand_for_hash(oop obj) const {
+bool Klass::expand_for_hash(oop obj, markWord m) const {
   assert(UseCompactObjectHeaders, "only with compact i-hash");
-  assert((size_t)hash_offset_in_bytes(obj) <= (obj->base_size_given_klass(obj->mark(), this) * HeapWordSize), "hash offset must be eq or lt base size: hash offset: %d, base size: %zu", hash_offset_in_bytes(obj), obj->base_size_given_klass(obj->mark(), this) * HeapWordSize);
-  return obj->base_size_given_klass(obj->mark(), this) * HeapWordSize - hash_offset_in_bytes(obj) < (int)sizeof(uint32_t);
+  assert((size_t)hash_offset_in_bytes(obj) <= (obj->base_size_given_klass(m, this) * HeapWordSize), "hash offset must be eq or lt base size: hash offset: %d, base size: %zu", hash_offset_in_bytes(obj), obj->base_size_given_klass(m, this) * HeapWordSize);
+  return obj->base_size_given_klass(m, this) * HeapWordSize - hash_offset_in_bytes(obj) < (int)sizeof(uint32_t);
 }

--- a/src/hotspot/share/oops/klass.cpp
+++ b/src/hotspot/share/oops/klass.cpp
@@ -1338,6 +1338,9 @@ static NumberSeq seq = NumberSeq();
 
 bool Klass::expand_for_hash(oop obj, markWord m) const {
   assert(UseCompactObjectHeaders, "only with compact i-hash");
-  assert((size_t)hash_offset_in_bytes(obj) <= (obj->base_size_given_klass(m, this) * HeapWordSize), "hash offset must be eq or lt base size: hash offset: %d, base size: %zu", hash_offset_in_bytes(obj), obj->base_size_given_klass(m, this) * HeapWordSize);
-  return obj->base_size_given_klass(m, this) * HeapWordSize - hash_offset_in_bytes(obj) < (int)sizeof(uint32_t);
+  {
+    ResourceMark rm;
+    assert((size_t)hash_offset_in_bytes(obj,m ) <= (obj->base_size_given_klass(m, this) * HeapWordSize), "hash offset must be eq or lt base size: hash offset: %d, base size: %zu, class-name: %s", hash_offset_in_bytes(obj, m), obj->base_size_given_klass(m, this) * HeapWordSize, external_name());
+  }
+  return obj->base_size_given_klass(m, this) * HeapWordSize - hash_offset_in_bytes(obj, m) < (int)sizeof(uint32_t);
 }

--- a/src/hotspot/share/oops/klass.hpp
+++ b/src/hotspot/share/oops/klass.hpp
@@ -791,7 +791,7 @@ public:
   // Returns true if this Klass needs to be addressable via narrow Klass ID.
   inline bool needs_narrow_id() const;
 
-  virtual int hash_offset_in_bytes(oop obj) const = 0;
+  virtual int hash_offset_in_bytes(oop obj, markWord m) const = 0;
   static int kind_offset_in_bytes() { return (int)offset_of(Klass, _kind); }
 
   bool expand_for_hash(oop obj, markWord m) const;

--- a/src/hotspot/share/oops/klass.hpp
+++ b/src/hotspot/share/oops/klass.hpp
@@ -794,7 +794,7 @@ public:
   virtual int hash_offset_in_bytes(oop obj) const = 0;
   static int kind_offset_in_bytes() { return (int)offset_of(Klass, _kind); }
 
-  bool expand_for_hash(oop obj) const;
+  bool expand_for_hash(oop obj, markWord m) const;
 };
 
 #endif // SHARE_OOPS_KLASS_HPP

--- a/src/hotspot/share/oops/oop.cpp
+++ b/src/hotspot/share/oops/oop.cpp
@@ -135,7 +135,7 @@ void oopDesc::initialize_hash_if_necessary(oop obj, Klass* k, markWord m) {
   assert(m.is_hashed_not_expanded(), "must be hashed but not moved");
   assert(!m.is_hashed_expanded(), "must not be moved: " INTPTR_FORMAT, m.value());
   uint32_t hash = static_cast<uint32_t>(ObjectSynchronizer::get_next_hash(nullptr, obj));
-  int offset = k->hash_offset_in_bytes(cast_to_oop(this));
+  int offset = k->hash_offset_in_bytes(cast_to_oop(this), m);
   assert(offset >= 4, "hash offset must not be in header");
 #ifndef PRODUCT
   log_trace(ihash)("Initializing hash for " PTR_FORMAT ", old: " PTR_FORMAT ", hash: %d, offset: %d", p2i(this), p2i(obj), hash, offset);

--- a/src/hotspot/share/oops/oop.inline.hpp
+++ b/src/hotspot/share/oops/oop.inline.hpp
@@ -202,7 +202,7 @@ size_t oopDesc::size_given_mark_and_klass(markWord mrk, const Klass* kls) {
   size_t sz = base_size_given_klass(mrk, kls);
   if (UseCompactObjectHeaders) {
     assert(!mrk.has_displaced_mark_helper(), "must not be displaced");
-    if (mrk.is_expanded() && kls->expand_for_hash(cast_to_oop(this))) {
+    if (mrk.is_expanded() && kls->expand_for_hash(cast_to_oop(this), mrk)) {
       sz = align_object_size(sz + 1);
     }
   }
@@ -213,7 +213,7 @@ size_t oopDesc::copy_size(size_t size, markWord mark) const {
   if (UseCompactObjectHeaders) {
     assert(!mark.has_displaced_mark_helper(), "must not be displaced");
     Klass* klass = mark.klass();
-    if (mark.is_hashed_not_expanded() && klass->expand_for_hash(cast_to_oop(this))) {
+    if (mark.is_hashed_not_expanded() && klass->expand_for_hash(cast_to_oop(this), mark)) {
       size = align_object_size(size + 1);
     }
   }
@@ -225,10 +225,10 @@ size_t oopDesc::copy_size_cds(size_t size, markWord mark) const {
   if (UseCompactObjectHeaders) {
     assert(!mark.has_displaced_mark_helper(), "must not be displaced");
     Klass* klass = mark.klass();
-    if (mark.is_hashed_not_expanded() && klass->expand_for_hash(cast_to_oop(this))) {
+    if (mark.is_hashed_not_expanded() && klass->expand_for_hash(cast_to_oop(this), mark)) {
       size = align_object_size(size + 1);
     }
-    if (mark.is_not_hashed_expanded() && klass->expand_for_hash(cast_to_oop(this))) {
+    if (mark.is_not_hashed_expanded() && klass->expand_for_hash(cast_to_oop(this), mark)) {
       size = align_object_size(size - ObjectAlignmentInBytes / HeapWordSize);
     }
   }

--- a/src/hotspot/share/oops/oop.inline.hpp
+++ b/src/hotspot/share/oops/oop.inline.hpp
@@ -515,7 +515,7 @@ intptr_t oopDesc::identity_hash() {
     markWord mrk = mark();
     if (mrk.is_hashed_expanded()) {
       Klass* klass = mrk.klass();
-      return int_field(klass->hash_offset_in_bytes(cast_to_oop(this)));
+      return int_field(klass->hash_offset_in_bytes(cast_to_oop(this), mrk));
     }
     // Fall-through to slow-case.
   } else {

--- a/src/hotspot/share/runtime/lightweightSynchronizer.cpp
+++ b/src/hotspot/share/runtime/lightweightSynchronizer.cpp
@@ -1232,7 +1232,7 @@ uint32_t LightweightSynchronizer::get_hash(markWord mark, oop obj, Klass* klass)
   //assert(mark.is_neutral() | mark.is_fast_locked(), "only from neutral or fast-locked mark: " INTPTR_FORMAT, mark.value());
   assert(mark.is_hashed(), "only from hashed or copied object");
   if (mark.is_hashed_expanded()) {
-    return obj->int_field(klass->hash_offset_in_bytes(obj));
+    return obj->int_field(klass->hash_offset_in_bytes(obj, mark));
   } else {
     assert(mark.is_hashed_not_expanded(), "must be hashed");
     assert(hashCode == 6 || hashCode == 2, "must have idempotent hashCode");

--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -996,7 +996,7 @@ static intptr_t install_hash_code(Thread* current, oop obj) {
       markWord new_mark;
       if (mark.is_not_hashed_expanded()) {
         new_mark = mark.set_hashed_expanded();
-        int offset = mark.klass()->hash_offset_in_bytes(obj);
+        int offset = mark.klass()->hash_offset_in_bytes(obj, mark);
         obj->int_field_put(offset, (jint) hash);
       } else {
         new_mark = mark.set_hashed_not_expanded();


### PR DESCRIPTION
Multiple GC threads can concurrently update an object's mark-word (Parallel, G1 and Shenandoah). We need to be careful when doing object-size calculations and pass-through the pre-loaded, safe mark-word, instead of re-loading the mark-word from the object. In the latter case, we might read a forwarding pointer and interpret the bits as hash-bits which would lead to wrong size-calculation and crash.

Testing:
- hotspot_gc (+UCOH)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8353849](https://bugs.openjdk.org/browse/JDK-8353849): [Lilliput] Avoid race in compact identity hashcode (**Bug** - P2)


### Reviewers
 * [Zhengyu Gu](https://openjdk.org/census#zgu) (@zhengyu123 - **Reviewer**) ⚠️ Review applies to [12804a55](https://git.openjdk.org/lilliput/pull/196/files/12804a55a634c1a7a2394d4533bc9a29e18d2692)
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput.git pull/196/head:pull/196` \
`$ git checkout pull/196`

Update a local copy of the PR: \
`$ git checkout pull/196` \
`$ git pull https://git.openjdk.org/lilliput.git pull/196/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 196`

View PR using the GUI difftool: \
`$ git pr show -t 196`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput/pull/196.diff">https://git.openjdk.org/lilliput/pull/196.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/lilliput/pull/196#issuecomment-2783237033)
</details>
