### PR TITLE
8368755: [Lilliput] Fix CompressedClassSpaceSize handling

### DIFF
--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -1758,8 +1758,9 @@ char* MetaspaceShared::reserve_address_space_for_archives(FileMapInfo* static_ma
   const size_t ccs_begin_offset = align_up(archive_space_size, class_space_alignment);
   const size_t gap_size = ccs_begin_offset - archive_space_size;
 
-  // Reduce class space size if it would not fit into the Klass encoding range
-  constexpr size_t max_encoding_range_size = 4 * G;
+  // Reduce class space size if it would not fit into the maximum possible Klass encoding range. That
+  // range is defined by the narrowKlass size.
+  const size_t max_encoding_range_size = CompressedKlassPointers::max_klass_range_size();
   guarantee(archive_space_size < max_encoding_range_size - class_space_alignment, "Archive too large");
   if ((archive_space_size + gap_size + class_space_size) > max_encoding_range_size) {
     class_space_size = align_down(max_encoding_range_size - archive_space_size - gap_size, class_space_alignment);

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -3768,6 +3768,9 @@ void Arguments::set_compact_headers_flags() {
   if (UseCompactObjectHeaders && FLAG_IS_DEFAULT(hashCode)) {
     hashCode = 6;
   }
+  if (UseCompactObjectHeaders && FLAG_IS_DEFAULT(CompressedClassSpaceSize)) {
+    FLAG_SET_DEFAULT(CompressedClassSpaceSize, 512 * M);
+  }
 #endif
 }
 

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1401,7 +1401,7 @@ const int ObjectAlignmentInBytes = 8;
           "Maximum size of Metaspaces (in bytes)")                          \
           constraint(MaxMetaspaceSizeConstraintFunc,AfterErgo)              \
                                                                             \
-  product(size_t, CompressedClassSpaceSize, 128*M,                          \
+  product(size_t, CompressedClassSpaceSize, 1*G,                            \
           "Maximum size of class area in Metaspace when compressed "        \
           "class pointers are used")                                        \
           range(1*M, LP64_ONLY(4*G) NOT_LP64(max_uintx))                    \

--- a/test/hotspot/jtreg/gc/arguments/TestUseCompressedOopsErgoTools.java
+++ b/test/hotspot/jtreg/gc/arguments/TestUseCompressedOopsErgoTools.java
@@ -125,7 +125,7 @@ class TestUseCompressedOopsErgoTools {
     checkUseCompressedOops(join(gcflags, "-XX:ObjectAlignmentInBytes=16"), maxHeapForCompressedOops + 1, false);
 
     // use a different CompressedClassSpaceSize
-    String compressedClassSpaceSizeArg = "-XX:CompressedClassSpaceSize=" + 2 * getCompressedClassSpaceSize();
+    String compressedClassSpaceSizeArg = "-XX:CompressedClassSpaceSize=" + getCompressedClassSpaceSize() / 2;
     maxHeapForCompressedOops = getMaxHeapForCompressedOops(join(gcflags, compressedClassSpaceSizeArg));
 
     checkUseCompressedOops(join(gcflags, compressedClassSpaceSizeArg), maxHeapForCompressedOops, true);


### PR DESCRIPTION
We currently set the default CompressedClassSpaceSize to 128M - much lower than the current upstream default of 1G, and still much lower than the possible encoding range with 4-byte-headers of 512M. I think I did this earlier to make some tests pass and to address a problem with CDS which also wants a smallish share of it, but I have in-fact only hidden a bug.

The way it should work is to set the CompressedClassSpaceSize to 512M and let CDS take its share and use the rest for class-space. This is infact implemented by [JDK-8332514](https://bugs.openjdk.org/browse/JDK-8332514) since a while. However, there is a bug there that prevents it from working with 4-byte-headers: it has 4G encoding range hard-coded.

This change fixes:
- It reverts the default CCSS to 1G
- It sets CCSS to 512M when running with COH
- It makes the auto-sizing work by setting the correct encoding range
- It fixes a test that tries to use CCSS*2. I changed it to use CCSS/2, I think this is still in the spirit of the test ('use a different CCSS and see if it still works')

Testing:
- [x] tier1
- [x] tier2
- [x] gc/arguments/TestUseCompressedOopsErgoTools.java (affected by the change)
- [x] runtime/cds/appcds/dynamicArchive/DynamicLotsOfClasses.java (failed before, fixed by this change)
- [x] runtime/cds/appcds/LotsOfJRTClasses.java (failed before, fixed by this change)