### PR TITLE
8372151: Lilliput2: Don't copy mark-word in Object.clone()

### DIFF
--- a/src/hotspot/share/gc/g1/g1FullGCCompactTask.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCCompactTask.cpp
@@ -63,7 +63,7 @@ void G1FullGCCompactTask::copy_object_to_new_location(oop obj) {
   Copy::aligned_conjoint_words(obj_addr, destination, size);
 
   // There is no need to transform stack chunks - marking already did that.
-  cast_to_oop(destination)->init_mark();
+  cast_to_oop(destination)->reinit_mark();
   cast_to_oop(destination)->initialize_hash_if_necessary(obj);
   assert(cast_to_oop(destination)->klass() != nullptr, "should have a class");
 }

--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -2374,7 +2374,7 @@ void MoveAndUpdateClosure::do_addr(HeapWord* addr, size_t words) {
     assert(FullGCForwarding::is_forwarded(cast_to_oop(source())), "inv");
     assert(FullGCForwarding::forwardee(cast_to_oop(source())) == cast_to_oop(destination()), "inv");
     Copy::aligned_conjoint_words(source(), copy_destination(), words);
-    cast_to_oop(copy_destination())->init_mark();
+    cast_to_oop(copy_destination())->reinit_mark();
   }
 
   update_state(words);

--- a/src/hotspot/share/gc/parallel/psParallelCompactNew.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompactNew.cpp
@@ -1006,7 +1006,7 @@ void PSParallelCompactNew::compact() {
           }
 
           Copy::aligned_conjoint_words(current, dst, size);
-          fwd->init_mark();
+          fwd->reinit_mark();
           fwd->initialize_hash_if_necessary(obj);
         } else {
           // The start_array must be updated even if the object is not moving.

--- a/src/hotspot/share/gc/serial/serialFullGC.cpp
+++ b/src/hotspot/share/gc/serial/serialFullGC.cpp
@@ -238,7 +238,7 @@ class Compacter {
       if (!after_first_dead) {
         // This obj will stay in-place and we'll not see it during relocation.
         // Fix the markword.
-        obj->init_mark();
+        obj->reinit_mark();
       } else {
         FullGCForwarding::forward_to(obj, cast_to_oop(new_addr));
       }
@@ -270,7 +270,7 @@ class Compacter {
       prefetch_write_copy(new_addr);
       Copy::aligned_conjoint_words(addr, new_addr, obj_size);
     }
-    new_obj->init_mark();
+    new_obj->reinit_mark();
     if (addr != new_addr) {
       new_obj->initialize_hash_if_necessary(obj);
     }

--- a/src/hotspot/share/gc/shared/c2/barrierSetC2.cpp
+++ b/src/hotspot/share/gc/shared/c2/barrierSetC2.cpp
@@ -714,9 +714,7 @@ int BarrierSetC2::arraycopy_payload_base_offset(bool is_array) {
       // Exclude length to copy by 8 bytes words.
       base_off += sizeof(int);
     } else {
-      if (UseCompactObjectHeaders) {
-        base_off = 0; /* FIXME */
-      } else {
+      if (!UseCompactObjectHeaders) {
         // Include klass to copy by 8 bytes words.
         base_off = instanceOopDesc::klass_offset_in_bytes();
       }
@@ -728,6 +726,39 @@ int BarrierSetC2::arraycopy_payload_base_offset(bool is_array) {
 
 void BarrierSetC2::clone(GraphKit* kit, Node* src_base, Node* dst_base, Node* size, bool is_array) const {
   int base_off = arraycopy_payload_base_offset(is_array);
+  if (UseCompactObjectHeaders && !is_aligned(base_off, BytesPerLong) &&
+      !kit->gvn().type(src_base)->isa_aryptr()) {
+    guarantee(is_aligned(base_off, BytesPerInt), "must be 4-bytes aligned");
+    // The optimized copy routine only copies 8-byte words. For this reason, we must
+    // copy the 4 bytes at offset 4 separately.
+    // Use the correct field-specific alias derived from the typed address, matching
+    // the pattern in PhaseMacroExpand::generate_arraycopy (macroArrayCopy.cpp).
+    // Using AliasIdxRaw would create a mismatch between the typed address and the
+    // raw memory chain, causing an escape analysis assertion failure.
+    //
+    // Skip this when src_base has an array type. With StressReflectiveCode, the
+    // instance path of the clone can be live in the IR even when the type system
+    // knows src_base is an array. The pre-copy is unnecessary on such paths (they
+    // are unreachable at runtime), and creating a LoadNode at the array length
+    // offset would assert (LoadRangeNode required).
+    Node* sptr = kit->basic_plus_adr(src_base, base_off);
+    Node* dptr = kit->basic_plus_adr(dst_base, base_off);
+    const TypePtr* s_adr_type = kit->gvn().type(sptr)->is_ptr();
+    const TypePtr* d_adr_type = kit->gvn().type(dptr)->is_ptr();
+    uint s_alias_idx = Compile::current()->get_alias_index(s_adr_type);
+    uint d_alias_idx = Compile::current()->get_alias_index(d_adr_type);
+    Node* first = kit->gvn().transform(LoadNode::make(kit->gvn(), kit->control(), kit->memory(s_alias_idx),
+                                       sptr, s_adr_type, TypeInt::INT, T_INT,
+                                       MemNode::unordered));
+    Node* st = kit->gvn().transform(StoreNode::make(kit->gvn(), kit->control(), kit->memory(d_alias_idx),
+                                                    dptr, d_adr_type,
+                                                    first, T_INT, MemNode::unordered));
+    kit->set_memory(st, d_alias_idx);
+    kit->record_for_igvn(st);
+    base_off += sizeof(jint);
+    guarantee(is_aligned(base_off, BytesPerLong), "must be 8-bytes aligned");
+  }
+
   Node* payload_size = size;
   Node* offset = kit->MakeConX(base_off);
   payload_size = kit->gvn().transform(new SubXNode(payload_size, offset));

--- a/src/hotspot/share/gc/shared/c2/barrierSetC2.cpp
+++ b/src/hotspot/share/gc/shared/c2/barrierSetC2.cpp
@@ -882,7 +882,10 @@ void BarrierSetC2::clone_in_runtime(PhaseMacroExpand* phase, ArrayCopyNode* ac,
 
   // The native clone we are calling here expects the object size in words.
   // Add header/offset size to payload size to get object size.
-  Node* const base_offset = phase->MakeConX(arraycopy_payload_base_offset(ac->is_clone_array()) >> LogBytesPerLong);
+  // Use the actual offset stored in the ArrayCopyNode (in bytes), not
+  // arraycopy_payload_base_offset(), because clone() may have bumped the
+  // offset past a 4-byte pre-copy for compact object headers.
+  Node* const base_offset = phase->transform_later(new URShiftXNode(ac->in(ArrayCopyNode::SrcPos), phase->intcon(LogBytesPerLong)));
   Node* const full_size = phase->transform_later(new AddXNode(size, base_offset));
   // HeapAccess<>::clone expects size in heap words.
   // For 64-bits platforms, this is a no-operation.

--- a/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
@@ -884,7 +884,7 @@ public:
       oop new_obj = cast_to_oop(compact_to);
 
       ContinuationGCSupport::relativize_stack_chunk(new_obj);
-      new_obj->init_mark();
+      new_obj->reinit_mark();
       new_obj->initialize_hash_if_necessary(p);
     }
   }
@@ -1018,7 +1018,7 @@ void ShenandoahFullGC::compact_humongous_objects() {
       ContinuationGCSupport::relativize_stack_chunk(cast_to_oop<HeapWord*>(r->bottom()));
 
       oop new_obj = cast_to_oop(heap->get_region(new_start)->bottom());
-      new_obj->init_mark();
+      new_obj->reinit_mark();
 
       {
         ShenandoahAffiliation original_affiliation = r->affiliation();

--- a/src/hotspot/share/oops/accessBackend.inline.hpp
+++ b/src/hotspot/share/oops/accessBackend.inline.hpp
@@ -327,7 +327,7 @@ inline void RawAccessBarrier<decorators>::clone(oop src, oop dst, size_t size) {
                                             reinterpret_cast<jlong*>((oopDesc*)dst),
                                             align_object_size(size) / HeapWordsPerLong);
   // Clear the header
-  dst->init_mark();
+  dst->set_mark(dst->prototype_mark());
 }
 
 #endif // SHARE_OOPS_ACCESSBACKEND_INLINE_HPP

--- a/src/hotspot/share/oops/accessBackend.inline.hpp
+++ b/src/hotspot/share/oops/accessBackend.inline.hpp
@@ -327,7 +327,7 @@ inline void RawAccessBarrier<decorators>::clone(oop src, oop dst, size_t size) {
                                             reinterpret_cast<jlong*>((oopDesc*)dst),
                                             align_object_size(size) / HeapWordsPerLong);
   // Clear the header
-  dst->set_mark(dst->prototype_mark());
+  dst->init_mark();
 }
 
 #endif // SHARE_OOPS_ACCESSBACKEND_INLINE_HPP

--- a/src/hotspot/share/oops/oop.hpp
+++ b/src/hotspot/share/oops/oop.hpp
@@ -82,9 +82,21 @@ class oopDesc {
   // Returns the prototype mark that should be used for this object.
   inline markWord prototype_mark() const;
 
-  // Used only to re-initialize the mark word (e.g., of promoted
-  // objects during a GC) -- requires a valid klass pointer
+  // Initializes the mark word of an object (typically an object copy)
+  // to the prototype mark -- requires a valid klass pointer.
+  // This completely resets the mark-word, except for the
+  // Klass bits.
+  // This is typically used by clone() routines, where the copy of
+  // the object is a new object identity.
   inline void init_mark();
+
+  // Re-initializes the mark word of an object (typically an object copy)
+  // to the prototype mark -- requires a valid klass pointer.
+  // This completely resets the mark-word, except for the
+  // Klass bits and the hashcode, which are preserved.
+  // This is typically used by GCs when they copy object to new locations,
+  // where the copy of the object preserves the previous identity.
+  inline void reinit_mark();
 
   inline Klass* klass() const;
   inline Klass* klass_or_null() const;

--- a/src/hotspot/share/oops/oop.inline.hpp
+++ b/src/hotspot/share/oops/oop.inline.hpp
@@ -111,6 +111,10 @@ markWord oopDesc::prototype_mark() const {
 }
 
 void oopDesc::init_mark() {
+  set_mark(prototype_mark());
+}
+
+void oopDesc::reinit_mark() {
   if (UseCompactObjectHeaders) {
     markWord m = prototype_mark().copy_hashctrl_from(mark());
     assert(m.is_neutral(), "must be neutral");

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -671,7 +671,12 @@ JVM_ENTRY(jobject, JVM_Clone(JNIEnv* env, jobject handle))
   }
 
   // Make shallow object copy
-  const size_t size = obj->size();
+  // With compact object headers, the original might have been expanded by GC
+  // for the identity hash. The clone must be allocated at the base size, since
+  // it will get a fresh (not-hashed, not-expanded) mark word.
+  const size_t size = UseCompactObjectHeaders
+    ? klass->oop_size(obj(), obj->mark().set_not_hashed_not_expanded())
+    : obj->size();
   oop new_obj_oop = nullptr;
   if (obj->is_array()) {
     const int length = ((arrayOop)obj())->length();

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -675,7 +675,7 @@ JVM_ENTRY(jobject, JVM_Clone(JNIEnv* env, jobject handle))
   // for the identity hash. The clone must be allocated at the base size, since
   // it will get a fresh (not-hashed, not-expanded) mark word.
   const size_t size = UseCompactObjectHeaders
-    ? klass->oop_size(obj(), obj->mark().set_not_hashed_not_expanded())
+    ? obj->base_size_given_klass(obj->mark(), klass)
     : obj->size();
   oop new_obj_oop = nullptr;
   if (obj->is_array()) {

--- a/test/hotspot/jtreg/gc/stress/ihash/TestStressIHash.java
+++ b/test/hotspot/jtreg/gc/stress/ihash/TestStressIHash.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2026, Datadog, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package gc.stress.ihash;
+
+/*
+ * @test id=Serial
+ * @bug 8372151
+ * @summary Stress test: cloning identity-hashed objects must not copy mark-word hash-control bits
+ * @requires vm.gc.Serial
+ * @key stress
+ * @run main/othervm/timeout=300
+ *      -XX:+UseCompactObjectHeaders -XX:+UseSerialGC
+ *      -XX:+UnlockDiagnosticVMOptions -XX:+VerifyDuringGC
+ *      -Xmx256m
+ *      gc.stress.ihash.TestStressIHash
+ */
+
+/*
+ * @test id=Parallel
+ * @bug 8372151
+ * @summary Stress test: cloning identity-hashed objects must not copy mark-word hash-control bits
+ * @requires vm.gc.Parallel
+ * @key stress
+ * @run main/othervm/timeout=300
+ *      -XX:+UseCompactObjectHeaders -XX:+UseParallelGC
+ *      -XX:+UnlockDiagnosticVMOptions -XX:+VerifyDuringGC
+ *      -Xmx256m
+ *      gc.stress.ihash.TestStressIHash
+ */
+
+/*
+ * @test id=G1
+ * @bug 8372151
+ * @summary Stress test: cloning identity-hashed objects must not copy mark-word hash-control bits
+ * @requires vm.gc.G1
+ * @key stress
+ * @run main/othervm/timeout=300
+ *      -XX:+UseCompactObjectHeaders -XX:+UseG1GC
+ *      -XX:+UnlockDiagnosticVMOptions -XX:+VerifyDuringGC
+ *      -Xmx256m
+ *      gc.stress.ihash.TestStressIHash
+ */
+
+/*
+ * @test id=Shenandoah
+ * @bug 8372151
+ * @summary Stress test: cloning identity-hashed objects must not copy mark-word hash-control bits
+ * @requires vm.gc.Shenandoah
+ * @key stress
+ * @run main/othervm/timeout=300
+ *      -XX:+UseCompactObjectHeaders -XX:+UseShenandoahGC
+ *      -XX:+UnlockDiagnosticVMOptions -XX:+VerifyDuringGC
+ *      -Xmx256m
+ *      gc.stress.ihash.TestStressIHash
+ */
+
+/*
+ * @test id=Z
+ * @bug 8372151
+ * @summary Stress test: cloning identity-hashed objects must not copy mark-word hash-control bits
+ * @requires vm.gc.Z
+ * @key stress
+ * @run main/othervm/timeout=300
+ *      -XX:+UseCompactObjectHeaders -XX:+UseZGC
+ *      -XX:+UnlockDiagnosticVMOptions -XX:+VerifyDuringGC
+ *      -Xmx256m
+ *      gc.stress.ihash.TestStressIHash
+ */
+
+import java.util.Random;
+
+/**
+ * Regression test for JDK-8372151.
+ *
+ * With compact object headers (4-byte mark-word), the identity hash state is
+ * tracked via two "hashctrl" bits in the mark-word. When an object is hashed
+ * and later relocated by GC, the GC may "expand" it by one HeapWord to store
+ * the hash value, setting the hashctrl bits to "hashed-expanded" (11).
+ *
+ * The bug: Object.clone() copied the mark-word from source to destination,
+ * including the hashctrl bits. A clone of an expanded object would therefore
+ * appear expanded (hashctrl=11) without actually having the extra HeapWord
+ * allocated. This causes two problems:
+ *  1. The clone's identity hash is the same as the source's (semantic bug).
+ *  2. JVM_Clone allocates the clone at expanded size but then resets the
+ *     mark-word to prototype (not-hashed, not-expanded), creating a size
+ *     mismatch that crashes GCs using linear heap iteration (e.g., Serial).
+ *
+ * This test creates objects whose layout guarantees hash-expansion (a single
+ * int field: header(4) + int(4) = 8 bytes, no room for the 4-byte hash),
+ * hashes them, forces a GC to expand them, then clones them. It verifies
+ * both that clones get unique identity hashes (semantic correctness) and that
+ * the heap remains intact (-XX:+VerifyDuringGC detects size mismatches).
+ */
+public class TestStressIHash {
+
+    // With compact headers: header(4) + int(4) = 8 bytes (1 HeapWord).
+    // The identity hash needs 4 bytes but there is no gap in the layout,
+    // so GC must expand the object by one word when preserving the hash.
+    static class Payload implements Cloneable {
+        int field;
+
+        Payload(int v) { field = v; }
+
+        @Override
+        public Payload clone() {
+            try {
+                return (Payload) super.clone();
+            } catch (CloneNotSupportedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    static final int BATCH_SIZE = 100_000;
+    static final int MAX_SURVIVORS = 1_000_000;
+
+    public static void main(String[] args) {
+        Random rng = new Random(12345);
+        Object[] survivors = new Object[MAX_SURVIVORS];
+        int survivorCount = 0;
+        int totalCreated = 0;
+        int sharedHashes = 0;
+        int totalCloned = 0;
+
+        while (survivorCount < MAX_SURVIVORS) {
+            // Phase 1: Create a batch of objects and hash every one of them.
+            Payload[] batch = new Payload[BATCH_SIZE];
+            int[] srcHashes = new int[BATCH_SIZE];
+            for (int i = 0; i < BATCH_SIZE; i++) {
+                batch[i] = new Payload(totalCreated++);
+                srcHashes[i] = System.identityHashCode(batch[i]);
+            }
+
+            // Phase 2: Force a GC cycle. Surviving hashed objects that need
+            // expansion get relocated with an extra HeapWord and their
+            // hashctrl bits set to "hashed-expanded" (11).
+            System.gc();
+
+            // Phase 3: Clone the (now expanded) batch objects and verify that
+            // each clone gets a unique identity hash. With the bug, clones
+            // inherit the source's hash because the hashctrl bits and stored
+            // hash value are copied from the source mark-word.
+            for (int i = 0; i < BATCH_SIZE; i++) {
+                Payload clone = batch[i].clone();
+                totalCloned++;
+                int cloneHash = System.identityHashCode(clone);
+                if (cloneHash == srcHashes[i]) {
+                    sharedHashes++;
+                }
+                if (rng.nextInt(10) == 0 && survivorCount < MAX_SURVIVORS) {
+                    survivors[survivorCount++] = clone;
+                }
+            }
+
+            // Let the originals die.
+            batch = null;
+        }
+
+        // Final GC: with VerifyDuringGC, this walks the heap and will detect
+        // corrupt clones if the allocation-size vs mark-word bug is present.
+        System.gc();
+
+        // Verify that clones got independent identity hashes. Random hash
+        // collisions are possible but extremely rare (~1 in 2^32 per pair).
+        // The threshold of 10 accounts for any statistical noise.
+        if (sharedHashes > 10) {
+            throw new RuntimeException("FAIL: " + sharedHashes + " / " + totalCloned
+                + " clones share identity hash with source object");
+        }
+    }
+}


### PR DESCRIPTION
We've observed heap corruption with Lilliput2 (see bug report). The root cause is that when we do an Object.clone(), we also copy the mark-word to the new object, which is wrong: we might copy an active lock-state, which is wrong, and we might also copy the hash bits, which results in wrong size calculations in the new object.

The fast C2 copy routine only copies 8-byte-words, and I did not want to mess with that. I'm emitting a separate load&store to copy the first 4 bytes, and only use the 8-bytes-copy-routine on the remaining 8-byte words, and avoid copying the mark-word altogether.

For the runtime case, we copy the full object, and re-initialize the mark word with its prototype header afterwards. (init_mark() preserves the hash-bits, and is used by full GCs for initializing the mark-words of object copies.)

Testing:
 - [x] The problem could reliably be reproduced by running: `java -XX:+UseCompactObjectHeaders -XX:+VerifyDuringGC -Xmx9g -Xms9g -jar renaissance-gpl-0.16.1.jar dotty` and does not fail anymore with the fix
 - [x] tier1 +UCOH
 - [x] tier1 -UCOH

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8372151](https://bugs.openjdk.org/browse/JDK-8372151): Lilliput2: Don't copy mark-word in Object.clone() (**Bug** - P4)


### Reviewers
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - **Reviewer**)
 * [Oli Gillespie](https://openjdk.org/census#ogillespie) (@olivergillespie - Author) ⚠️ Review applies to [dab4136b](https://git.openjdk.org/lilliput/pull/207/files/dab4136b3f2622ba2aba5f20ea1fbaf127f31d1d)
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput.git pull/207/head:pull/207` \
`$ git checkout pull/207`

Update a local copy of the PR: \
`$ git checkout pull/207` \
`$ git pull https://git.openjdk.org/lilliput.git pull/207/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 207`

View PR using the GUI difftool: \
`$ git pr show -t 207`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput/pull/207.diff">https://git.openjdk.org/lilliput/pull/207.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/lilliput/pull/207#issuecomment-3984773162)
</details>
