### PR TITLE
8373698: [Lilliput] Fix oop-checking with ZGC/CDS and compact headers

### DIFF
--- a/src/hotspot/share/cds/aotStreamedHeapLoader.cpp
+++ b/src/hotspot/share/cds/aotStreamedHeapLoader.cpp
@@ -156,6 +156,24 @@ static int archive_array_length(oopDesc* archive_array) {
   return *(int*)(address(archive_array) + arrayOopDesc::length_offset_in_bytes());
 }
 
+// archive_object lives in CDS mapped memory, not in the GC heap.
+// Calling expand_for_hash() converts the raw oopDesc* to an oop, which
+// triggers oop verification.  ZGC's verifier rejects non-heap addresses,
+// so we must suspend the check for that call.
+#ifdef CHECK_UNHANDLED_OOPS
+class SuspendCheckOopFunction {
+  CheckOopFunctionPointer _saved;
+public:
+  SuspendCheckOopFunction()  : _saved(check_oop_function) { check_oop_function = nullptr; }
+  ~SuspendCheckOopFunction()                               { check_oop_function = _saved; }
+};
+#endif
+
+static bool archive_expand_for_hash(Klass* klass, oopDesc* archive_object) {
+  DEBUG_ONLY(SuspendCheckOopFunction suspend;)
+  return klass->expand_for_hash(archive_object, archive_object->mark());
+}
+
 static size_t archive_object_size(oopDesc* archive_object) {
   Klass* klass = archive_object->klass();
   int lh = klass->layout_helper();
@@ -166,7 +184,7 @@ static size_t archive_object_size(oopDesc* archive_object) {
       return ((size_t*)(archive_object))[-1];
     } else {
       size_t size = (size_t)Klass::layout_helper_size_in_bytes(lh) >> LogHeapWordSize;
-      if (UseCompactObjectHeaders && archive_object->mark().is_expanded() && klass->expand_for_hash(archive_object, archive_object->mark())) {
+      if (UseCompactObjectHeaders && archive_object->mark().is_expanded() && archive_expand_for_hash(klass, archive_object)) {
         size = align_object_size(size + 1);
       }
       return size;
@@ -179,7 +197,7 @@ static size_t archive_object_size(oopDesc* archive_object) {
     size_in_bytes += (size_t)Klass::layout_helper_header_size(lh);
 
     size_t size = align_up(size_in_bytes, (size_t)MinObjAlignmentInBytes) / HeapWordSize;
-    if (UseCompactObjectHeaders && archive_object->mark().is_expanded() && klass->expand_for_hash(archive_object, archive_object->mark())) {
+    if (UseCompactObjectHeaders && archive_object->mark().is_expanded() && archive_expand_for_hash(klass, archive_object)) {
       size = align_object_size(size + 1);
     }
     return size;

--- a/src/hotspot/share/cds/aotStreamedHeapLoader.cpp
+++ b/src/hotspot/share/cds/aotStreamedHeapLoader.cpp
@@ -161,7 +161,7 @@ static int archive_array_length(oopDesc* archive_array) {
 // triggers oop verification.  ZGC's verifier rejects non-heap addresses,
 // so we must suspend the check for that call.
 #ifdef CHECK_UNHANDLED_OOPS
-class SuspendCheckOopFunction {
+class SuspendCheckOopFunction : public StackObj {
   CheckOopFunctionPointer _saved;
 public:
   SuspendCheckOopFunction()  : _saved(check_oop_function) { check_oop_function = nullptr; }
@@ -170,7 +170,7 @@ public:
 #endif
 
 static bool archive_expand_for_hash(Klass* klass, oopDesc* archive_object) {
-  DEBUG_ONLY(SuspendCheckOopFunction suspend;)
+  CHECK_UNHANDLED_OOPS_ONLY(SuspendCheckOopFunction suspend;)
   return klass->expand_for_hash(archive_object, archive_object->mark());
 }
 


### PR DESCRIPTION
UnsafeIntrinsicsTest.java (and some others) are failing with +COH and ZGC. The reason is:

  1. archive_object_size() (aotStreamedHeapLoader.cpp:159) operates on oopDesc* pointers to archived objects in CDS shared memory (not the GC
  heap)
  2. The COH code at lines 169 and 182 calls klass->expand_for_hash(archive_object, ...) which takes an oop parameter
  3. The implicit oopDesc* → oop conversion calls on_construction() which validates the address via ZGC's check_is_valid_zaddress()
  4. ZGC requires addresses to have the heap base bit set (zAddress.inline.hpp:450) and be within heap range (:456), but CDS objects are
  outside ZGC's virtual address space

The fix is to temporarily disable oop-checking around the affected code, because those are not real oops in the Java heap.

The alternative would have been to change all the i-hash-functions to accept oopDesc* instead of oop, but that would disable the oop-check wholesale, even for valid heap objects, which is not what we want.

Testing:
 - [x] UnsafeIntrinsicsTest.java
 - [x] tier1 +UCOH
 - [x] tier1 -UCOH

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8373698](https://bugs.openjdk.org/browse/JDK-8373698): [Lilliput] Fix oop-checking with ZGC/CDS and compact headers (**Bug** - P4)


### Reviewers
 * [Oli Gillespie](https://openjdk.org/census#ogillespie) (@olivergillespie - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput.git pull/212/head:pull/212` \
`$ git checkout pull/212`

Update a local copy of the PR: \
`$ git checkout pull/212` \
`$ git pull https://git.openjdk.org/lilliput.git pull/212/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 212`

View PR using the GUI difftool: \
`$ git pr show -t 212`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput/pull/212.diff">https://git.openjdk.org/lilliput/pull/212.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/lilliput/pull/212#issuecomment-4176100469)
</details>
