### PR TITLE
8381999: [Lilliput2] Increase region size for Parallel Full GC

### DIFF
--- a/src/hotspot/share/gc/parallel/psParallelCompactNew.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompactNew.cpp
@@ -375,7 +375,7 @@ void PSParallelCompactNew::post_compact()
 
 void PSParallelCompactNew::setup_regions_parallel() {
   static const size_t REGION_SIZE_WORDS = compute_region_size();
-  log_debug(gc, compaction)("RegionSizeBytes: %zu bytes (%.2f MB)", REGION_SIZE_WORDS * HeapWordSize, (double)(REGION_SIZE_WORDS * HeapWordSize) / (1024.0 * 1024.0));
+  log_debug(gc, compaction)("Region size: %zu bytes (%.2f MB)", REGION_SIZE_WORDS * HeapWordSize, (double)(REGION_SIZE_WORDS * HeapWordSize) / (1024.0 * 1024.0));
 
   size_t num_regions = 0;
   for (uint i = old_space_id; i < last_space_id; ++i) {
@@ -423,7 +423,7 @@ void PSParallelCompactNew::setup_regions_parallel() {
 }
 
 size_t PSParallelCompactNew::compute_region_size() {
-  // Default 0.5MB Region Size
+  // Minimum 0.5MB Region Size
   const size_t FLOOR_REGION_SIZE_WORDS = (SpaceAlignment / HeapWordSize);
   size_t total_heap_words = 0;
   for (uint i = old_space_id; i < last_space_id; ++i) {
@@ -431,8 +431,7 @@ size_t PSParallelCompactNew::compute_region_size() {
   }
 
   // Per-worker region count for dynamic region sizing
-  const uint MaxWastePercent = 5;  // 5% waste threshold
-  const uint RegionsPerWorker = 100 / MaxWastePercent;
+  const uint RegionsPerWorker = 20;  // Based on 5% boundary waste threshold
   const uint max_workers = ParallelScavengeHeap::heap()->workers().max_workers();
   const size_t total_regions_count = (size_t)max_workers * RegionsPerWorker;
   const size_t DYNAMIC_REGION_SIZE_WORDS = round_up_power_of_2(total_heap_words / total_regions_count);

--- a/src/hotspot/share/gc/parallel/psParallelCompactNew.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompactNew.cpp
@@ -316,7 +316,7 @@ void PSParallelCompactNew::post_compact()
         }
       }
     }
-    log_develop_debug(gc, compaction)("total live: %zu, total waste: %zu, ratio: %f", total_live, total_waste, ((float)total_waste)/((float)(total_live + total_waste)));
+    log_debug(gc, compaction)("total live: %zu, total waste: %zu, ratio: %f", total_live, total_waste, ((float)total_waste)/((float)(total_live + total_waste)));
   }
   {
     FREE_C_HEAP_ARRAY(PCRegionData*, _per_worker_region_data);
@@ -374,7 +374,10 @@ void PSParallelCompactNew::post_compact()
 }
 
 void PSParallelCompactNew::setup_regions_parallel() {
-  static const size_t REGION_SIZE_WORDS = (SpaceAlignment / HeapWordSize);
+
+  static const size_t REGION_SIZE_WORDS = compute_region_size();
+  log_debug(gc, compaction)("RegionSizeBytes: %zu bytes (%.2f MB)", REGION_SIZE_WORDS * HeapWordSize, (double)(REGION_SIZE_WORDS * HeapWordSize) / (1024.0 * 1024.0));
+
   size_t num_regions = 0;
   for (uint i = old_space_id; i < last_space_id; ++i) {
     MutableSpace* const space = _space_info[i].space();
@@ -418,6 +421,27 @@ void PSParallelCompactNew::setup_regions_parallel() {
   }
   _num_regions = region_idx;
   log_info(gc)("Number of regions: %zu", _num_regions);
+}
+
+size_t PSParallelCompactNew::compute_region_size() {
+  
+  // Default 0.5MB Region Size
+  const size_t FLOOR_REGION_SIZE_WORDS = (SpaceAlignment / HeapWordSize);
+  
+  size_t total_heap_words = 0;
+  for (uint i = old_space_id; i < last_space_id; ++i) {
+    total_heap_words += _space_info[i].space()->capacity_in_words();
+  }
+
+  // Per-worker region count for dynamic region sizing
+  const uint MaxWastePercent = 5;  // 5% waste threshold
+  const uint RegionsPerWorker = 100 / MaxWastePercent;
+  const uint max_workers = ParallelScavengeHeap::heap()->workers().max_workers();
+  const size_t total_regions_count = (size_t)max_workers * RegionsPerWorker;
+  const size_t DYNAMIC_REGION_SIZE_WORDS = round_up_power_of_2(total_heap_words / total_regions_count);
+  
+  return MAX2(DYNAMIC_REGION_SIZE_WORDS, FLOOR_REGION_SIZE_WORDS);
+
 }
 
 void PSParallelCompactNew::setup_regions_serial() {

--- a/src/hotspot/share/gc/parallel/psParallelCompactNew.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompactNew.cpp
@@ -423,18 +423,18 @@ void PSParallelCompactNew::setup_regions_parallel() {
 
 size_t PSParallelCompactNew::calculate_region_size() {
   // Minimum 0.5MB region size
-  const size_t floor_region_size_words = (SpaceAlignment / HeapWordSize);
+  static const size_t FLOOR_REGION_SIZE_WORDS = (SpaceAlignment / HeapWordSize);
   size_t total_heap_words = 0;
   for (uint i = old_space_id; i < last_space_id; ++i) {
     total_heap_words += _space_info[i].space()->capacity_in_words();
   }
 
   // Per-worker region count for dynamic region sizing
-  const uint regions_per_worker = 20;  // Based on 5% boundary waste threshold
+  static const uint REGIONS_PER_WORKER = 20;  // Based on 5% boundary waste threshold
   const uint max_workers = ParallelScavengeHeap::heap()->workers().max_workers();
-  const size_t total_regions_count = (size_t)max_workers * regions_per_worker;
+  const size_t total_regions_count = (size_t)max_workers * REGIONS_PER_WORKER;
   const size_t dynamic_region_size_words = total_heap_words / total_regions_count;
-  return round_up_power_of_2(MAX2(dynamic_region_size_words, floor_region_size_words));
+  return round_up_power_of_2(MAX2(dynamic_region_size_words, FLOOR_REGION_SIZE_WORDS));
 }
 
 void PSParallelCompactNew::setup_regions_serial() {

--- a/src/hotspot/share/gc/parallel/psParallelCompactNew.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompactNew.cpp
@@ -374,7 +374,7 @@ void PSParallelCompactNew::post_compact()
 }
 
 void PSParallelCompactNew::setup_regions_parallel() {
-  static const size_t REGION_SIZE_WORDS = compute_region_size();
+  const size_t REGION_SIZE_WORDS = compute_region_size();
   log_debug(gc, compaction)("Region size: %zu bytes (%.2f MB)", REGION_SIZE_WORDS * HeapWordSize, (double)(REGION_SIZE_WORDS * HeapWordSize) / (1024.0 * 1024.0));
 
   size_t num_regions = 0;

--- a/src/hotspot/share/gc/parallel/psParallelCompactNew.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompactNew.cpp
@@ -374,13 +374,13 @@ void PSParallelCompactNew::post_compact()
 }
 
 void PSParallelCompactNew::setup_regions_parallel() {
-  const size_t REGION_SIZE_WORDS = compute_region_size();
+  const size_t region_size_words = calculate_region_size();
 
   size_t num_regions = 0;
   for (uint i = old_space_id; i < last_space_id; ++i) {
     MutableSpace* const space = _space_info[i].space();
     size_t const space_size_words = space->capacity_in_words();
-    num_regions += align_up(space_size_words, REGION_SIZE_WORDS) / REGION_SIZE_WORDS;
+    num_regions += align_up(space_size_words, region_size_words) / region_size_words;
   }
   _region_data_array = NEW_C_HEAP_ARRAY(PCRegionData, num_regions, mtGC);
 
@@ -391,7 +391,7 @@ void PSParallelCompactNew::setup_regions_parallel() {
     HeapWord* sp_end = space->end();
     HeapWord* sp_top = space->top();
     while (addr < sp_end) {
-      HeapWord* end = MIN2(align_up(addr + REGION_SIZE_WORDS, REGION_SIZE_WORDS), space->end());
+      HeapWord* end = MIN2(align_up(addr + region_size_words, region_size_words), space->end());
       if (addr < sp_top) {
         HeapWord* prev_obj_start = _mark_bitmap.find_obj_beg_reverse(addr, end);
         if (prev_obj_start < end) {
@@ -418,10 +418,10 @@ void PSParallelCompactNew::setup_regions_parallel() {
     }
   }
   _num_regions = region_idx;
-  log_info(gc)("Number of regions: %zu, region size: " EXACTFMT, _num_regions, EXACTFMTARGS(REGION_SIZE_WORDS * HeapWordSize));
+  log_info(gc)("Number of regions: %zu, region size: " EXACTFMT, _num_regions, EXACTFMTARGS(region_size_words * HeapWordSize));
 }
 
-size_t PSParallelCompactNew::compute_region_size() {
+size_t PSParallelCompactNew::calculate_region_size() {
   // Minimum 0.5MB region size
   const size_t floor_region_size_words = (SpaceAlignment / HeapWordSize);
   size_t total_heap_words = 0;

--- a/src/hotspot/share/gc/parallel/psParallelCompactNew.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompactNew.cpp
@@ -425,7 +425,6 @@ void PSParallelCompactNew::setup_regions_parallel() {
 size_t PSParallelCompactNew::compute_region_size() {
   // Default 0.5MB Region Size
   const size_t FLOOR_REGION_SIZE_WORDS = (SpaceAlignment / HeapWordSize);
-  
   size_t total_heap_words = 0;
   for (uint i = old_space_id; i < last_space_id; ++i) {
     total_heap_words += _space_info[i].space()->capacity_in_words();
@@ -437,7 +436,6 @@ size_t PSParallelCompactNew::compute_region_size() {
   const uint max_workers = ParallelScavengeHeap::heap()->workers().max_workers();
   const size_t total_regions_count = (size_t)max_workers * RegionsPerWorker;
   const size_t DYNAMIC_REGION_SIZE_WORDS = round_up_power_of_2(total_heap_words / total_regions_count);
-  
   return MAX2(DYNAMIC_REGION_SIZE_WORDS, FLOOR_REGION_SIZE_WORDS);
 }
 

--- a/src/hotspot/share/gc/parallel/psParallelCompactNew.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompactNew.cpp
@@ -375,7 +375,6 @@ void PSParallelCompactNew::post_compact()
 
 void PSParallelCompactNew::setup_regions_parallel() {
   const size_t REGION_SIZE_WORDS = compute_region_size();
-  log_debug(gc, compaction)("Region size: %zu bytes (%.2f MB)", REGION_SIZE_WORDS * HeapWordSize, (double)(REGION_SIZE_WORDS * HeapWordSize) / (1024.0 * 1024.0));
 
   size_t num_regions = 0;
   for (uint i = old_space_id; i < last_space_id; ++i) {
@@ -419,23 +418,23 @@ void PSParallelCompactNew::setup_regions_parallel() {
     }
   }
   _num_regions = region_idx;
-  log_info(gc)("Number of regions: %zu", _num_regions);
+  log_info(gc)("Number of regions: %zu, region size: " EXACTFMT, _num_regions, EXACTFMTARGS(REGION_SIZE_WORDS * HeapWordSize));
 }
 
 size_t PSParallelCompactNew::compute_region_size() {
-  // Minimum 0.5MB Region Size
-  const size_t FLOOR_REGION_SIZE_WORDS = (SpaceAlignment / HeapWordSize);
+  // Minimum 0.5MB region size
+  const size_t floor_region_size_words = (SpaceAlignment / HeapWordSize);
   size_t total_heap_words = 0;
   for (uint i = old_space_id; i < last_space_id; ++i) {
     total_heap_words += _space_info[i].space()->capacity_in_words();
   }
 
   // Per-worker region count for dynamic region sizing
-  const uint RegionsPerWorker = 20;  // Based on 5% boundary waste threshold
+  const uint regions_per_worker = 20;  // Based on 5% boundary waste threshold
   const uint max_workers = ParallelScavengeHeap::heap()->workers().max_workers();
-  const size_t total_regions_count = (size_t)max_workers * RegionsPerWorker;
-  const size_t DYNAMIC_REGION_SIZE_WORDS = total_heap_words / total_regions_count;
-  return round_up_power_of_2(MAX2(DYNAMIC_REGION_SIZE_WORDS, FLOOR_REGION_SIZE_WORDS));
+  const size_t total_regions_count = (size_t)max_workers * regions_per_worker;
+  const size_t dynamic_region_size_words = total_heap_words / total_regions_count;
+  return round_up_power_of_2(MAX2(dynamic_region_size_words, floor_region_size_words));
 }
 
 void PSParallelCompactNew::setup_regions_serial() {

--- a/src/hotspot/share/gc/parallel/psParallelCompactNew.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompactNew.cpp
@@ -374,7 +374,6 @@ void PSParallelCompactNew::post_compact()
 }
 
 void PSParallelCompactNew::setup_regions_parallel() {
-
   static const size_t REGION_SIZE_WORDS = compute_region_size();
   log_debug(gc, compaction)("RegionSizeBytes: %zu bytes (%.2f MB)", REGION_SIZE_WORDS * HeapWordSize, (double)(REGION_SIZE_WORDS * HeapWordSize) / (1024.0 * 1024.0));
 
@@ -424,7 +423,6 @@ void PSParallelCompactNew::setup_regions_parallel() {
 }
 
 size_t PSParallelCompactNew::compute_region_size() {
-  
   // Default 0.5MB Region Size
   const size_t FLOOR_REGION_SIZE_WORDS = (SpaceAlignment / HeapWordSize);
   
@@ -441,7 +439,6 @@ size_t PSParallelCompactNew::compute_region_size() {
   const size_t DYNAMIC_REGION_SIZE_WORDS = round_up_power_of_2(total_heap_words / total_regions_count);
   
   return MAX2(DYNAMIC_REGION_SIZE_WORDS, FLOOR_REGION_SIZE_WORDS);
-
 }
 
 void PSParallelCompactNew::setup_regions_serial() {

--- a/src/hotspot/share/gc/parallel/psParallelCompactNew.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompactNew.cpp
@@ -434,8 +434,8 @@ size_t PSParallelCompactNew::compute_region_size() {
   const uint RegionsPerWorker = 20;  // Based on 5% boundary waste threshold
   const uint max_workers = ParallelScavengeHeap::heap()->workers().max_workers();
   const size_t total_regions_count = (size_t)max_workers * RegionsPerWorker;
-  const size_t DYNAMIC_REGION_SIZE_WORDS = round_up_power_of_2(total_heap_words / total_regions_count);
-  return MAX2(DYNAMIC_REGION_SIZE_WORDS, FLOOR_REGION_SIZE_WORDS);
+  const size_t DYNAMIC_REGION_SIZE_WORDS = total_heap_words / total_regions_count;
+  return round_up_power_of_2(MAX2(DYNAMIC_REGION_SIZE_WORDS, FLOOR_REGION_SIZE_WORDS));
 }
 
 void PSParallelCompactNew::setup_regions_serial() {

--- a/src/hotspot/share/gc/parallel/psParallelCompactNew.hpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompactNew.hpp
@@ -283,7 +283,7 @@ private:
 
   static void summary_phase();
   static void setup_regions_parallel();
-  static size_t compute_region_size();
+  static size_t calculate_region_size();
   static void setup_regions_serial();
 
   static void adjust_pointers();

--- a/src/hotspot/share/gc/parallel/psParallelCompactNew.hpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompactNew.hpp
@@ -283,6 +283,7 @@ private:
 
   static void summary_phase();
   static void setup_regions_parallel();
+  static size_t compute_region_size();
   static void setup_regions_serial();
 
   static void adjust_pointers();


### PR DESCRIPTION
Linked issue :  https://bugs.openjdk.org/browse/JDK-8381999

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

## Problem

Parallel Full GC (`psParallelCompactNew`) uses a fixed **0.5MB** region size. Normal (non-maximum) compaction can't move humongous objects ( objects bigger than region size) past other humongous objects. This can lead to a state where the GC becomes unproductive and immediately triggers maximum compaction. An example of this can be found in [JDK-8375467: [Lilliput] Unproductive Full GC with Parallel](https://bugs.openjdk.org/browse/JDK-8375467)

## Change

Replace the fixed region size with a dynamic calculation:
```
region_size = max_waste_percent × heap_size / num_workers
```

Each worker can leave at most one region of waste at the boundary between worker sets (the last region it processes can be almost completely empty). With _**N** workers_ and _**R** regions per worker_, total boundary waste is at most N regions out of N * R total, i.e. 1/R of the heap.

<img width="468" height="225" alt="image" src="https://github.com/user-attachments/assets/6dc193de-d467-48f2-a6e1-4c3d6a38f550" />


Defining 5% as the maximum tolerable boundary waste gives Regions per worker ≥ 20. So our calculation is based on each worker having 20 regions to work with. From there, the region size follows directly:
```
total_regions = max_workers * 20
region_size   = heap_size / total_regions
              = heap_size / (max_workers * 20)
```

The result is rounded up to the nearest power of 2 (for alignment), and floored at the original 0.5MB default to avoid unreasonably small regions on tiny heaps.

For a 256MB heap with 4 workers this gives ~4MB regions; for a 4GB heap with 8 workers, ~32MB. Objects that were humongous at 0.5MB (like the 1MB arrays in the JDK-8375467 reproducer) now fit comfortably within a single region and compact normally.

## Regressions?

Each worker gets fewer regions (each being larger). Objects still slide freely across the same worker's regions, so compaction for each worker is unchanged. Bin-packing waste at region tops actually decreases slightly with fewer, larger regions. Only the addresses where worker boundaries fall is changed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8381999](https://bugs.openjdk.org/browse/JDK-8381999): [Lilliput2] Increase region size for Parallel Full GC (**Enhancement** - P4)


### Reviewers
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**) ⚠️ Review applies to [3a53afe9](https://git.openjdk.org/lilliput/pull/213/files/3a53afe9912700ae1b6d736e4e6538aab30b8751)
 * [Oli Gillespie](https://openjdk.org/census#ogillespie) (@olivergillespie - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput.git pull/213/head:pull/213` \
`$ git checkout pull/213`

Update a local copy of the PR: \
`$ git checkout pull/213` \
`$ git pull https://git.openjdk.org/lilliput.git pull/213/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 213`

View PR using the GUI difftool: \
`$ git pr show -t 213`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput/pull/213.diff">https://git.openjdk.org/lilliput/pull/213.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/lilliput/pull/213#issuecomment-4224057980)
</details>
