### PR TITLE
8383498: [Lilliput2] [ubsan] - shift exponent 32 is too large in fastHash

### DIFF
--- a/src/hotspot/share/utilities/fastHash.hpp
+++ b/src/hotspot/share/utilities/fastHash.hpp
@@ -57,11 +57,13 @@ private:
 
   static uint64_t ror64(uint64_t x, uint64_t distance) {
     distance = distance & (64 - 1);
+    if (distance == 0) return x;
     return (x >> distance) | (x << (64 - distance));
   }
 
   static uint32_t ror32(uint32_t x, uint32_t distance) {
     distance = distance & (32 - 1);
+    if (distance == 0) return x;
     return (x >> distance) | (x << (32 - distance));
   }
 


### PR DESCRIPTION
Fix ubsan error.

```
fastHash.hpp:65:33: runtime error: shift exponent 32 is too large for 32-bit type 'unsigned int' 
 #0 in FastHash::ror32(unsigned int, unsigned int) /src/hotspot/share/utilities/fastHash.hpp:65 
```

Simple early return for 0. [Still compiles to a single ror](https://godbolt.org/#g:!((g:!((g:!((h:codeEditor,i:(filename:'1',fontScale:14,fontUsePx:'0',j:1,lang:c%2B%2B,selection:(endColumn:1,endLineNumber:16,positionColumn:1,positionLineNumber:16,selectionStartColumn:1,selectionStartLineNumber:16,startColumn:1,startLineNumber:16),source:'%23include+%3Ccstdlib%3E%0A%0A__attribute__((noinline))+static+unsigned+int+ror32(unsigned+int+x,+unsigned+int+distance)+%7B%0A++++distance+%3D+distance+%26+(32+-+1)%3B%0A++++if+(distance+%3D%3D+0)+return+x%3B%0A++++return+(x+%3E%3E+distance)+%7C+(x+%3C%3C+(32+-+distance))%3B%0A%7D%0A%0A__attribute__((noinline))+static+unsigned+long+ror64(unsigned+long+x,+unsigned+long+distance)+%7B%0A++++distance+%3D+distance+%26+(64+-+1)%3B%0A++++if+(distance+%3D%3D+0)+return+x%3B%0A++++return+(x+%3E%3E+distance)+%7C+(x+%3C%3C+(64+-+distance))%3B%0A%7D%0A%0A%23include+%3Ccstdio%3E%0A%0Aint+main()+%7B%0A++++printf(%22ror32%3D%25d%5Cn%22,+ror32(rand(),+rand()))%3B%0A++++printf(%22ror64%3D%25d%5Cn%22,+ror64(rand(),+rand()))%3B%0A++++return+0%3B%0A%7D%0A'),l:'5',n:'0',o:'C%2B%2B+source+%231',t:'0')),k:63.44249809596344,l:'4',n:'0',o:'',s:0,t:'0'),(g:!((h:compiler,i:(compiler:arm64gtrunk,filters:(b:'0',binary:'1',binaryObject:'1',commentOnly:'0',debugCalls:'1',demangle:'0',directives:'0',execute:'1',intel:'0',libraryCode:'0',trim:'1',verboseDemangling:'0'),flagsViewOpen:'1',fontScale:14,fontUsePx:'0',j:1,lang:c%2B%2B,libs:!(),options:'-O3',overrides:!(),selection:(endColumn:1,endLineNumber:1,positionColumn:1,positionLineNumber:1,selectionStartColumn:1,selectionStartLineNumber:1,startColumn:1,startLineNumber:1),source:1),l:'5',n:'0',o:'+ARM64+gcc+trunk+(Editor+%231)',t:'0')),k:36.55750190403656,l:'4',n:'0',o:'',s:0,t:'0')),l:'2',n:'0',o:'',t:'0')),version:4).

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8383498](https://bugs.openjdk.org/browse/JDK-8383498): [Lilliput2] [ubsan] - shift exponent 32 is too large in fastHash (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - Committer)
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput.git pull/215/head:pull/215` \
`$ git checkout pull/215`

Update a local copy of the PR: \
`$ git checkout pull/215` \
`$ git pull https://git.openjdk.org/lilliput.git pull/215/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 215`

View PR using the GUI difftool: \
`$ git pr show -t 215`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput/pull/215.diff">https://git.openjdk.org/lilliput/pull/215.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/lilliput/pull/215#issuecomment-4334873188)
</details>
