### PR TITLE
8383517: [Lilliput2] .jcheck/conf points to JDK project, not Lilliput

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -1,5 +1,5 @@
 [general]
-project=jdk
+project=lilliput
 jbs=JDK
 version=27
 

--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -23,7 +23,7 @@ ignore-tabs=.*\.gmk|Makefile
 message=Merge
 
 [checks "reviewers"]
-reviewers=1
+committers=1
 ignore=duke
 
 [checks "committer"]


### PR DESCRIPTION
Seems like this was never changed.

I noticed [here](https://github.com/openjdk/lilliput/pull/215#issuecomment-4334702713) that I was not recognized as a committer, which I'm guessing is because it's checking the jdk project instead of the lilliput project. Not sure if it has any other impact.

Since Lilliput has no reviewers, I've also changed the reviewers=1 requirement to committers=1, like [Valhalla has](https://github.com/openjdk/valhalla/blob/lworld/.jcheck/conf#L23C1-L23C13).

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8383517](https://bugs.openjdk.org/browse/JDK-8383517): [Lilliput2] .jcheck/conf points to JDK project, not Lilliput (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to [4f76243c](https://git.openjdk.org/lilliput/pull/216/files/4f76243c472a37f334493574c34dd15fd97fc2a1)
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**) ⚠️ Review applies to [4f76243c](https://git.openjdk.org/lilliput/pull/216/files/4f76243c472a37f334493574c34dd15fd97fc2a1)
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput.git pull/216/head:pull/216` \
`$ git checkout pull/216`

Update a local copy of the PR: \
`$ git checkout pull/216` \
`$ git pull https://git.openjdk.org/lilliput.git pull/216/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 216`

View PR using the GUI difftool: \
`$ git pr show -t 216`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput/pull/216.diff">https://git.openjdk.org/lilliput/pull/216.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/lilliput/pull/216#issuecomment-4335948483)
</details>
