### PR TITLE
8383907: [Lilliput2] CDS assertion failure in oopDesc::initialize_hash_if_necessary

### DIFF
--- a/src/hotspot/share/cds/aotStreamedHeapWriter.cpp
+++ b/src/hotspot/share/cds/aotStreamedHeapWriter.cpp
@@ -377,6 +377,12 @@ void AOTStreamedHeapWriter::update_header_for_buffered_addr(address buffered_add
   markWord mw = markWord::prototype();
   oopDesc* fake_oop = (oopDesc*)buffered_addr;
 
+  if (UseCompactObjectHeaders) {
+    mw = mw.set_narrow_klass(nk);
+  } else {
+    fake_oop->set_narrow_klass(nk);
+  }
+
   // We need to retain the identity_hash, because it may have been used by some hashtables
   // in the shared heap. This also has the side effect of pre-initializing the
   // identity_hash for all shared objects, so they are less likely to be written
@@ -403,12 +409,7 @@ void AOTStreamedHeapWriter::update_header_for_buffered_addr(address buffered_add
     mw = mw.set_marked();
   }
 
-  if (UseCompactObjectHeaders) {
-    fake_oop->set_mark(mw.set_narrow_klass(nk));
-  } else {
-    fake_oop->set_mark(mw);
-    fake_oop->set_narrow_klass(nk);
-  }
+  fake_oop->set_mark(mw);
 }
 
 class AOTStreamedHeapWriter::EmbeddedOopMapper: public BasicOopIterateClosure {


### PR DESCRIPTION
Using CDS with CompactObjectHeaders with assertions enabled fails like this:

```
# assert(m.narrow_klass() != 0) failed: must not be null
# Problematic frame:
# V [libjvm.so+0x178b8a1] oopDesc::initialize_hash_if_necessary(oop, Klass*, markWord)+0x321
``` 

Easy fix by setting the narrow_klass first.

Previously failed, now passes: `CONF=fastdebug make test TEST="hotspot/jtreg/runtime/cds/appcds/TestZGCWithCDS.java" JTREG="VM_OPTIONS=-XX:+UseCompactObjectHeaders"`

(I think the failure is benign, not an actual functional problem, so this is just reordering to please the assert)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8383907](https://bugs.openjdk.org/browse/JDK-8383907): [Lilliput2] CDS assertion failure in oopDesc::initialize_hash_if_necessary (**Bug** - P4)


### Reviewers
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput.git pull/217/head:pull/217` \
`$ git checkout pull/217`

Update a local copy of the PR: \
`$ git checkout pull/217` \
`$ git pull https://git.openjdk.org/lilliput.git pull/217/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 217`

View PR using the GUI difftool: \
`$ git pr show -t 217`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput/pull/217.diff">https://git.openjdk.org/lilliput/pull/217.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/lilliput/pull/217#issuecomment-4386515737)
</details>
