### PR TITLE
8387150: [Lilliput2] C2: identityHashCode intrinsic returns stale hash for relocated object with compact object headers

### DIFF
--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -4807,7 +4807,14 @@ bool LibraryCallKit::inline_native_hashcode(bool is_virtual, bool is_static) {
       Node* M = _gvn.intcon(0x337954D5);
       Node* A = _gvn.intcon(0xAAAAAAAA);
       // Split object address into lo and hi 32 bits.
-      Node* obj_addr = _gvn.transform(new CastP2XNode(nullptr, obj));
+      // Pin the address materialization to the current control (the post-check,
+      // post-safepoint branch). With a null control input this CastP2X (and the
+      // pure FastHash arithmetic that consumes it) is free-floating, so Global
+      // Code Motion may hoist it above an intervening GC safepoint. If the GC
+      // relocates the object, the oop reference is updated but the already
+      // materialized raw address is not, and the recomputed hash would be based
+      // on the stale pre-relocation address - violating identity-hash stability.
+      Node* obj_addr = _gvn.transform(new CastP2XNode(control(), obj));
       Node* x = _gvn.transform(new ConvL2INode(obj_addr));
       Node* upper_addr = _gvn.transform(new URShiftLNode(obj_addr, _gvn.intcon(32)));
       Node* y = _gvn.transform(new ConvL2INode(upper_addr));

--- a/test/hotspot/jtreg/gc/stress/ihash/TestHashCodeC2Relocation.java
+++ b/test/hotspot/jtreg/gc/stress/ihash/TestHashCodeC2Relocation.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2026, Amazon.com, Inc. or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+package gc.stress.ihash;
+
+/*
+ * @test id=g1
+ * @bug 8387150
+ * @summary Identity hash code stays stable across GC relocation when the
+ *          C2-compiled hashCode intrinsic recomputes an address-based hash.
+ * @requires vm.gc.G1
+ * @requires vm.compiler2.enabled
+ * @requires vm.opt.UseCompactObjectHeaders == null | vm.opt.UseCompactObjectHeaders == true
+ * @run main/othervm -XX:+UseCompactObjectHeaders -XX:+UseG1GC -Xms64m -Xmx64m
+ *      gc.stress.ihash.TestHashCodeC2Relocation
+ */
+
+/*
+ * @test id=parallel
+ * @bug 8387150
+ * @summary Identity hash code stays stable across GC relocation when the
+ *          C2-compiled hashCode intrinsic recomputes an address-based hash.
+ * @requires vm.gc.Parallel
+ * @requires vm.compiler2.enabled
+ * @requires vm.opt.UseCompactObjectHeaders == null | vm.opt.UseCompactObjectHeaders == true
+ * @run main/othervm -XX:+UseCompactObjectHeaders -XX:+UseParallelGC -Xms64m -Xmx64m
+ *      gc.stress.ihash.TestHashCodeC2Relocation
+ */
+
+/*
+ * @test id=serial
+ * @bug 8387150
+ * @summary Identity hash code stays stable across GC relocation when the
+ *          C2-compiled hashCode intrinsic recomputes an address-based hash.
+ * @requires vm.gc.Serial
+ * @requires vm.compiler2.enabled
+ * @requires vm.opt.UseCompactObjectHeaders == null | vm.opt.UseCompactObjectHeaders == true
+ * @run main/othervm -XX:+UseCompactObjectHeaders -XX:+UseSerialGC -Xms64m -Xmx64m
+ *      gc.stress.ihash.TestHashCodeC2Relocation
+ */
+
+/*
+ * @test id=shenandoah
+ * @bug 8387150
+ * @summary Identity hash code stays stable across GC relocation when the
+ *          C2-compiled hashCode intrinsic recomputes an address-based hash.
+ * @requires vm.gc.Shenandoah
+ * @requires vm.compiler2.enabled
+ * @requires vm.opt.UseCompactObjectHeaders == null | vm.opt.UseCompactObjectHeaders == true
+ * @run main/othervm -XX:+UseCompactObjectHeaders -XX:+UseShenandoahGC -Xms64m -Xmx64m
+ *      gc.stress.ihash.TestHashCodeC2Relocation
+ */
+
+/*
+ * @test id=zgc
+ * @bug 8387150
+ * @summary Identity hash code stays stable across GC relocation when the
+ *          C2-compiled hashCode intrinsic recomputes an address-based hash.
+ * @requires vm.gc.Z
+ * @requires vm.compiler2.enabled
+ * @requires vm.opt.UseCompactObjectHeaders == null | vm.opt.UseCompactObjectHeaders == true
+ * @run main/othervm -XX:+UseCompactObjectHeaders -XX:+UseZGC -Xms64m -Xmx64m
+ *      gc.stress.ihash.TestHashCodeC2Relocation
+ */
+
+/**
+ * Regression test for a C2 miscompilation of the {@code System.identityHashCode}
+ * intrinsic under {@code -XX:+UseCompactObjectHeaders}.
+ *
+ * With compact headers there is no room in the 64-bit header to always store a
+ * 31-bit identity hash. An object that has been hashed but not yet expanded by
+ * the GC (hashctrl state {@code 0b01}) has its identity hash recomputed on every
+ * read from the object's current heap address ({@code FastHash(address)}). This
+ * is only correct while the object stays at the same address; when the GC
+ * relocates the object it freezes the hash into a hidden field (state
+ * {@code 0b11}).
+ *
+ * The C2 intrinsic inlined the {@code 0b01} recompute and materialized the raw
+ * object address with a free-floating {@code CastP2X} (null control input).
+ * Global Code Motion could hoist that materialization above a GC safepoint;
+ * after a relocation the oop reference is updated but the already-materialized
+ * raw address is not, so the recomputed hash was derived from the stale
+ * pre-relocation address. The result: {@code System.identityHashCode} returned
+ * inconsistent values for a single live object, violating the
+ * {@code Object.hashCode()} stability contract.
+ *
+ * The reproducer hashes a fresh object, forces young-gen relocation via
+ * allocation churn, and re-reads the hash. The "install after relocation"
+ * ordering, warmed up so probe() is C2-compiled, is the shape that triggered the
+ * miscompiled path. A correct VM reports zero mismatches.
+ */
+public class TestHashCodeC2Relocation {
+
+    // Keep GC honest; defeat allocation elimination of the churn garbage.
+    static volatile Object sink;
+
+    static final long ITERS = 2_000_000L;
+
+    /** Allocate short-lived garbage so the next young GC relocates our surviving object. */
+    static void churn() {
+        Object[] junk = new Object[64];
+        for (int k = 0; k < 64; k++) {
+            junk[k] = new byte[256];
+        }
+        sink = junk;
+    }
+
+    /**
+     * @return a non-null description of the first observed violation, or null if stable.
+     */
+    static String probe(long iters, boolean installBefore) {
+        for (long i = 0; i < iters; i++) {
+            Object o = new Object();
+            int h0, h1;
+            if (installBefore) {
+                h0 = System.identityHashCode(o);   // install hash, THEN relocate
+                churn();
+                h1 = System.identityHashCode(o);
+            } else {
+                churn();                           // relocate, THEN first read installs/loads hash
+                h0 = System.identityHashCode(o);
+                h1 = System.identityHashCode(o);
+            }
+            if (h1 != h0) {
+                int settled = System.identityHashCode(o); // re-read returns the TRUE (frozen) hash
+                return "identityHashCode returned inconsistent values for a live object"
+                        + " at iter=" + i + ": h0=" + h0 + " h1=" + h1
+                        + " settledReread=" + settled;
+            }
+        }
+        return null;
+    }
+
+    public static void main(String[] args) {
+        // Warm up with the safe ordering first so that probe() is compiled by C2
+        // with the installBefore branch profiled -- the shape that exposed the bug.
+        String warmup = probe(ITERS, true);
+        if (warmup != null) {
+            throw new RuntimeException("[warmup/installBefore] " + warmup);
+        }
+
+        // Detection run: read the identity hash only after relocation.
+        String result = probe(ITERS, false);
+        if (result != null) {
+            throw new RuntimeException("[installAfter] " + result);
+        }
+
+        System.out.println("PASSED: identity hash codes stable across relocation");
+    }
+}


### PR DESCRIPTION
The `inline_native_hashcode` method materializes the object address for the `hashCode == 6` hash recompute path with a control-free CastP2X and because of that the GCM can float the cast above a prior safepoint. Consequently, if the object is relocated during that safepoint, the raw address of the object is stale (the oop is updated, the fetched object address isn't) and the recomputed hash no longer matches the frozen value - `System.identityHashCode` returns inconsistent results for a live object in hashctrl state 0b01.

The fix I'm proposing in this PR is to pin the CastP2X to current control(): `Node* obj_addr = _gvn.transform(new CastP2XNode(control(), obj));` Only the 0b01 recompute path is affected.

### Testing

New regression test gc/stress/ihash/TestHashCodeC2Relocation.java (G1/Parallel/Serial/Shenandoah) — fails before, passes after. Reproducer drops from thousands of mismatches to zero across all collectors, including fastdebug with +StressGCM/+StressLCM. Existing gc/stress/ihash tests pass.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8387150](https://bugs.openjdk.org/browse/JDK-8387150): [Lilliput2] C2: identityHashCode intrinsic returns stale hash for relocated object with compact object headers (**Bug** - P4)


### Reviewers
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - no project role)
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - no project role)
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput.git pull/219/head:pull/219` \
`$ git checkout pull/219`

Update a local copy of the PR: \
`$ git checkout pull/219` \
`$ git pull https://git.openjdk.org/lilliput.git pull/219/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 219`

View PR using the GUI difftool: \
`$ git pr show -t 219`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput/pull/219.diff">https://git.openjdk.org/lilliput/pull/219.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/lilliput/pull/219#issuecomment-4782022892)
</details>
