### PR TITLE
8387335: [Lilliput2] G1: Preserve hash after humongous compaction

### DIFF
--- a/src/hotspot/share/gc/g1/g1Allocator.cpp
+++ b/src/hotspot/share/gc/g1/g1Allocator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -246,12 +246,22 @@ HeapWord* G1Allocator::par_allocate_during_gc(G1HeapRegionAttr dest,
   }
 }
 
+#ifdef ASSERT
+void G1Allocator::assert_not_humongous(size_t word_size) {
+  // With CompactObjectHeaders, objects can expand during copy to accomodate hashcode.
+  // It's possible this expansion crosses the humongous threshold. In this case, we allow
+  // that and just treat it as not humongous.
+  size_t pre_expansion_size = UseCompactObjectHeaders ? word_size - 1 : word_size;
+  assert(!_g1h->is_humongous(pre_expansion_size),
+          "we should not be seeing humongous-size allocations in this path");
+}
+#endif
+
 HeapWord* G1Allocator::survivor_attempt_allocation(uint node_index,
                                                    size_t min_word_size,
                                                    size_t desired_word_size,
                                                    size_t* actual_word_size) {
-  assert(!_g1h->is_humongous(desired_word_size),
-         "we should not be seeing humongous-size allocations in this path");
+  assert_not_humongous(desired_word_size);
 
   HeapWord* result = survivor_gc_alloc_region(node_index)->attempt_allocation(min_word_size,
                                                                               desired_word_size,
@@ -276,8 +286,7 @@ HeapWord* G1Allocator::survivor_attempt_allocation(uint node_index,
 HeapWord* G1Allocator::old_attempt_allocation(size_t min_word_size,
                                               size_t desired_word_size,
                                               size_t* actual_word_size) {
-  assert(!_g1h->is_humongous(desired_word_size),
-         "we should not be seeing humongous-size allocations in this path");
+  assert_not_humongous(desired_word_size);
 
   HeapWord* result = old_gc_alloc_region()->attempt_allocation(min_word_size,
                                                                desired_word_size,

--- a/src/hotspot/share/gc/g1/g1Allocator.hpp
+++ b/src/hotspot/share/gc/g1/g1Allocator.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -74,6 +74,8 @@ private:
   inline MutatorAllocRegion* mutator_alloc_region(uint node_index);
   inline SurvivorGCAllocRegion* survivor_gc_alloc_region(uint node_index);
   inline OldGCAllocRegion* old_gc_alloc_region();
+
+  void assert_not_humongous(size_t word_size) NOT_DEBUG_RETURN;
 
   // Allocation attempt during GC for a survivor object / PLAB.
   HeapWord* survivor_attempt_allocation(uint node_index,

--- a/src/hotspot/share/gc/g1/g1FullGCCompactTask.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCCompactTask.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -125,6 +125,14 @@ void G1FullGCCompactTask::compact_humongous_obj(G1HeapRegion* src_hr) {
 
   uint src_num_regions = (uint)G1CollectedHeap::humongous_obj_size_in_regions(src_word_size);
   uint dest_num_regions = (uint)G1CollectedHeap::humongous_obj_size_in_regions(dest_word_size);
+  if (dest_num_regions > src_num_regions) {
+    // If the object has grown just over the region boundary, due to hash-code expansion, we'll
+    // need a new region. Track it for heuristics.
+    assert(UseCompactObjectHeaders, "only possible through hash-code expansion");
+    uint new_regions = dest_num_regions - src_num_regions;
+    assert(new_regions == 1, "can only possibly grow by 1 region");
+    _g1h->policy()->old_gen_alloc_tracker()->record_collection_pause_humongous_allocation(G1HeapRegion::GrainBytes);
+  }
   HeapWord* destination = cast_from_oop<HeapWord*>(FullGCForwarding::forwardee(obj));
 
   assert(collector()->mark_bitmap()->is_marked(obj), "Should only compact marked objects");

--- a/src/hotspot/share/gc/g1/g1FullGCCompactTask.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCCompactTask.cpp
@@ -120,9 +120,11 @@ void G1FullGCCompactTask::compact_humongous_obj(G1HeapRegion* src_hr) {
   assert(src_hr->is_starts_humongous(), "Should be start region of the humongous object");
 
   oop obj = cast_to_oop(src_hr->bottom());
-  size_t word_size = obj->size();
+  size_t src_word_size = obj->size();
+  size_t dest_word_size = obj->copy_size(src_word_size, obj->mark());
 
-  uint num_regions = (uint)G1CollectedHeap::humongous_obj_size_in_regions(word_size);
+  uint src_num_regions = (uint)G1CollectedHeap::humongous_obj_size_in_regions(src_word_size);
+  uint dest_num_regions = (uint)G1CollectedHeap::humongous_obj_size_in_regions(dest_word_size);
   HeapWord* destination = cast_from_oop<HeapWord*>(FullGCForwarding::forwardee(obj));
 
   assert(collector()->mark_bitmap()->is_marked(obj), "Should only compact marked objects");
@@ -132,16 +134,16 @@ void G1FullGCCompactTask::compact_humongous_obj(G1HeapRegion* src_hr) {
 
   uint dest_start_idx = _g1h->addr_to_region(destination);
   // Update the metadata for the destination regions.
-  _g1h->set_humongous_metadata(_g1h->region_at(dest_start_idx), num_regions, word_size, false);
+  _g1h->set_humongous_metadata(_g1h->region_at(dest_start_idx), dest_num_regions, dest_word_size, false);
 
   // Free the source regions that do not overlap with the destination regions.
   uint src_start_idx = src_hr->hrm_index();
-  free_non_overlapping_regions(src_start_idx, dest_start_idx, num_regions);
+  free_non_overlapping_regions(src_start_idx, dest_start_idx, src_num_regions, dest_num_regions);
 }
 
-void G1FullGCCompactTask::free_non_overlapping_regions(uint src_start_idx, uint dest_start_idx, uint num_regions) {
-  uint dest_end_idx = dest_start_idx + num_regions -1;
-  uint src_end_idx  = src_start_idx + num_regions - 1;
+void G1FullGCCompactTask::free_non_overlapping_regions(uint src_start_idx, uint dest_start_idx, uint src_num_regions, uint dest_num_regions) {
+  uint dest_end_idx = dest_start_idx + dest_num_regions - 1;
+  uint src_end_idx  = src_start_idx + src_num_regions - 1;
 
   uint non_overlapping_start = dest_end_idx < src_start_idx ?
                                src_start_idx :

--- a/src/hotspot/share/gc/g1/g1FullGCCompactTask.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCCompactTask.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/g1/g1FullGCCompactTask.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCCompactTask.hpp
@@ -42,7 +42,7 @@ class G1FullGCCompactTask : public G1FullGCTask {
 
   void compact_region(G1HeapRegion* hr);
   void compact_humongous_obj(G1HeapRegion* hr);
-  void free_non_overlapping_regions(uint src_start_idx, uint dest_start_idx, uint num_regions);
+  void free_non_overlapping_regions(uint src_start_idx, uint dest_start_idx, uint src_num_regions, uint dest_num_regions);
 
   static void copy_object_to_new_location(oop obj);
 

--- a/test/hotspot/jtreg/gc/stress/ihash/TestHumongousHash.java
+++ b/test/hotspot/jtreg/gc/stress/ihash/TestHumongousHash.java
@@ -94,7 +94,9 @@ public class TestHumongousHash {
         // Check for corruption in hash-code, length or data.
         boolean fail = false;
         for (int i = 0; i < numObjects; i++) {
-            if (i % 2 == 0) continue;
+            if (i % 2 == 0) {
+                continue;
+            }
             byte[] largeObject = largeObjects.get(i);
             if (System.identityHashCode(largeObject) != hashes.get(i)) {
                 System.out.println("hash mismatch at " + i);
@@ -112,7 +114,7 @@ public class TestHumongousHash {
             }
         }
         if (fail) {
-           throw new RuntimeException("Identity hash-code, length or data corruption detected.");
+            throw new RuntimeException("Identity hash-code, length or data corruption detected.");
         }
     }
 }

--- a/test/hotspot/jtreg/gc/stress/ihash/TestHumongousHash.java
+++ b/test/hotspot/jtreg/gc/stress/ihash/TestHumongousHash.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package gc.stress.ihash;
+
+/*
+ * @test id=G1
+ * @bug 8387335
+ * @summary Stress test: does humongous object compaction corrupt hash-code or other objects?
+ * @requires vm.gc.G1
+ * @key stress
+ * @run main/othervm/timeout=300
+ *      -XX:+UseCompactObjectHeaders -XX:+UseG1GC
+ *      -XX:+UnlockDiagnosticVMOptions -XX:+VerifyDuringGC
+ *      -XX:-ExplicitGCInvokesConcurrent
+ *      -Xmx512m -XX:G1HeapRegionSize=1M
+ *      gc.stress.ihash.TestHumongousHash
+ */
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class TestHumongousHash {
+    public static void main(String[] args) {
+        // For G1, 50% of region size. For Shenandoah, 100%. We want to stress objects over the
+        // threshold, but also particularly objects near a region boundary (hash-code expansion)
+        // could see an object expand from below threshold to above threshold, or from fitting in
+        // N regions to requiring N+1 regions.
+        int humongousThreshold = 512 * 1024;
+
+        for (int i = 1; i < 10; i++) {
+            test(humongousThreshold * i);
+        }
+    }
+
+    static void test(int objectSize) {
+        List<byte[]> largeObjects = new ArrayList<>();
+        List<Integer> hashes = new ArrayList<>();
+
+        int numObjects = 0;
+        try {
+            while (true) {
+                // Stress various sizes near the threshold, below and above.
+                byte[] largeObject = new byte[objectSize + numObjects - 32];
+                Arrays.fill(largeObject, (byte) numObjects);
+                largeObjects.add(largeObject);
+                hashes.add(System.identityHashCode(largeObject));
+                numObjects++;
+            }
+        } catch (OutOfMemoryError e) {
+            // That's enough.
+        }
+
+        // Fragment so that GC can compact.
+        for (int i = 0; i < numObjects; i++) {
+            if (i % 2 == 0) {
+                largeObjects.set(i, null);
+            }
+        }
+
+        // Trigger compaction. System.gc() doesn't trigger it in all cases (e.g. G1), so we fill up
+        // the heap to trigger OOM, too.
+        System.gc();
+        ArrayList<byte[]> boom = new ArrayList<>();
+        try {
+            while (true) {
+                boom.add(new byte[100_000_000]);
+            }
+        } catch (OutOfMemoryError e) {
+            boom = null;
+        }
+
+        // Check for corruption in hash-code, length or data.
+        boolean fail = false;
+        for (int i = 0; i < numObjects; i++) {
+            if (i % 2 == 0) continue;
+            byte[] largeObject = largeObjects.get(i);
+            if (System.identityHashCode(largeObject) != hashes.get(i)) {
+                System.out.println("hash mismatch at " + i);
+                fail = true;
+            }
+            if (largeObject.length != objectSize - 32 + i) {
+                System.out.println("length corruption at " + i);
+                fail = true;
+            }
+            for (int x = 0; x < largeObject.length; x++) {
+                if (largeObject[x] != (byte) i) {
+                    System.out.println("corruption at [" + i + "][" + x + "]");
+                    fail = true;
+                }
+            }
+        }
+        if (fail) {
+           throw new RuntimeException("Identity hash-code, length or data corruption detected.");
+        }
+    }
+}


### PR DESCRIPTION
Fix for G1 humongous object compaction with Lilliput 2 related to hash-code expansion.

G1 correctly uses copy_size in the compaction planning phase, but then when it comes to actually moving it, we don't account for copy_size. In particular, passing a too-small size to set_humongous_metadata can cause the filler object to overwrite the hash-code at the end of the object.

Also fix the region accounting (note that skipping the fix for `free_non_overlapping_regions` doesn't cause the test to fail, I'm not sure exactly why. it fails when removing any of the other fixes, though).

Before the fix, the test will fail with:

```
# JRE version: OpenJDK Runtime Environment (27.0) (build 27-internal-adhoc.ogillesp.lilliput)
# Java VM: OpenJDK 64-Bit Server VM (27-internal-adhoc.ogillesp.lilliput, mixed mode, sharing, tiered, compressed oops, compact obj headers, g1 gc, linux-amd64)
# Problematic frame:
# V  [libjvm.so+0x96ebdd][0.456s][error][gc,verify] GC(25) Object 0x00000000e1080018 has a null klass
```

or if we don't use VerifyDuringGC, then we'll see:

```
...
hash mismatch at 509
hash mismatch at 511
hash mismatch at 517
hash mismatch at 519
STDERR:
java.lang.RuntimeException: Identity hash-code, length or data corruption detected.
```

The test is intentionally set up to be ready for Shenandoah, too, which has a similar issue.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8387335](https://bugs.openjdk.org/browse/JDK-8387335): [Lilliput2] G1: Preserve hash after humongous compaction (**Bug** - P4)


### Reviewers
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput.git pull/221/head:pull/221` \
`$ git checkout pull/221`

Update a local copy of the PR: \
`$ git checkout pull/221` \
`$ git pull https://git.openjdk.org/lilliput.git pull/221/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 221`

View PR using the GUI difftool: \
`$ git pr show -t 221`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput/pull/221.diff">https://git.openjdk.org/lilliput/pull/221.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/lilliput/pull/221#issuecomment-4810622388)
</details>
