### PR TITLE
8387311: [Lilliput2] ArrayKlass::hash_offset_in_bytes overflows int for ~2GB+ arrays, corrupting the heap on GC

### DIFF
--- a/src/hotspot/share/cds/heapShared.cpp
+++ b/src/hotspot/share/cds/heapShared.cpp
@@ -902,9 +902,9 @@ void HeapShared::copy_java_mirror(oop orig_mirror, oop scratch_m) {
         scratch_m->set_mark(scratch_m->initialize_hash_if_necessary(orig_mirror, orig_klass, mark));
       } else {
         assert(mark.is_hashed_expanded(), "must be hashed & moved");
-        int offset = orig_klass->hash_offset_in_bytes(orig_mirror, mark);
+        size_t offset = orig_klass->hash_offset_in_bytes(orig_mirror, mark);
         assert(offset >= 4, "hash offset must not be in header");
-        scratch_m->int_field_put(offset, (jint) src_hash);
+        scratch_m->hash_field_put(offset, (jint) src_hash);
         scratch_m->set_mark(mark);
       }
       assert(scratch_m->mark().is_hashed_expanded(), "must be hashed & moved");

--- a/src/hotspot/share/ci/ciInstanceKlass.hpp
+++ b/src/hotspot/share/ci/ciInstanceKlass.hpp
@@ -309,7 +309,9 @@ public:
   GrowableArray<ciInstanceKlass*>* transitive_interfaces() const;
 
   int hash_offset_in_bytes() const {
-    return get_instanceKlass()->hash_offset_in_bytes(nullptr, markWord(0));
+    // An InstanceKlass hash offset always fits an int (only array hash offsets
+    // can exceed INT_MAX). C2 consumes this as a compile-time int field offset.
+    return checked_cast<int>(get_instanceKlass()->hash_offset_in_bytes(nullptr, markWord(0)));
   }
 
   // Replay support

--- a/src/hotspot/share/oops/arrayKlass.cpp
+++ b/src/hotspot/share/oops/arrayKlass.cpp
@@ -288,10 +288,15 @@ void ArrayKlass::oop_verify_on(oop obj, outputStream* st) {
   guarantee(a->length() >= 0, "array with negative length?");
 }
 
-int ArrayKlass::hash_offset_in_bytes(oop obj, markWord m) const {
+size_t ArrayKlass::hash_offset_in_bytes(oop obj, markWord m) const {
   assert(UseCompactObjectHeaders, "only with compact i-hash");
   arrayOop ary = arrayOop(obj);
   BasicType type = element_type();
   int length = LP64_ONLY(m.array_length()) NOT_LP64(ary->length());
-  return ary->base_offset_in_bytes(type) + (length << log2_element_size());
+  // The identity-hash word sits right after the elements. For multi-byte
+  // element types a ~2GB array makes this offset exceed INT_MAX, so it must be
+  // computed and stored in 64-bit. Doing the shift in 32-bit int overflowed to
+  // a negative offset and corrupted the heap during GC expansion.
+  return static_cast<size_t>(ary->base_offset_in_bytes(type)) +
+         (static_cast<size_t>(length) << log2_element_size());
 }

--- a/src/hotspot/share/oops/arrayKlass.hpp
+++ b/src/hotspot/share/oops/arrayKlass.hpp
@@ -114,7 +114,7 @@ class ArrayKlass: public Klass {
   // Return a handle.
   static void     complete_create_array_klass(ArrayKlass* k, Klass* super_klass, ModuleEntry* module, TRAPS);
 
-  int hash_offset_in_bytes(oop obj, markWord m) const override;
+  size_t hash_offset_in_bytes(oop obj, markWord m) const override;
 
   // JVMTI support
   jint jvmti_class_status() const override;

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -972,7 +972,7 @@ public:
     return layout_helper_to_size_helper(layout_helper());
   }
 
-  virtual int hash_offset_in_bytes(oop obj, markWord m) const override {
+  virtual size_t hash_offset_in_bytes(oop obj, markWord m) const override {
     assert(UseCompactObjectHeaders, "only with compact i-hash");
     return _hash_offset;
   }

--- a/src/hotspot/share/oops/instanceMirrorKlass.cpp
+++ b/src/hotspot/share/oops/instanceMirrorKlass.cpp
@@ -81,14 +81,14 @@ int InstanceMirrorKlass::compute_static_oop_field_count(oop obj) {
   return 0;
 }
 
-int InstanceMirrorKlass::hash_offset_in_bytes(oop obj, markWord m) const {
+size_t InstanceMirrorKlass::hash_offset_in_bytes(oop obj, markWord m) const {
   assert(UseCompactObjectHeaders, "only with compact i-hash");
   // TODO: There may be gaps that we could use, e.g. in the fields of Class,
   // between the fields of Class and the static fields or in or at the end of
   // the static fields block.
   // When implementing any change here, make sure that allocate_instance()
   // and corresponding code in InstanceMirrorKlass.java are in sync.
-  return checked_cast<int>(obj->base_size_given_klass(m, this) * BytesPerWord);
+  return obj->base_size_given_klass(m, this) * BytesPerWord;
 }
 
 #if INCLUDE_CDS

--- a/src/hotspot/share/oops/instanceMirrorKlass.hpp
+++ b/src/hotspot/share/oops/instanceMirrorKlass.hpp
@@ -68,7 +68,7 @@ class InstanceMirrorKlass: public InstanceKlass {
 
   // Returns the size of the instance including the extra static fields.
   size_t oop_size(oop obj, markWord mark) const override;
-  int hash_offset_in_bytes(oop obj, markWord m) const override;
+  size_t hash_offset_in_bytes(oop obj, markWord m) const override;
 
   // Static field offset is an offset into the Heap, should be converted by
   // based on UseCompressedOop for traversal

--- a/src/hotspot/share/oops/klass.cpp
+++ b/src/hotspot/share/oops/klass.cpp
@@ -1353,7 +1353,7 @@ bool Klass::expand_for_hash(oop obj, markWord m) const {
   assert(UseCompactObjectHeaders, "only with compact i-hash");
   {
     ResourceMark rm;
-    assert((size_t)hash_offset_in_bytes(obj,m ) <= (obj->base_size_given_klass(m, this) * HeapWordSize), "hash offset must be eq or lt base size: hash offset: %d, base size: %zu, class-name: %s", hash_offset_in_bytes(obj, m), obj->base_size_given_klass(m, this) * HeapWordSize, external_name());
+    assert(hash_offset_in_bytes(obj, m) <= (obj->base_size_given_klass(m, this) * HeapWordSize), "hash offset must be eq or lt base size: hash offset: %zu, base size: %zu, class-name: %s", hash_offset_in_bytes(obj, m), obj->base_size_given_klass(m, this) * HeapWordSize, external_name());
   }
-  return obj->base_size_given_klass(m, this) * HeapWordSize - hash_offset_in_bytes(obj, m) < (int)sizeof(uint32_t);
+  return obj->base_size_given_klass(m, this) * HeapWordSize - hash_offset_in_bytes(obj, m) < sizeof(uint32_t);
 }

--- a/src/hotspot/share/oops/klass.hpp
+++ b/src/hotspot/share/oops/klass.hpp
@@ -786,7 +786,7 @@ public:
 
   static void on_secondary_supers_verification_failure(Klass* super, Klass* sub, bool linear_result, bool table_result, const char* msg);
 
-  virtual int hash_offset_in_bytes(oop obj, markWord m) const = 0;
+  virtual size_t hash_offset_in_bytes(oop obj, markWord m) const = 0;
 
   static int kind_offset_in_bytes() { return (int)offset_of(Klass, _kind); }
 

--- a/src/hotspot/share/oops/oop.cpp
+++ b/src/hotspot/share/oops/oop.cpp
@@ -132,10 +132,10 @@ markWord oopDesc::initialize_hash_if_necessary(oop obj, Klass* k, markWord m) {
   assert(m.is_hashed_not_expanded(), "must be hashed but not moved");
   assert(!m.is_hashed_expanded(), "must not be moved: " INTPTR_FORMAT, m.value());
   uint32_t hash = static_cast<uint32_t>(ObjectSynchronizer::get_next_hash(nullptr, obj));
-  int offset = k->hash_offset_in_bytes(cast_to_oop(this), m);
+  size_t offset = k->hash_offset_in_bytes(cast_to_oop(this), m);
   assert(offset >= 4, "hash offset must not be in header");
-  log_develop_trace(gc)("Initializing hash for " PTR_FORMAT ", old: " PTR_FORMAT ", hash: %d, offset: %d, is_mirror: %s", p2i(this), p2i(obj), hash, offset, BOOL_TO_STR(k->is_mirror_instance_klass()));
-  int_field_put(offset, (jint) hash);
+  log_develop_trace(gc)("Initializing hash for " PTR_FORMAT ", old: " PTR_FORMAT ", hash: %d, offset: %zu, is_mirror: %s", p2i(this), p2i(obj), hash, offset, BOOL_TO_STR(k->is_mirror_instance_klass()));
+  hash_field_put(offset, (jint) hash);
   m = m.set_hashed_expanded();
   assert(static_cast<uint32_t>(ObjectSynchronizer::get_hash(m, cast_to_oop(this), k)) == hash,
          "hash must remain the same");

--- a/src/hotspot/share/oops/oop.hpp
+++ b/src/hotspot/share/oops/oop.hpp
@@ -226,6 +226,12 @@ class oopDesc {
   jint int_field(int offset) const;
   void int_field_put(int offset, jint contents);
 
+  // Read/write the 4-byte identity-hash slot. Object-internal offsets normally
+  // fit an int, but the hash slot of a very large (~2GB+) array can sit beyond
+  // INT_MAX, so it is addressed with a size_t offset.
+  inline jint hash_field(size_t offset) const;
+  inline void hash_field_put(size_t offset, jint contents);
+
   jshort short_field(int offset) const;
   void short_field_put(int offset, jshort contents);
 

--- a/src/hotspot/share/oops/oop.inline.hpp
+++ b/src/hotspot/share/oops/oop.inline.hpp
@@ -362,6 +362,8 @@ inline void   oopDesc::short_field_put(int offset, jshort value)    { *field_add
 
 inline jint oopDesc::int_field(int offset) const                    { return *field_addr<jint>(offset);     }
 inline void oopDesc::int_field_put(int offset, jint value)          { *field_addr<jint>(offset) = value;    }
+inline jint oopDesc::hash_field(size_t offset) const                { return *reinterpret_cast<jint*>(cast_from_oop<intptr_t>(as_oop()) + offset); }
+inline void oopDesc::hash_field_put(size_t offset, jint value)      { *reinterpret_cast<jint*>(cast_from_oop<intptr_t>(as_oop()) + offset) = value; }
 inline jint oopDesc::int_field_relaxed(int offset) const            { return AtomicAccess::load(field_addr<jint>(offset)); }
 inline void oopDesc::int_field_put_relaxed(int offset, jint value)  { AtomicAccess::store(field_addr<jint>(offset), value); }
 
@@ -544,7 +546,7 @@ intptr_t oopDesc::identity_hash() {
     markWord mrk = mark();
     if (mrk.is_hashed_expanded()) {
       Klass* klass = mrk.klass();
-      return int_field(klass->hash_offset_in_bytes(cast_to_oop(this), mrk));
+      return hash_field(klass->hash_offset_in_bytes(cast_to_oop(this), mrk));
     }
     // Fall-through to slow-case.
   } else {

--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -664,8 +664,8 @@ intptr_t ObjectSynchronizer::FastHashCode(Thread* current, oop obj) {
       markWord new_mark;
       if (mark.is_not_hashed_expanded()) {
         new_mark = mark.set_hashed_expanded();
-        int offset = mark.klass()->hash_offset_in_bytes(obj, mark);
-        obj->int_field_put(offset, (jint) hash);
+        size_t offset = mark.klass()->hash_offset_in_bytes(obj, mark);
+        obj->hash_field_put(offset, (jint) hash);
       } else {
         new_mark = mark.set_hashed_not_expanded();
       }
@@ -772,7 +772,7 @@ uint32_t ObjectSynchronizer::get_hash(markWord mark, oop obj, Klass* klass) {
   //assert(mark.is_neutral() | mark.is_fast_locked(), "only from neutral or fast-locked mark: " INTPTR_FORMAT, mark.value());
   assert(mark.is_hashed(), "only from hashed or copied object");
   if (mark.is_hashed_expanded()) {
-    return obj->int_field(klass->hash_offset_in_bytes(obj, mark));
+    return obj->hash_field(klass->hash_offset_in_bytes(obj, mark));
   } else {
     assert(mark.is_hashed_not_expanded(), "must be hashed");
     assert(hashCode == 6 || hashCode == 2, "must have idempotent hashCode");

--- a/test/hotspot/jtreg/gc/stress/ihash/TestHashCodeLargeArray.java
+++ b/test/hotspot/jtreg/gc/stress/ihash/TestHashCodeLargeArray.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2026, Amazon.com, Inc. or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test id=parallel
+ * @bug 8387311
+ * @summary Hashing a >2GB array and relocating it must not overflow the hash
+ *          offset and corrupt the heap (compact object headers).
+ * @library /test/lib
+ * @library /
+ * @requires vm.gc.Parallel
+ * @requires vm.opt.UseCompactObjectHeaders == null | vm.opt.UseCompactObjectHeaders == true
+ * @requires os.maxMemory >= 4G
+ * @requires sun.arch.data.model == "64"
+ * @key stress
+ * @run main/othervm/timeout=300 -XX:+UseCompactObjectHeaders -XX:+UseParallelGC -Xmx4g
+ *      TestHashCodeLargeArray
+ */
+
+/*
+ * @test id=serial
+ * @bug 8387311
+ * @summary Hashing a >2GB array and relocating it must not overflow the hash
+ *          offset and corrupt the heap (compact object headers).
+ * @library /test/lib
+ * @library /
+ * @requires vm.gc.Serial
+ * @requires vm.opt.UseCompactObjectHeaders == null | vm.opt.UseCompactObjectHeaders == true
+ * @requires os.maxMemory >= 4G
+ * @requires sun.arch.data.model == "64"
+ * @key stress
+ * @run main/othervm/timeout=300 -XX:+UseCompactObjectHeaders -XX:+UseSerialGC -Xmx4g
+ *      TestHashCodeLargeArray
+ */
+
+/*
+ * @test id=g1
+ * @bug 8387311
+ * @summary Hashing a >2GB array and relocating it must not overflow the hash
+ *          offset and corrupt the heap (compact object headers).
+ * @library /test/lib
+ * @library /
+ * @requires vm.gc.G1
+ * @requires vm.opt.UseCompactObjectHeaders == null | vm.opt.UseCompactObjectHeaders == true
+ * @requires os.maxMemory >= 4G
+ * @requires sun.arch.data.model == "64"
+ * @key stress
+ * @run main/othervm/timeout=300 -XX:+UseCompactObjectHeaders -XX:+UseG1GC -Xmx4g
+ *      TestHashCodeLargeArray
+ */
+
+/*
+ * @test id=shen
+ * @bug 8387311
+ * @summary Hashing a >2GB array and relocating it must not overflow the hash
+ *          offset and corrupt the heap (compact object headers).
+ * @library /test/lib
+ * @library /
+ * @requires vm.gc.Shenandoah
+ * @requires vm.opt.UseCompactObjectHeaders == null | vm.opt.UseCompactObjectHeaders == true
+ * @requires os.maxMemory >= 4G
+ * @requires sun.arch.data.model == "64"
+ * @key stress
+ * @run main/othervm/timeout=300 -XX:+UseCompactObjectHeaders -XX:+UseShenandoahGC -Xmx4g
+ *      TestHashCodeLargeArray
+ */
+
+/*
+ * @test id=zgc
+ * @bug 8387311
+ * @summary Hashing a >2GB array and relocating it must not overflow the hash
+ *          offset and corrupt the heap (compact object headers).
+ * @library /test/lib
+ * @library /
+ * @requires vm.gc.Z
+ * @requires vm.opt.UseCompactObjectHeaders == null | vm.opt.UseCompactObjectHeaders == true
+ * @requires os.maxMemory >= 4G
+ * @requires sun.arch.data.model == "64"
+ * @key stress
+ * @run main/othervm/timeout=300 -XX:+UseCompactObjectHeaders -XX:+UseZGC -Xmx4g
+ *      TestHashCodeLargeArray
+ */
+
+import jtreg.SkippedException;
+
+/*
+ * Regression test for an integer-overflow in ArrayKlass::hash_offset_in_bytes
+ * under -XX:+UseCompactObjectHeaders.
+ *
+ * With compact headers an array's identity hash is stored in a hidden word that
+ * the GC appends right after the elements when it "expands" the (hashed but not
+ * yet expanded) object. The offset of that word was computed as
+ * {@code base_offset + (length << log2_element_size)} in 32-bit int. For a
+ * multi-byte element array of ~2GB or more this overflows to a negative value.
+ * The GC then writes the 4-byte hash at a sign-extended negative displacement
+ * from the object base, outside the array, which is a SIGSEGV or, worse, silent
+ * corruption of a neighboring heap object.
+ *
+ * The test allocates a long[] just past the 2GB element-byte boundary
+ * (length 2^28 + 8, whose payload 8*(2^28+8) makes the would-be hash offset
+ * exceed INT_MAX), installs its identity hash, forces several relocating GC
+ * cycles, and verifies the array contents and identity hash survive. On the
+ * buggy VM this crashes (or silently corrupts a neighbor) during the first GC
+ * that relocates the array.
+ *
+ * A long[] (8-byte elements) is used rather than an int[] so the offset crosses
+ * INT_MAX at half the element count, keeping the heap footprint near 2GB while
+ * still exercising the multi-byte-element overflow path.
+ *
+ * If the host cannot supply enough memory to allocate the array, the test ends
+ * with a SkippedException so jtreg records SKIPPED (not PASSED). A passing
+ * result must mean the relocating path was actually exercised.
+ */
+public class TestHashCodeLargeArray {
+
+    // 2^28 + 8 longs. payload = 8 * (2^28 + 8) bytes > INT_MAX, so the hash
+    // word offset (base + payload) overflows a 32-bit int in the buggy code.
+    static final int LEN = 268435456 + 8;
+
+    static volatile Object sink;
+
+    public static void main(String[] args) {
+        long[] a;
+        try {
+            a = new long[LEN];
+        } catch (OutOfMemoryError e) {
+            throw new SkippedException("Not enough heap to allocate the array");
+        }
+
+        // Touch first/last element so corruption of the tail is detectable.
+        a[0] = 0x1111111111111111L;
+        a[LEN - 1] = 0x2222222222222222L;
+
+        // Install identity hash. The mark word becomes "hashed, not expanded".
+        int h0 = System.identityHashCode(a);
+
+        // Force relocation: the compacting GC expands the object and writes the
+        // hash word at hash_offset_in_bytes(). This is where the overflow bites.
+        for (int round = 0; round < 5; round++) {
+            // Short-lived garbage to provoke promotion and compaction.
+            for (int i = 0; i < 64; i++) {
+                sink = new byte[1 << 20];
+            }
+            System.gc();
+
+            int h1 = System.identityHashCode(a);
+            if (h1 != h0) {
+                throw new RuntimeException("identity hash changed across GC: h0=" + h0 + " h1=" + h1);
+            }
+            if (a.length != LEN || a[0] != 0x1111111111111111L || a[LEN - 1] != 0x2222222222222222L) {
+                throw new RuntimeException("array contents corrupted after GC round " + round
+                        + ": length=" + a.length + " first=" + Long.toHexString(a[0])
+                        + " last=" + Long.toHexString(a[LEN - 1]));
+            }
+        }
+
+        System.out.println("PASSED: large-array identity hash stable across relocation");
+    }
+}


### PR DESCRIPTION
With `-XX:+UseCompactObjectHeaders` an array's identity hash is stored in a hidden word the GC appends after the elements when it expands a hashed-but-not-expanded object. `ArrayKlass::hash_offset_in_bytes` computed that offset as `base_offset + (length << log2_element_size)` in 32-bit int. For a multi-byte-element array of ~2GB or more the shift overflows to a negative value, so the GC writes the 4-byte hash outside the array during relocation, crashing with SIGSEGV or corrupting a neighbouring object.

Fix: compute the offset in 64-bit (`size_t`). Only arrays can exceed INT_MAX, so the hash read/write sites use `size_t`-offset accessors. InstanceKlass and mirror offsets and the C2 path still use int.

Adds `gc/stress/ihash/TestHashCodeLargeArray.java`, which hashes a 2GB+ `long[]`, forces relocating GCs across Parallel/Serial/G1/Shenandoah/Z, and checks the hash and contents survive. It crashes on the unfixed VM and passes after the fix.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8387311](https://bugs.openjdk.org/browse/JDK-8387311): [Lilliput2] ArrayKlass::hash_offset_in_bytes overflows int for ~2GB+ arrays, corrupting the heap on GC (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput.git pull/222/head:pull/222` \
`$ git checkout pull/222`

Update a local copy of the PR: \
`$ git checkout pull/222` \
`$ git pull https://git.openjdk.org/lilliput.git pull/222/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 222`

View PR using the GUI difftool: \
`$ git pr show -t 222`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput/pull/222.diff">https://git.openjdk.org/lilliput/pull/222.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/lilliput/pull/222#issuecomment-4835403171)
</details>
