### PR TITLE
8387659: [Lilliput2] Remove remaining hashctrl_mask references

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/Mark.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/Mark.java
@@ -65,7 +65,6 @@ public class Mark extends VMObject {
     ageMaskInPlace      = db.lookupLongConstant("markWord::age_mask_in_place").longValue();
     hashMask            = db.lookupLongConstant("markWord::hash_mask").longValue();
     hashMaskInPlace     = db.lookupLongConstant("markWord::hash_mask_in_place").longValue();
-    hashCtrlMask        = db.lookupLongConstant("markWord::hashctrl_mask").longValue();
     hashCtrlMaskInPlace = db.lookupLongConstant("markWord::hashctrl_mask_in_place").longValue();
     hashCtrlHashedMaskInPlace =   db.lookupLongConstant("markWord::hashctrl_hashed_mask_in_place").longValue();
     hashCtrlExpandedMaskInPlace = db.lookupLongConstant("markWord::hashctrl_expanded_mask_in_place").longValue();
@@ -101,7 +100,6 @@ public class Mark extends VMObject {
   private static long ageMaskInPlace;
   private static long hashMask;
   private static long hashMaskInPlace;
-  private static long hashCtrlMask;
   private static long hashCtrlMaskInPlace;
   private static long hashCtrlHashedMaskInPlace;
   private static long hashCtrlExpandedMaskInPlace;


### PR DESCRIPTION
I noticed in a GHA that we have a dangling reference to hashctrl_mask which is gone since the last merge. It's not even used in the place where it still lives (serviceability) so this is a very simple/trivial remove.

Testing:
 - [x] GHA is sufficient

Note: the remaining GHA seem to be unrelated, most likely infra issues.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8387659](https://bugs.openjdk.org/browse/JDK-8387659): [Lilliput2] Remove remaining hashctrl_mask references (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput.git pull/224/head:pull/224` \
`$ git checkout pull/224`

Update a local copy of the PR: \
`$ git checkout pull/224` \
`$ git pull https://git.openjdk.org/lilliput.git pull/224/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 224`

View PR using the GUI difftool: \
`$ git pr show -t 224`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput/pull/224.diff">https://git.openjdk.org/lilliput/pull/224.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/lilliput/pull/224#issuecomment-4867918832)
</details>
