### PR TITLE
8387994: [Lilliput2] Shenandoah: runtime error: division by zero from fullGCForwarding.inline.hpp

### DIFF
--- a/src/hotspot/share/gc/shared/fullGCForwarding.inline.hpp
+++ b/src/hotspot/share/gc/shared/fullGCForwarding.inline.hpp
@@ -273,14 +273,23 @@ void FullGCForwardingImpl<BITS>::begin() {
 template <int BITS>
 void FullGCForwardingImpl<BITS>::end() {
 #ifndef PRODUCT
-  size_t fallback_table_size = _fallback_table != nullptr ? _fallback_table->get_mem_size(Thread::current()) : 0;
-  log_info(gc)("Total forwardings: " UINT64_FORMAT ", fallback forwardings: " UINT64_FORMAT
-                ", ratio: %f, memory used by fallback table: %zu%s, memory used by bases table: %zu%s",
-               _num_forwardings, _num_fallback_forwardings, static_cast<float>(_num_forwardings) / static_cast<float>(_num_fallback_forwardings),
-               byte_size_in_proper_unit(fallback_table_size),
-               proper_unit_for_byte_size(fallback_table_size),
-               byte_size_in_proper_unit(sizeof(HeapWord*) * _num_regions),
-               proper_unit_for_byte_size(sizeof(HeapWord*) * _num_regions));
+  if (log_is_enabled(Info, gc)) {
+    size_t fallback_table_size = _fallback_table != nullptr ? _fallback_table->get_mem_size(Thread::current()) : 0;
+    char fallback_ratio[32];
+    if (_num_fallback_forwardings != 0) {
+      (void) os::snprintf(fallback_ratio, sizeof(fallback_ratio), "%f",
+                          static_cast<float>(_num_forwardings) / static_cast<float>(_num_fallback_forwardings));
+    } else {
+      (void) os::snprintf(fallback_ratio, sizeof(fallback_ratio), "n/a");
+    }
+    log_info(gc)("Total forwardings: " UINT64_FORMAT ", fallback forwardings: " UINT64_FORMAT
+                  ", ratio: %s, memory used by fallback table: %zu%s, memory used by bases table: %zu%s",
+                 _num_forwardings, _num_fallback_forwardings, fallback_ratio,
+                 byte_size_in_proper_unit(fallback_table_size),
+                 proper_unit_for_byte_size(fallback_table_size),
+                 byte_size_in_proper_unit(sizeof(HeapWord*) * _num_regions),
+                 proper_unit_for_byte_size(sizeof(HeapWord*) * _num_regions));
+  }
 #endif
 #ifdef _LP64
   assert(_bases_table != nullptr, "should be initialized");


### PR DESCRIPTION
Fix the division by zero error from fullGCForwarding.inline.hpp, print n/a instead if _num_fallback_forwardings is 0

Test:
- [x] hotspot_gc_shenandoah with JTREG="JAVA_OPTIONS=-XX:+UnlockExperimentalVMOptions -XX:+UseCompactObjectHeaders"

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [JDK-8387994](https://bugs.openjdk.org/browse/JDK-8387994): [Lilliput2] Shenandoah: runtime error: division by zero from fullGCForwarding.inline.hpp (**Bug** - P4)


### Reviewers
 * [Oli Gillespie](https://openjdk.org/census#ogillespie) (@olivergillespie - Committer)
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/lilliput.git pull/226/head:pull/226` \
`$ git checkout pull/226`

Update a local copy of the PR: \
`$ git checkout pull/226` \
`$ git pull https://git.openjdk.org/lilliput.git pull/226/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 226`

View PR using the GUI difftool: \
`$ git pr show -t 226`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/lilliput/pull/226.diff">https://git.openjdk.org/lilliput/pull/226.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/lilliput/pull/226#issuecomment-4920080334)
</details>
